### PR TITLE
Add server-side error reporting pipeline

### DIFF
--- a/src/components/elements/CurateIndividual/CurateIndividual.tsx
+++ b/src/components/elements/CurateIndividual/CurateIndividual.tsx
@@ -16,6 +16,7 @@ import { useSession } from "next-auth/react";
 import { allowedPermissions, toastMessage } from "../../../utils/constants";
 import ToastContainerWrapper from "../ToastContainerWrapper/ToastContainerWrapper";
 import { reciterConfig } from "../../../../config/local";
+import { reportError } from '../../../utils/reportError';
 
 
 
@@ -102,6 +103,7 @@ const CurateIndividual = () => {
         setHeadShot(headShotViewAttributes)
       })
       .catch(error => {
+        reportError('ERR-9010', 'Curate individual error', error);
         // setLoading(false);
       });
   }

--- a/src/components/elements/Manage/AdminSettings.tsx
+++ b/src/components/elements/Manage/AdminSettings.tsx
@@ -12,6 +12,7 @@ import { toast } from "react-toastify";
 import { resolveSrv } from "dns";
 import ToastContainerWrapper from "../ToastContainerWrapper/ToastContainerWrapper";
 import moment from 'moment-timezone';
+import { reportError } from '../../../utils/reportError';
 
 
 const AdminSettings = () => {
@@ -73,6 +74,7 @@ const AdminSettings = () => {
       })
       .catch(error => {
         console.log(error);
+        reportError('ERR-9001', 'Admin settings fetch failed', error);
         setLoading(false);
       });
   }
@@ -154,6 +156,7 @@ const AdminSettings = () => {
       })
       .catch(error => {
         console.log(error)
+        reportError('ERR-9002', 'Admin settings save failed', error);
         setLoading(false);
       });
   }
@@ -233,6 +236,7 @@ const AdminSettings = () => {
           });
         }
       }).catch(error => {
+      reportError('ERR-9003', 'Admin settings update failed', error);
       setSendTestEmailLoading(false);
         toast.error("Send Test Email failed - " + error.title, {
           position: "top-right",

--- a/src/components/elements/Manage/ManageUsers.tsx
+++ b/src/components/elements/Manage/ManageUsers.tsx
@@ -14,6 +14,7 @@ import { toast } from "react-toastify"
 import Pagination from '../Pagination/Pagination';
 import Filter from "../Filter/Filter";
 import { useSession } from 'next-auth/react';
+import { reportError } from '../../../utils/reportError';
 
 
 
@@ -106,6 +107,7 @@ const ManageUsers = () => {
       })
       .catch(error => {
         console.log(error)
+        reportError('ERR-5010', 'Manage users fetch failed', error);
         setpageLoading(false);
       });
   }

--- a/src/components/elements/ManageProfile/ManageProfile.tsx
+++ b/src/components/elements/ManageProfile/ManageProfile.tsx
@@ -14,6 +14,7 @@ import { reciterConfig } from "../../../../config/local";
 import { toast } from "react-toastify";
 import { allowedPermissions } from "../../../utils/constants";
 import Loader from "../Common/Loader";
+import { reportError } from '../../../utils/reportError';
 
 
 const ManageProfle = () => {
@@ -87,7 +88,7 @@ const ManageProfle = () => {
         }).then(data => {
 
         }).catch(error => {
-
+            reportError('ERR-1010', 'Profile fetch failed', error);
         })
     }
 
@@ -116,6 +117,7 @@ const ManageProfle = () => {
             })
             .catch(error => {
                 console.log(error);
+                reportError('ERR-1011', 'Profile update failed', error);
             });
     }
 
@@ -155,6 +157,7 @@ const ManageProfle = () => {
             .catch(error => {
                 setLoadProfileData(false)
                 console.log(error);
+                reportError('ERR-1012', 'Profile image upload failed', error);
             });
     }
 

--- a/src/components/elements/Notifications/Notifications.tsx
+++ b/src/components/elements/Notifications/Notifications.tsx
@@ -13,6 +13,7 @@ import { allowedPermissions } from "../../../utils/constants";
 import { toast } from "react-toastify";
 import Slider from '@mui/material/Slider';
 import Box from '@mui/material/Box';
+import { reportError } from '../../../utils/reportError';
 
 
 const Notifications = () => {
@@ -132,6 +133,7 @@ const Notifications = () => {
       })
       .catch(error => {
         console.log(error)
+        reportError('ERR-6010', 'Notifications fetch failed', error);
       });
   }
 

--- a/src/components/elements/Profile/Profile.tsx
+++ b/src/components/elements/Profile/Profile.tsx
@@ -12,6 +12,7 @@ import Excel from 'exceljs';
 import { ExportButton } from "../Report/ExportButton";
 import { useSession } from 'next-auth/react';
 import { allowedPermissions, setHelptextInfo, setReportFilterLabels } from "../../../utils/constants";
+import { reportError } from '../../../utils/reportError';
 
 
 
@@ -135,6 +136,7 @@ const Profile = ({
       })
       .catch(error => {
         console.log(error)
+        reportError('ERR-1020', 'Profile data fetch failed', error);
         setIsError(true);
       })
   }
@@ -164,6 +166,7 @@ const Profile = ({
     })
     .catch(error => {
       console.log(error)
+      reportError('ERR-8010', 'Profile publications fetch failed', error);
       setIsError(true);
     })
   }
@@ -190,6 +193,7 @@ const Profile = ({
       })
       .catch(error => {
         console.log(error)
+        reportError('ERR-8011', 'Profile report fetch failed', error);
         setIsError(true);
         setIsLoading(false);
       })
@@ -394,6 +398,7 @@ const Profile = ({
     }).catch(error => {
       setExportArticleCsvLoading(false);
       console.log(error);
+      reportError('ERR-8012', 'Profile export failed', error);
     })
   }
 

--- a/src/components/elements/Report/SearchSummary.tsx
+++ b/src/components/elements/Report/SearchSummary.tsx
@@ -12,6 +12,7 @@ import Excel from 'exceljs';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import { setReportFilterDisplayRank, setReportFilterLabels,setIsVisible, setReportFilterKeyNames } from "../../../utils/constants";
+import { reportError } from '../../../utils/reportError';
 
 
 const SearchSummary = ({ 
@@ -123,6 +124,7 @@ const SearchSummary = ({
     })
     .catch(error => {
       console.log(error)
+      reportError('ERR-8001', 'Search summary fetch failed', error);
       setExportError(true);
       setExportArticleLoading(false);
     })
@@ -163,6 +165,7 @@ const SearchSummary = ({
     })
     .catch(error => {
       console.log(error)
+      reportError('ERR-8002', 'Search summary export failed', error);
       setExportError(true);
       setExportArticlePplLoading(false);
     })
@@ -197,6 +200,7 @@ const SearchSummary = ({
     }).catch(error => {
       setExportAuthorshipCsvLoading(false);
       console.log(error);
+      reportError('ERR-8003', 'Search summary CSV failed', error);
     })
   }
 
@@ -307,6 +311,7 @@ const SearchSummary = ({
     }).catch(error => {
       setExportArticleCsvLoading(false);
       console.log(error);
+      reportError('ERR-8004', 'Search summary RTF failed', error);
     })
   }
 

--- a/src/pages/api/log.ts
+++ b/src/pages/api/log.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).end();
+  const { code, message, context } = req.body || {};
+  if (!code) return res.status(400).json({ error: "Missing error code" });
+  console.error(`[CLIENT:${code}]`, message || "", context || "");
+  res.status(204).end();
+}

--- a/src/redux/actions/actions.js
+++ b/src/redux/actions/actions.js
@@ -3,6 +3,7 @@ import fetchWithTimeout from '../../utils/fetchWithTimeout';
 import { toast } from "react-toastify"
 import { reciterConfig } from '../../../config/local';
 import { initialStatePubSearchFilter } from "../reducers/reducers";
+import { reportError } from '../../utils/reportError';
 
 
 export const addError = (message) =>
@@ -79,6 +80,7 @@ export const identityFetchData = uid => dispatch => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-1001", "Identity API failed", error);
 
             toast.error("Identity Api failed for " + uid + " - " + error.title, {
                 position: "top-right",
@@ -145,6 +147,7 @@ export const identityFetchAllData = (request) => dispatch => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-1002", "Identity All API failed", error);
             toast.error("Identity All Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -207,6 +210,7 @@ export const identityFetchPaginatedData = (page, limit,filters) => dispatch => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-1003", "Identity Paginated API failed", error);
             toast.error("Identity Fetch PaginatedData Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -275,6 +279,7 @@ export const reciterFetchData = (uid, refresh) => dispatch => {
                 autoClose: 2000,
                 theme: 'colored'
             });
+            reportError("ERR-1004", "Feature generator API failed", error);
 
             dispatch(
                 addIdentityORFeatureGenError("Feature-Generator-Error")
@@ -436,7 +441,7 @@ export const pubmedFetchData = query => dispatch => {
                 autoClose: 2000,
                 theme: 'colored'
             });
-            
+            reportError("ERR-2001", "PubMed query failed", error);
 
             dispatch({
                 type: methods.PUBMED_CHANGE_DATA,
@@ -548,6 +553,7 @@ export const reciterUpdatePublication = (uid, request) => dispatch => {
         .catch(error => {
 
             console.log(error)
+            reportError("ERR-3001", "Update GoldStandard API failed", error);
             toast.error("Update GoldStandard Api Error" + error.title + " for " + uid, {
                 position: "top-right",
                 autoClose: 2000,
@@ -607,6 +613,7 @@ export const reciterUpdatePublication = (uid, request) => dispatch => {
             .catch(error => {
 
                 console.log(error)
+                reportError("ERR-3002", "DB feedback log API failed", error);
                 toast.error("Db feedback log Api Error" + error.title + " for " + uid, {
                     position: "top-right",
                     autoClose: 2000,
@@ -716,6 +723,7 @@ export const reciterUpdatePublicationGroup = (uid, request) => dispatch => {
         .catch(error => {
 
             console.log(error)
+            reportError("ERR-3003", "Update GoldStandard Group API failed", error);
             toast.error("Update GoldStandard Api Error" + error.title + " for " + uid, {
                 position: "top-right",
                 autoClose: 2000,
@@ -772,6 +780,7 @@ export const reciterUpdatePublicationGroup = (uid, request) => dispatch => {
             .catch(error => {
 
                 console.log(error)
+                reportError("ERR-3004", "DB feedback log Group API failed", error);
                 toast.error("Db feedback log Api Error" + error.title + " for " + uid, {
                     position: "top-right",
                     autoClose: 2000,
@@ -830,6 +839,7 @@ export const authUser = auth => dispatch => {
             }
         })
         .catch(err => {
+            reportError("ERR-4001", "Auth API failed", err);
             return dispatch(
                 addError(err)
             )
@@ -855,6 +865,7 @@ export const getSession = sid => dispatch => {
         })
         .catch(err => {
             console.log(err)
+            reportError("ERR-4002", "Get session failed", err);
             return dispatch(
                 addError(err)
             )
@@ -898,6 +909,7 @@ export const orgUnitsFetchAllData = () => dispatch => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-5001", "Org Units API failed", error);
             toast.error("Organizational Units Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -951,6 +963,7 @@ export const institutionsFetchAllData = () => dispatch => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-5002", "Institutions API failed", error);
             toast.error("Institutional Units Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1004,6 +1017,7 @@ export const personTypesFetchAllData = () => dispatch => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-5003", "Person Types API failed", error);
             toast.error("Person Types Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1185,6 +1199,7 @@ export const publicationsFetchGroupData = (ids, updateData) => dispatch => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-2002", "Feature generator group API failed", error);
             toast.error("Feature generator by group Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1245,6 +1260,7 @@ export const fetchFeedbacklog = (id) => dispatch => {
 
     }).catch(error => {
         console.log(error)
+        reportError("ERR-2003", "Feedback log API failed", error);
         toast.error("Feedback log Api failed for " + id + " - " + error.title, {
             position: "top-right",
             autoClose: 2000,
@@ -1290,6 +1306,7 @@ export const fetchGroupFeedbacklog = (ids) => dispatch => {
             }
         }).catch(error => {
             console.log(error);
+            reportError("ERR-2004", "Group feedback log API failed", error);
 
             dispatch({
                 type: methods.FEEDBACKLOG_CANCEL_FETCHING_GROUP
@@ -1329,6 +1346,7 @@ const getAuthorsFilter = (authorInput) => async (dispatch) => {
         })
     }).catch(error => {
         console.log(error);
+        reportError("ERR-6001", "Author Filter API failed", error);
         toast.error("Author Filter Api failed - " + error.title, {
             position: "top-right",
             autoClose: 2000,
@@ -1360,6 +1378,7 @@ const getDateFilter = () => async (dispatch) => {
         })
     }).catch(error => {
         console.log(error);
+        reportError("ERR-6002", "Date Filter API failed", error);
         toast.error("Date Filter Api failed - " + error.title, {
             position: "top-right",
             autoClose: 2000,
@@ -1402,6 +1421,7 @@ const getArticleTypeFilter = () => async (dispatch) => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-6003", "Article Type Filter API failed", error);
             toast.error("Article Type Filter Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1444,6 +1464,7 @@ const getJournalFilter = (journalInput) => async (dispatch) => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-6004", "Journal Filter API failed", error);
             toast.error("Journal Filter Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1455,7 +1476,7 @@ const getJournalFilter = (journalInput) => async (dispatch) => {
         })
 }
 
-// Journal Rank Filter 
+// Journal Rank Filter
 const getJournalRank = () => async (dispatch) => {
     return fetch('/api/db/reports/filter/journalrank', {
         credentials: "same-origin",
@@ -1486,6 +1507,7 @@ const getJournalRank = () => async (dispatch) => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-6005", "Journal Rank Filter API failed", error);
             toast.error("Journal Rank Filter Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1528,6 +1550,7 @@ export const getOrgUnits = () => async (dispatch) => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-6006", "Org Units Filter API failed", error);
             toast.error("Organizational Units Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1570,6 +1593,7 @@ export const getInstitutions = () => async (dispatch) => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-6007", "Institutions Filter API failed", error);
             toast.error("Institutional Units Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1612,6 +1636,7 @@ export const getAdminDepartments = () => async (dispatch) => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-6008", "Admin Departments API failed", error);
             toast.error("List All Admin DEPATMENTS Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1653,6 +1678,7 @@ export const getAdminRoles = () => async (dispatch) => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-6009", "Admin Roles API failed", error);
             toast.error("List All Admin DEPATMENTS Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1695,6 +1721,7 @@ export const getPersonTypes = () => async (dispatch) => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-6010", "Person Types Filter API failed", error);
             toast.error("Person Types Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -1737,6 +1764,7 @@ export const updateAuthorFilter = (authorInput, count,isFrom) => (dispatch) => {
         }
     }).catch(error => {
         console.log(error);
+        reportError("ERR-6011", "Author Filter update API failed", error);
         toast.error("Author Filter Api failed - " + error.title, {
             position: "top-right",
             autoClose: 2000,
@@ -1779,6 +1807,7 @@ export const updateJournalFilter = (journalInput, count) => (dispatch) => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-6012", "Journal Filter update API failed", error);
             toast.error("Journal Filter Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -2015,6 +2044,7 @@ export const getReportsResults = (requestBody, paginationUpdate = false) => disp
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-7001", "Reports Search API failed", error);
             toast.error("Reports Search Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -2120,6 +2150,7 @@ export const getReportsResultsInitial = (limit = 20, offset = 0) => dispatch => 
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-7002", "Reports Search Initial API failed", error);
             toast.error("Reports Search Api failed - " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -2164,6 +2195,7 @@ export const getReportsAuthors = (pmids) => {
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-7003", "Reports Authors API failed", error);
         })
 }
 
@@ -2198,6 +2230,7 @@ export const createAdminUser = (userData) =>{
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-7004", "Create Admin User API failed", error);
             toast.error("create api " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -2232,6 +2265,7 @@ export const fetchUserInfoByID = (userID) =>{
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-7005", "Fetch User Info API failed", error);
             toast.error("create api " + error.title, {
                 position: "top-right",
                 autoClose: 2000,
@@ -2275,6 +2309,7 @@ export const fetchReportsResultsIds = (requestBody) => dispatch => {
         })
     }).catch(error => {
         console.log(error)
+        reportError("ERR-7006", "Reports Results IDs API failed", error);
         toast.error("Reports Search Pmids Api failed - " + error.title, {
             position: "top-right",
             autoClose: 2000,
@@ -2332,6 +2367,7 @@ export const saveNotification = (payload) => dispatch => {
            })
       }).catch(error => {
         console.log(error)
+        reportError("ERR-7007", "Save Notification API failed", error);
         toast.error("Save notification Api failed - " + error.title, {
           position: "top-right",
           autoClose: 2000,
@@ -2365,6 +2401,7 @@ export const  sendNotification = (payload) =>{
         })
         .catch(error => {
             console.log(error)
+            reportError("ERR-7008", "Send Notification API failed", error);
         })
 }
 
@@ -2394,6 +2431,7 @@ export const disableNotificationbyID = (payload) => dispatch => {
       
     }).catch(error => {
       console.log(error)
+      reportError("ERR-7009", "Disable Notification API failed", error);
       toast.error("Save notification Api failed - " + error.title, {
         position: "top-right",
         autoClose: 2000,
@@ -2447,6 +2485,6 @@ export const sendEmailData = (requestBody) => dispatch => {
             autoClose: 2000,
             theme: 'colored'
         });
-        
+        reportError("ERR-7010", "Send Email API failed", error);
     })
 }

--- a/src/utils/reportError.ts
+++ b/src/utils/reportError.ts
@@ -1,0 +1,9 @@
+export function reportError(code: string, message: string, context?: any) {
+  try {
+    fetch("/api/log", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code, message, context: context?.message || String(context || "") }),
+    }).catch(() => {}); // fire-and-forget
+  } catch {}
+}


### PR DESCRIPTION
## Summary

- Creates a server-side logging endpoint (`/api/log`) so client-side errors reach server logs even when users can't share browser DevTools
- Creates a `reportError()` fire-and-forget helper that POSTs error codes to the server
- Adds `reportError()` calls to **57 catch blocks** across the codebase (39 in actions.js, 18 in components)

## New Files

| File | Purpose |
|------|---------|
| `src/pages/api/log.ts` | POST endpoint that receives `{code, message, context}` and writes `[CLIENT:ERR-XXXX]` to server console |
| `src/utils/reportError.ts` | Fire-and-forget helper that calls `/api/log` — never blocks, never throws |

## Modified Files

| File | Changes |
|------|---------|
| `src/redux/actions/actions.js` | Import + 39 `reportError()` calls (ERR-1001 through ERR-7010) covering all API/redux error paths |
| `ManageProfile.tsx` | Import + 3 calls (ERR-1010, ERR-1011, ERR-1012) |
| `ManageUsers.tsx` | Import + 1 call (ERR-5010) |
| `AdminSettings.tsx` | Import + 3 calls (ERR-9001, ERR-9002, ERR-9003) |
| `SearchSummary.tsx` | Import + 4 calls (ERR-8001, ERR-8002, ERR-8003, ERR-8004) |
| `Notifications.tsx` | Import + 1 call (ERR-6010) |
| `CurateIndividual.tsx` | Import + 1 call (ERR-9010) |
| `Profile.tsx` | Import + 4 calls (ERR-1020, ERR-8010, ERR-8011, ERR-8012) |

## Error Code Scheme

| Range | Category |
|-------|----------|
| ERR-1xxx | Identity / Profile APIs |
| ERR-2xxx | PubMed / Feature Generator / Feedback |
| ERR-3xxx | Gold Standard updates |
| ERR-4xxx | Authentication |
| ERR-5xxx | Organization / Institution / User management |
| ERR-6xxx | Filters / Notifications |
| ERR-7xxx | Reports / Admin |
| ERR-8xxx | Search Summary / Biblio Analysis |
| ERR-9xxx | Admin Settings / Curate |

## Test plan

- [ ] Trigger a client-side error (e.g., network failure) → verify `[CLIENT:ERR-XXXX]` appears in server console
- [ ] Verify `/api/log` returns 405 for GET, 400 for missing code, 204 for valid POST
- [ ] Verify `reportError()` never blocks UI or throws on failure
