### PR TITLE
Fix TypeScript build error in AdminSettings.tsx

### DIFF
--- a/src/components/elements/Manage/AdminSettings.tsx
+++ b/src/components/elements/Manage/AdminSettings.tsx
@@ -77,7 +77,7 @@ const AdminSettings = () => {
       });
   }
 
-  const handleValueChange = (viewLabelIndex?: number, viewAttrIndex?: number, name? : string, e?:any , labelName? : string) => {
+  const handleValueChange = (viewLabelIndex?: number, viewAttrIndex?: number, name? : string, e?:any , labelName? : string | number) => {
     if(name === "personIdentifier" || name === "emailOverride") setIsSendTestEmail(false);
 
     setSettings(settings.map((obj, index1) => {


### PR DESCRIPTION
## Summary

Fixes a TypeScript type error in `AdminSettings.tsx` that would cause `next build` to fail with strict checking.

## Change

`handleValueChange` parameter `labelName` widened from `string` to `string | number` — it receives a numeric `rolesIndex` at line 467.

## Test plan

- [ ] `npx next build` passes cleanly
