### PR TITLE
Use getServerSession in index.js + add SAML error logging

### DIFF
--- a/src/pages/api/auth/saml-acs.js
+++ b/src/pages/api/auth/saml-acs.js
@@ -30,6 +30,7 @@ export default async function handler(req, res) {
         res.redirect(302, '/auth/finalize');
     }
     catch (err) {
+    console.error("[SAML-ACS]", err);
     res.redirect('/auth/error?error=Callback_Error');
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,109 +1,53 @@
-import { getSession } from "next-auth/react"
+import { getServerSession } from "next-auth/next"
+import { options } from "./api/auth/[...nextauth]";
 import { allowedPermissions } from "../utils/constants";
 
-// function RedirectTo(to){
-//     const router = useRouter();
-//     useEffect(()=>{
-//       router.push(to)
-//     },[to])
-//   }
-
 export async function getServerSideProps(ctx) {
-    console.log("context information",ctx);
-    const session = await getSession(ctx);
-    let userPermissions =null;
+  try {
+    const session = await getServerSession(ctx.req, ctx.res, options);
+    let userPermissions = null;
     let personIdentifier = null;
-    if(session && session.data && session.data.userRoles)
-    {  
-        userPermissions = JSON.parse(session.data?.userRoles);
-         personIdentifier = userPermissions && userPermissions.length > 0 ? userPermissions[0].personIdentifier : ""
+    if (session && session.data && session.data.userRoles) {
+      userPermissions = JSON.parse(session.data?.userRoles);
+      personIdentifier = userPermissions && userPermissions.length > 0 ? userPermissions[0].personIdentifier : "";
     }
-    if (process.env.NEXT_PUBLIC_LOGIN_PROVIDER !== "SAML") {
-        //Redirect to search after login
-        if (session && session.data) {
-            if (session.data.databaseUser && session.data.databaseUser.status == 0) {
-                return {
-                    redirect: {
-                        destination: "/noaccess",
-                        permanent: false,
-                    },
-                };
-            }
-            else if (userPermissions && userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self)) {
-                return {
-                    redirect: {
-                        destination: `/curate/${personIdentifier}`,
-                        permanent: false,
-                    },
-                };
-            } 
-            else if ( userPermissions && userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_All || role.roleLabel === allowedPermissions.Reporter_All || role.roleLabel === allowedPermissions.Superuser)) {
-                return {
-                    redirect: {
-                        destination: "/search",
-                        permanent: false,
-                    },
-                };
-            } else {
-                return {
-                    redirect: {
-                        destination: "/noaccess",
-                        permanent: false,
-                    },
-                };
-            }
-        }
 
-        return {
-            redirect: {
-                destination: "/login",
-                permanent: false,
-            },
-        };
-    }
-    //Redirect to search after login
-    if (session && session.data) {
-        if (session.data.databaseUser && session.data.databaseUser.status == 0) {
-            return {
-                redirect: {
-                    destination: "/noaccess",
-                    permanent: false,
-                },
-            };
-        }
-        else if (userPermissions && userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self)) {
-            return {
-                redirect: {
-                    destination: `/curate/${personIdentifier}`,
-                    permanent: false,
-                },
-            };
-        }
-        else if (userPermissions && userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_All || role.roleLabel === allowedPermissions.Reporter_All || role.roleLabel === allowedPermissions.Superuser)) 
-        {
-            return {
-                redirect: {
-                    destination: "/search",
-                    permanent: false,
-                },
-            };
-        }  else {
-            return {
-                redirect: {
-                    destination: "/noaccess",
-                    permanent: false,
-                },
-            };
-        }
-    }
+    // No session — redirect to login
     if (!session || !session.data) {
-    return {
-        redirect: {
-            destination: "/api/auth/saml-login?callbackUrl=/search", // Use your START route
-            permanent: false,
-        },
-    };
-}
+      if (process.env.NEXT_PUBLIC_LOGIN_PROVIDER !== "SAML") {
+        return { redirect: { destination: "/login", permanent: false } };
+      }
+      return { redirect: { destination: "/api/auth/saml-login?callbackUrl=/search", permanent: false } };
+    }
+
+    // Disabled user
+    if (session.data.databaseUser && session.data.databaseUser.status == 0) {
+      return { redirect: { destination: "/noaccess", permanent: false } };
+    }
+
+    // Curator_Self — redirect to their own curate page
+    if (userPermissions && userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self)) {
+      return { redirect: { destination: `/curate/${personIdentifier}`, permanent: false } };
+    }
+
+    // Curator_All, Reporter_All, Superuser — redirect to search
+    if (userPermissions && userPermissions.some(role =>
+      role.roleLabel === allowedPermissions.Curator_All ||
+      role.roleLabel === allowedPermissions.Reporter_All ||
+      role.roleLabel === allowedPermissions.Superuser
+    )) {
+      return { redirect: { destination: "/search", permanent: false } };
+    }
+
+    // Authenticated but no recognized role
+    return { redirect: { destination: "/noaccess", permanent: false } };
+  } catch (error) {
+    console.error("[INDEX:getServerSideProps]", error);
+    if (process.env.NEXT_PUBLIC_LOGIN_PROVIDER !== "SAML") {
+      return { redirect: { destination: "/login", permanent: false } };
+    }
+    return { redirect: { destination: "/api/auth/saml-login?callbackUrl=/search", permanent: false } };
+  }
 }
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- **index.js**: Migrates from `getSession` (internal HTTP fetch to `/api/auth/session`) to `getServerSession` (reads JWT directly) — faster, no round-trip. Wraps `getServerSideProps` in try/catch so auth failures redirect gracefully instead of returning 500. Also deduplicates the SAML vs non-SAML redirect logic which was copy-pasted across two code paths.
- **saml-acs.js**: Adds `console.error("[SAML-ACS]", err)` to the catch block so SAML assertion failures appear in server logs instead of silently redirecting.

## Test plan
- [ ] Login with DB credentials — should redirect to `/search` or `/curate/{id}` as before
- [ ] Login with SAML — same redirect behavior
- [ ] Disabled user (status=0) — should redirect to `/noaccess`
- [ ] Invalid SAML assertion — should log error server-side and redirect to `/auth/error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)