### PR TITLE
Show user-friendly message when no evidence metadata

### DIFF
--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -669,8 +669,10 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
 
 
                     </div>
-                    : <div>
-                        <span></span>
+                    : <div className={styles.publicationEvidenceBar}>
+                        <p className="text-muted fst-italic mt-2 mb-2" style={{fontSize: '14px'}}>
+                          Evidence data is not available for this article.
+                        </p>
                     </div>
             }
             <div className="clear-both"></div>


### PR DESCRIPTION
## Summary
- When an article has just been accepted/rejected, evidence data may not be available
- Previously showed blank space; now displays "Evidence data is not available for this article." in muted italic text
- Applies consistent `publicationEvidenceBar` styling to the no-evidence state

Closes #644

## Test plan
- [ ] Accept an article that has no evidence metadata
- [ ] Verify the message "Evidence data is not available for this article." appears where evidence would normally be
- [ ] Verify articles with evidence still display the evidence table normally
- [ ] Check styling matches the rest of the evidence bar area

🤖 Generated with [Claude Code](https://claude.com/claude-code)