### PR TITLE
fix(ci): replace deprecated ECR login command

### DIFF
--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -38,7 +38,7 @@ phases:
             aws s3 cp s3://reciter-config/config/prod/saml/reciter-saml.crt ./config/certs/reciter-saml.crt
             aws s3 cp s3://reciter-config/config/prod/saml/reciter-saml.key ./config/certs/reciter-saml.key
           fi
-        - $(aws ecr get-login --no-include-email)
+        - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $REPOSITORY_URI
         # - sed -i -e "s/ADMIN_API_KEY/$ADMIN_API_KEY/g" config/local.js
         # - sed -i -e "s/TOKEN_SECRET/$TOKEN_SECRET/g" config/local.js
         - cat config/local.js


### PR DESCRIPTION
## Summary
- Replaces `$(aws ecr get-login --no-include-email)` with `aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $REPOSITORY_URI`
- The old command was removed from AWS CLI v2 and has been causing all dev builds to fail at the PRE_BUILD phase with `exit status 252`

## Test plan
- [ ] Approve and trigger a dev build — PRE_BUILD phase should pass ECR login
- [ ] Confirm Docker image builds and pushes to ECR successfully