### PR TITLE
fix(ci): replace deprecated aws ecr get-login with get-login-password

### DIFF
--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -38,7 +38,7 @@ phases:
             aws s3 cp s3://reciter-config/config/prod/saml/reciter-saml.crt ./config/certs/reciter-saml.crt
             aws s3 cp s3://reciter-config/config/prod/saml/reciter-saml.key ./config/certs/reciter-saml.key
           fi
-        - $(aws ecr get-login --no-include-email)
+        - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $REPOSITORY_URI
         # - sed -i -e "s/ADMIN_API_KEY/$ADMIN_API_KEY/g" config/local.js
         # - sed -i -e "s/TOKEN_SECRET/$TOKEN_SECRET/g" config/local.js
         - cat config/local.js


### PR DESCRIPTION
## Summary

- Builds 997-999 (2026-04-22) failed in PRE_BUILD with `aws ecr get-login` exit 252 — the command was removed in AWS CLI v2.
- Last successful build was #996 (2026-04-07), so 14+ days of work — including the v1.3 RBAC refactor (Phases 14-17) — is sitting un-deployed on this branch.
- Replaces with the canonical `aws ecr get-login-password | docker login --password-stdin` pattern.

## Test plan

- [ ] Merge triggers CodeBuild #1000+
- [ ] Build succeeds through PRE_BUILD (was previously failing on the ecr login line)
- [ ] Image tag advances past `dev_Upd_NextJS14SNode18-996.2026-04-07.7feb0ba7`
- [ ] `kubectl get deployment reciter-pm-dev -n reciter -o jsonpath='{.spec.template.spec.containers[0].image}'` shows the new tag
- [ ] Hit `https://reciter-dev.weill.cornell.edu/api/auth/session` after re-login — JWT now contains `permissions` array (proves v1.3 enrichment is live)

## Followup

The same fix needs to land on `dev_v2` and `master` so prod redeploys don't hit the same wall. Separate PRs.