### PR TITLE
fix(build): pin @types/babel__traverse and @rushstack/eslint-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
   },
   "resolutions": {
     "@types/react": "^17.0.38",
-    "@types/react-dom": "^17"
+    "@types/react-dom": "^17",
+    "@types/babel__traverse": "7.18.5",
+    "@rushstack/eslint-patch": "1.0.6"
   }
 }


### PR DESCRIPTION
## Summary

Build #1000 (post-ECR-fix) failed at \`next build\` because the in-container build regenerates the lockfile and picks up newer transitive deps incompatible with this project's Node 14 / TS 4.4 baseline:

- \`@rushstack/eslint-patch >= 1.4\` imports \`node:path\` → fails on Node 14.16 (needs ≥16)
- \`@types/babel__traverse 7.28.0\` uses TS syntax not parseable by 4.4.3 (\`'?' expected\` at line 1467:40)

The committed lockfile already had these pinned to working versions (\`1.0.6\` and \`7.18.5\`) but the build script's \`npm install --package-lock-only\` discards those pins on every build.

This PR adds both to \`resolutions\` so \`npm-force-resolutions\` clamps them back after lockfile regen — preserving the existing build-script flow while fixing the new failure mode.

## Test plan

- [ ] Merge triggers CodeBuild
- [ ] BUILD phase passes (was failing on \`next build\`)
- [ ] Image tag advances to \`...affadd3...\` or successor
- [ ] \`/api/auth/session\` on reciter-dev shows enriched JWT with \`permissions\` array (proves v1.3 auth code is live)

## Followup

The build-script lockfile-regen pattern is fragile by design — every push roulettes on whatever's latest in the registry. A better fix later: switch to \`npm ci\`, drop \`npm-force-resolutions\`, move pins to npm-native \`overrides\`. Out of scope for this PR.