### PR TITLE
fix(build): use npm ci in Dockerfile deps stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG ASMS_USER_TRACKING_API_AUTHORIZATON
 ARG RECITER_API_BASE_URL
 ARG NEXT_PUBLIC_LOGIN_PROVIDER
 COPY package.json package-lock.json ./
-RUN npm install --frozen-lockfile
+RUN npm ci --ignore-scripts
 
 # Rebuild the source code only when needed
 FROM node:14.16.0-alpine AS builder


### PR DESCRIPTION
## Summary

Build #1001 failed identically to #1000 because the previous PR's pin to \`resolutions\` had no effect — the in-container deps install isn't actually respecting the lockfile. Build log shows:

\`\`\`
Step 22/60 : RUN npm install --frozen-lockfile
\`\`\`

\`--frozen-lockfile\` is a **Yarn flag** silently ignored by npm. So the deps stage has been doing a full semver re-resolve every build, pulling in latest \`@rushstack/eslint-patch\` (uses \`node:path\`, needs Node 16+) and \`@types/babel__traverse 7.28.0\` (TS syntax beyond 4.4.3).

## Fix

Switch deps stage to \`npm ci --ignore-scripts\`:
- \`npm ci\` respects the committed lockfile exactly (which already pins the working versions: \`1.0.6\` and \`7.18.5\`)
- \`--ignore-scripts\` skips the \`preinstall\` script, which was already silently failing (\`WARN lifecycle ... cannot run in wd\`) and trying to regenerate the lockfile

## Test plan

- [ ] Merge triggers CodeBuild
- [ ] Step 22 deps install resolves to the same versions as the committed lockfile
- [ ] BUILD phase passes through \`next build\`
- [ ] Image tag advances; reciter-dev shows v1.3 enriched JWT

## Followup

\`build\` and \`preinstall\` scripts still try to regenerate the lockfile via \`npm install --package-lock-only && npm-force-resolutions\`, but those run on lockfile only — node_modules in the builder stage is already correct from the deps stage. Could simplify the package.json scripts in a later cleanup PR.