### PR TITLE
fix(build): bump Dockerfile to node:18-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Install dependencies only when needed
-FROM node:14.16.0-alpine AS deps
+FROM node:18-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -24,8 +24,7 @@ COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
 
 # Rebuild the source code only when needed
-FROM node:14.16.0-alpine AS builder
-#FROM node:18-alpine AS builder
+FROM node:18-alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
@@ -49,8 +48,7 @@ RUN env
 RUN npm run build && npm install --production --ignore-scripts --prefer-offline
 
 # Production image, copy all the files and run next
-FROM node:14.16.0-alpine AS runner
-#FROM node:18-alpine AS runner
+FROM node:18-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production


### PR DESCRIPTION
## Summary

Build #1002 failed at \`Step 22 RUN npm ci\` with:

\`\`\`
npm ERR! Cannot read property '@babel/runtime' of undefined
\`\`\`

This is the classic symptom of **npm 6 trying to read a lockfileVersion 3 file**. The committed \`package-lock.json\` is v3 (per the \`7feb0ba\` commit message: *"regenerate clean package-lock.json (lockfileVersion 3) for Node 20 npm ci"*), but \`node:14.16.0-alpine\` ships npm 6.

The branch name \`dev_Upd_NextJS14SNode18\` indicated this all along — and two of the three Dockerfile stages already had commented-out \`node:18-alpine\` lines, so this migration was begun but never finished.

## Test plan

- [ ] Merge triggers CodeBuild
- [ ] Step 22 \`npm ci --ignore-scripts\` succeeds (resolves to committed lockfile versions: \`@types/babel__traverse 7.18.5\`, \`@rushstack/eslint-patch 1.0.6\`)
- [ ] BUILD phase passes through \`next build\`
- [ ] Image deploys to reciter-pm-dev
- [ ] \`/api/auth/session\` shows v1.3 enriched JWT with \`permissions\` array