### PR TITLE
fix(build): add --legacy-peer-deps to npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG ASMS_USER_TRACKING_API_AUTHORIZATON
 ARG RECITER_API_BASE_URL
 ARG NEXT_PUBLIC_LOGIN_PROVIDER
 COPY package.json package-lock.json ./
-RUN npm ci --ignore-scripts
+RUN npm ci --ignore-scripts --legacy-peer-deps
 
 # Rebuild the source code only when needed
 FROM node:18-alpine AS builder


### PR DESCRIPTION
Build #1003 hit ERESOLVE: lockfile has `@types/react@17` but `@types/react-dom@18.3.7` peer-requires `@types/react@^18`. npm 6 silently allowed this; npm 10 doesn't. `--legacy-peer-deps` restores the permissive behavior that worked in build #996. Final piece (hopefully) to get v1.3 deployed.