### PR TITLE
fix(build): remove unused resolutions field

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,11 +76,5 @@
     "jsonwebtoken": "^8.5.1",
     "sequelize-auto": "^0.8.5",
     "typescript": "4.4.3"
-  },
-  "resolutions": {
-    "@types/react": "^17.0.38",
-    "@types/react-dom": "^17",
-    "@types/babel__traverse": "7.18.5",
-    "@rushstack/eslint-patch": "1.0.6"
   }
 }


### PR DESCRIPTION
Build #1004 hit `npm error Invalid Version: ^17.0.38` — npm 10 strict-parses the yarn-only `resolutions` field and rejects it. The field has been dead weight since `npm-force-resolutions` was silently failing in preinstall anyway. Removing it.