### PR TITLE
fix(build): npm install + overrides to handle corrupt lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG ASMS_USER_TRACKING_API_AUTHORIZATON
 ARG RECITER_API_BASE_URL
 ARG NEXT_PUBLIC_LOGIN_PROVIDER
 COPY package.json package-lock.json ./
-RUN npm ci --ignore-scripts --legacy-peer-deps
+RUN npm install --legacy-peer-deps --ignore-scripts --no-audit --no-fund
 
 # Rebuild the source code only when needed
 FROM node:18-alpine AS builder

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "jsonwebtoken": "^8.5.1",
     "sequelize-auto": "^0.8.5",
     "typescript": "4.4.3"
+  },
+  "overrides": {
+    "@types/babel__traverse": "7.18.5"
   }
 }


### PR DESCRIPTION
Build #1005 hit `Invalid Version: ^17.0.38` because the committed lockfile has 14 entries with range specifiers as the `version` field — old corruption from `npm-force-resolutions` that npm 6 silently tolerated. Switching from `npm ci` (strict) to `npm install --legacy-peer-deps` (regenerates lockfile) and adding npm-native `overrides` to pin `@types/babel__traverse` for TS 4.4.3 compat.