### PR TITLE
fix(build): --legacy-peer-deps in builder stage too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ARG ASMS_USER_TRACKING_API_AUTHORIZATON
 ARG RECITER_API_BASE_URL
 ARG NEXT_PUBLIC_LOGIN_PROVIDER
 RUN env
-RUN npm run build && npm install --production --ignore-scripts --prefer-offline
+RUN npm run build && npm install --production --ignore-scripts --prefer-offline --legacy-peer-deps
 
 # Production image, copy all the files and run next
 FROM node:18-alpine AS runner


### PR DESCRIPTION
Build #1006 got past deps stage but failed at Step 44 (builder stage) with the same ERESOLVE conflict because `npm install --production` there doesn't have `--legacy-peer-deps`.