### PR TITLE
fix(build): simplify build script, drop lockfile regen

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "preinstall": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions",
     "dev": "next dev",
-    "build": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions && next build",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "generate-models": "node ./src/db/scripts/generateModels.js"


### PR DESCRIPTION
Build script's pre-build `npm install --package-lock-only` runs without `--legacy-peer-deps` and hits ERESOLVE before the outer install command can apply its flag. The whole regen+force-resolutions chain has been broken since preinstall stopped running. Simplifying to just `next build`.