### PR TITLE
fix(build): bump TypeScript to 4.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "typescript": "4.4.3"
   },
   "overrides": {
-    "@types/babel__traverse": "7.18.5"
+    "@types/babel__traverse": "7.18.5",
+    "@types/node": "16.11.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,10 +74,6 @@
     "http-build-query": "^0.7.0",
     "jsonwebtoken": "^8.5.1",
     "sequelize-auto": "^0.8.5",
-    "typescript": "4.4.3"
-  },
-  "overrides": {
-    "@types/babel__traverse": "7.18.5",
-    "@types/node": "16.11.7"
+    "typescript": "4.9.5"
   }
 }


### PR DESCRIPTION
TS 4.4.3 (Aug 2021) can't parse modern @types syntax — pinning each typedef one at a time is whack-a-mole. TS 4.9.5 is the last 4.x release and handles all the modern typedef syntax we've been hitting (instantiation expressions, typeof with type arguments). Drops the typedef pins as no longer needed.