### PR TITLE
fix(build): rm lockfile in builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,9 @@ ARG ASMS_USER_TRACKING_API_AUTHORIZATON
 ARG RECITER_API_BASE_URL
 ARG NEXT_PUBLIC_LOGIN_PROVIDER
 RUN env
-RUN npm run build && npm install --production --ignore-scripts --prefer-offline --legacy-peer-deps
+# Same lockfile-corruption issue as deps stage: COPY . . brought back the
+# original corrupt package-lock.json. Remove it before npm install --production.
+RUN rm -f package-lock.json && npm run build && npm install --production --ignore-scripts --prefer-offline --legacy-peer-deps
 
 # Production image, copy all the files and run next
 FROM node:18-alpine AS runner


### PR DESCRIPTION
Builder stage's COPY . . re-introduced the corrupt committed lockfile, so npm install --production hits Invalid Version: ^17.0.38 again. Same rm fix as we used in deps stage.