### PR TITLE
fix(auth): wire NEXTAUTH_SECRET into next-auth options

### DIFF
--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -324,6 +324,10 @@ const options = {
         jwt: true,
         maxAge: 7200,
     },
+    secret: process.env.NEXTAUTH_SECRET,
+    jwt: {
+        secret: process.env.NEXTAUTH_SECRET,
+    },
 };
 
 const persistUserLogin =async (cwid)=>{


### PR DESCRIPTION
Without this, next-auth auto-generates a fresh signing key on every pod start. JWTs get re-encrypted but old cookies become unreadable, causing infinite login loops. The env var was set in K8s secrets but never plumbed into the options object.