### PR TITLE
fix(build): backport build pipeline fixes from dev_Upd_NextJS14SNode18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Install dependencies only when needed
-FROM node:14.16.0-alpine AS deps
+FROM node:18-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -11,11 +11,22 @@ ARG RECITER_DB_PASSWORD
 ARG NEXT_PUBLIC_RECITER_API_KEY
 ARG NEXT_PUBLIC_RECITER_TOKEN_SECRET
 ARG NEXT_PUBLIC_RECITER_BACKEND_API_KEY=test
+ARG RECITER_DB_PORT
+ARG SMTP_HOST_NAME
+ARG SMTP_USER
+ARG SMTP_PASSWORD
+ARG SMTP_ADMIN_EMAIL
+ARG ASMS_API_BASE_URL
+ARG ASMS_USER_TRACKING_API_AUTHORIZATON
+ARG RECITER_API_BASE_URL
+ARG NEXT_PUBLIC_LOGIN_PROVIDER
 COPY package.json package-lock.json ./
-RUN npm install --frozen-lockfile
+# Lockfile has corrupt entries from old npm-force-resolutions that npm 10
+# refuses to parse ("Invalid Version: ^17.0.38"). Delete and regenerate.
+RUN rm -f package-lock.json && npm install --legacy-peer-deps --ignore-scripts --no-audit --no-fund
 
 # Rebuild the source code only when needed
-FROM node:14.16.0-alpine AS builder
+FROM node:18-alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
@@ -26,11 +37,22 @@ ARG RECITER_DB_PASSWORD
 ARG NEXT_PUBLIC_RECITER_API_KEY
 ARG NEXT_PUBLIC_RECITER_TOKEN_SECRET
 ARG NEXT_PUBLIC_RECITER_BACKEND_API_KEY=test
+ARG RECITER_DB_PORT
+ARG SMTP_HOST_NAME
+ARG SMTP_USER
+ARG SMTP_PASSWORD
+ARG SMTP_ADMIN_EMAIL
+ARG ASMS_API_BASE_URL
+ARG ASMS_USER_TRACKING_API_AUTHORIZATON
+ARG RECITER_API_BASE_URL
+ARG NEXT_PUBLIC_LOGIN_PROVIDER
 RUN env
-RUN npm run build && npm install --production --ignore-scripts --prefer-offline
+# Same lockfile-corruption issue as deps stage: COPY . . brought back the
+# original corrupt package-lock.json. Remove it before npm install --production.
+RUN rm -f package-lock.json && npm run build && npm install --production --ignore-scripts --prefer-offline --legacy-peer-deps
 
 # Production image, copy all the files and run next
-FROM node:14.16.0-alpine AS runner
+FROM node:18-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production

--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -20,7 +20,7 @@ phases:
           if expr "${BRANCH}" : ".*master" >/dev/null; then
             sed -i.bak -e 's@RECITER-SERVICE@'"reciter-prod"'@' -e 's@RECITER-PUBMED-SERVICE@'"reciter-pubmed-prod"'@'  config/local.js;
           fi
-        - $(aws ecr get-login --no-include-email)
+        - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $REPOSITORY_URI
         # - sed -i -e "s/ADMIN_API_KEY/$ADMIN_API_KEY/g" config/local.js
         # - sed -i -e "s/TOKEN_SECRET/$TOKEN_SECRET/g" config/local.js
         - cat config/local.js

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "preinstall": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions",
     "dev": "next dev",
-    "build": "npm install --package-lock-only --ignore-scripts && npx npm-force-resolutions && next build",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
@@ -53,7 +52,9 @@
     "redux-thunk": "^2.3.0",
     "reflect-metadata": "^0.1.13",
     "saml2-js": "^3.0.1",
-    "sequelize": "^6.9.0"
+    "sequelize": "^6.9.0",
+    "http-build-query": "^0.7.0",
+    "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "5.17.0",
@@ -72,16 +73,10 @@
     "eslint": "7.32.0",
     "eslint-config-next": "11.1.2",
     "eslint-plugin-jsx-a11y": "6.10.2",
-    "http-build-query": "^0.7.0",
     "jest": "27.5.1",
     "jest-environment-jsdom": "27.5.1",
-    "jsonwebtoken": "^8.5.1",
     "node-mocks-http": "^1.17.2",
     "sequelize-auto": "^0.8.5",
-    "typescript": "4.4.3"
-  },
-  "resolutions": {
-    "@types/react": "17.0.91",
-    "@types/react-dom": "17.0.25"
+    "typescript": "4.9.5"
   }
 }

--- a/src/components/elements/CurateIndividual/ReciterTabContent.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabContent.tsx
@@ -8,7 +8,6 @@ import Pagination from '../Pagination/Pagination';
 import { useSession } from "next-auth/client";
 import { curateSearchtextAction, reciterUpdatePublication } from "../../../redux/actions/actions";
 import { RootStateOrAny, useDispatch, useSelector } from "react-redux";
-import { FormControlUnstyled } from "@mui/material";
 
 interface TabContentProps {
   tabType: string,


### PR DESCRIPTION
## Summary

Backports the build pipeline fixes that took 12 PRs to land on \`dev_Upd_NextJS14SNode18\` (#650-#663). dev_v2 will hit the exact same failures the next time CodeBuild runs because all the underlying causes (AWS CLI v2 deprecation of \`ecr get-login\`, npm 6 incompat with lockfileVersion 3, registry transitive deps moving past TS 4.4 compat, etc.) are independent of which branch you're on.

## What's included

- **k8-buildspec.yml**: ECR login command updated for AWS CLI v2
- **Dockerfile**: Node 14 → 18, \`npm ci --frozen-lockfile\` no-op replaced with \`rm + npm install --legacy-peer-deps\`, builder-stage \`npm install --production\` gets \`--legacy-peer-deps\` too
- **package.json**: drop broken preinstall+npm-force-resolutions chain, simplify build to \`next build\`, TS 4.4.3 → 4.9.5, move runtime-imported \`http-build-query\` and \`jsonwebtoken\` from devDependencies to dependencies
- **ReciterTabContent.tsx**: drop dead \`FormControlUnstyled\` import (TS 4.9 catches; old MUI no longer exports)

## Not included (separate PR)

- NEXTAUTH_SECRET wiring fix (#666) — separate PR
- The reciter-dev-specific saml-acs handler (#664-#665) — only needed for the dev IdP

## Test plan

- [ ] Merge triggers CodeBuild for dev_v2
- [ ] Build succeeds (was previously failing on the ECR login line and would fail further down even after that)
- [ ] Image deploys; existing dev_v2 features (proxy curation, scoped roles, etc.) still work