### PR TITLE
fix(auth): wire NEXTAUTH_SECRET into NextAuth options

### DIFF
--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -179,6 +179,10 @@ const options = {
         jwt: true,
         maxAge: 7200,
     },
+    secret: process.env.NEXTAUTH_SECRET,
+    jwt: {
+        secret: process.env.NEXTAUTH_SECRET,
+    },
 };
 
 export default authHandler;


### PR DESCRIPTION
## Summary

Without this, next-auth auto-generates a fresh signing key on every pod restart (\`jwt_auto_generated_signing_key\` warning). JWT cookies from old pods become unreadable in new pods, causing infinite SAML login loops on every redeploy.

\`NEXTAUTH_SECRET\` is already set in K8s secrets — this PR just plumbs it into the options object as next-auth v3 expects.

## Test plan

- [ ] Merge + redeploy
- [ ] \`kubectl logs <pod>\` no longer shows \`jwt_auto_generated_signing_key\` or \`jwt_session_error\` warnings
- [ ] Existing logged-in users keep their session across pod restarts
- [ ] SAML login completes without bouncing back to \`/login\`

Companion to #667 (build pipeline backport). Both target dev_v2; can be merged in either order.