### PR TITLE
fix(auth): pass arrays to findUserPermissions / findOnePerson

### DIFF
--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -39,7 +39,7 @@ export const authOptions = {
         );
 
         const assignedRoles = await grantDefaultRolesToAdminUser(adminUser);
-        const userRoles = await findUserPermissions(credentials.username, 'cwid');
+        const userRoles = await findUserPermissions(["personIdentifier"], [credentials.username]);
 
         if (process.env.ASMS_API_BASE_URL)
           persistUserLogin(credentials.username)

--- a/src/utils/samlUtils.js
+++ b/src/utils/samlUtils.js
@@ -23,11 +23,11 @@ export const findOrcreateAdminUser = async(cwid,samlEmail,samlFirstName,samlLast
          // a different address than what's stored in admin_users).
          const dbPersonId = createdAdminUser.personIdentifier;
          if(dbPersonId) {
-            userRoles = await findUserPermissions(dbPersonId, "cwid")
+            userRoles = await findUserPermissions(["personIdentifier"], [dbPersonId])
          } else if(samlEmail) {
-            userRoles = await findUserPermissions(samlEmail, "email")
+            userRoles = await findUserPermissions(["email"], [samlEmail])
          } else if(cwid) {
-            userRoles = await findUserPermissions(cwid, "cwid")
+            userRoles = await findUserPermissions(["personIdentifier"], [cwid])
          }
          
          createdAdminUser['userRoles'] = userRoles;
@@ -87,9 +87,9 @@ export const grantDefaultRolesToAdminUser = async(adminUser) => {
     let finalAssignRolesPayload =[];
     if(adminUser && adminUser.personIdentifier)
     {
-        personAPIResponse = await findOnePerson("personIdentifier",adminUser.personIdentifier);
-        
-        existingAdminUserRoles = JSON.parse(await findUserPermissions(adminUser.personIdentifier, "cwid"))
+        personAPIResponse = await findOnePerson(["personIdentifier"], [adminUser.personIdentifier]);
+
+        existingAdminUserRoles = JSON.parse(await findUserPermissions(["personIdentifier"], [adminUser.personIdentifier]))
     } 
     if(assignRolesPayload && assignRolesPayload.length >= 2)
     {


### PR DESCRIPTION
Latent bug from v1.1-port merge: the API signatures of `findUserPermissions` and `findOnePerson` were rewritten to require arrays, but call sites in samlUtils.js and [...nextauth].jsx kept the old single-value style. Each SAML login throws `Both attrTypes and attrValues must be arrays` and returns 401 CredentialsSignin. Hidden until now because dev hasn't successfully built since April 7.