### PR TITLE
fix(auth): always pass both attrTypes (personIdentifier + email) to findUserPermissions

### DIFF
--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -39,7 +39,10 @@ export const authOptions = {
         );
 
         const assignedRoles = await grantDefaultRolesToAdminUser(adminUser);
-        const userRoles = await findUserPermissions(["personIdentifier"], [credentials.username]);
+        const userRoles = await findUserPermissions(
+          ["personIdentifier", "email"],
+          [credentials.username, credentials.email || ""]
+        );
 
         if (process.env.ASMS_API_BASE_URL)
           persistUserLogin(credentials.username)

--- a/src/utils/samlUtils.js
+++ b/src/utils/samlUtils.js
@@ -22,12 +22,13 @@ export const findOrcreateAdminUser = async(cwid,samlEmail,samlFirstName,samlLast
          // SAML-provided email may not match the DB email (e.g., IdP returns
          // a different address than what's stored in admin_users).
          const dbPersonId = createdAdminUser.personIdentifier;
-         if(dbPersonId) {
-            userRoles = await findUserPermissions(["personIdentifier"], [dbPersonId])
-         } else if(samlEmail) {
-            userRoles = await findUserPermissions(["email"], [samlEmail])
-         } else if(cwid) {
-            userRoles = await findUserPermissions(["personIdentifier"], [cwid])
+         // Controller's SQL references both :personIdentifier and :email
+         // unconditionally, so always pass both even if one is empty.
+         if(dbPersonId || samlEmail || cwid) {
+            userRoles = await findUserPermissions(
+                ["personIdentifier", "email"],
+                [dbPersonId || cwid || "", samlEmail || ""]
+            )
          }
          
          createdAdminUser['userRoles'] = userRoles;
@@ -89,7 +90,10 @@ export const grantDefaultRolesToAdminUser = async(adminUser) => {
     {
         personAPIResponse = await findOnePerson(["personIdentifier"], [adminUser.personIdentifier]);
 
-        existingAdminUserRoles = JSON.parse(await findUserPermissions(["personIdentifier"], [adminUser.personIdentifier]))
+        existingAdminUserRoles = JSON.parse(await findUserPermissions(
+            ["personIdentifier", "email"],
+            [adminUser.personIdentifier, adminUser.email || ""]
+        ))
     } 
     if(assignRolesPayload && assignRolesPayload.length >= 2)
     {


### PR DESCRIPTION
Followup to #670. The controller's SQL hardcodes both `:personIdentifier` and `:email` named replacements, so calls passing only one fail with sequelize's "Named replacement has no entry" error and 401 CredentialsSignin.