### PR TITLE
fix(build): drop deleted package-lock.json from Dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,11 @@ ARG ASMS_API_BASE_URL
 ARG ASMS_USER_TRACKING_API_AUTHORIZATON
 ARG RECITER_API_BASE_URL
 ARG NEXT_PUBLIC_LOGIN_PROVIDER
-COPY package.json package-lock.json ./
-# Lockfile has corrupt entries from old npm-force-resolutions that npm 10
-# refuses to parse ("Invalid Version: ^17.0.38"). Delete and regenerate.
-RUN rm -f package-lock.json && npm install --legacy-peer-deps --ignore-scripts --no-audit --no-fund
+COPY package.json ./
+# Lockfile is no longer committed (was corrupt with range-specifier
+# version entries from old npm-force-resolutions). Resolve fresh from
+# package.json each build.
+RUN npm install --legacy-peer-deps --ignore-scripts --no-audit --no-fund
 
 # Rebuild the source code only when needed
 FROM node:18-alpine AS builder


### PR DESCRIPTION
Followup to #672 — package-lock.json was removed in the revert but Dockerfile's COPY still references it.