### PR TITLE
fix(types): add capabilityKey to MenuItem

### DIFF
--- a/types/menu.d.ts
+++ b/types/menu.d.ts
@@ -9,4 +9,5 @@ export type MenuItem = {
   disabled?: boolean
   allowedRoleNames?:Array,
   isRequired?:boolean
+  capabilityKey?: string
 }


### PR DESCRIPTION
## Summary
- The Skeletons restore (PR #678) merged successfully but the next build failed with a TS2353 in `SideNavbar.tsx:160` — `capabilityKey` is assigned on each menu entry but missing from the `MenuItem` type.
- Adds `capabilityKey?: string` to `types/menu.d.ts` so capability-gated menu rendering type-checks.

## Test plan
- [ ] CodeBuild build for `dev_Upd_NextJS14SNode18` succeeds after merge
- [ ] `reciter-pm-dev` deployment rolls a new image
- [ ] SideNavbar still renders the correct items per role on reciter-dev