### PR TITLE
fix: use next-auth v3 tuple destructuring for useSession

### DIFF
--- a/src/components/elements/Report/Report.tsx
+++ b/src/components/elements/Report/Report.tsx
@@ -25,7 +25,7 @@ import ToastContainerWrapper from '../ToastContainerWrapper/ToastContainerWrappe
 
 const Report = () => {
   const dispatch = useDispatch()
-  const { data: session, status } = useSession(); const loading = status === "loading";
+  const [session] = useSession();
 
   // state to manage what content to display on inital load
   const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -58,7 +58,7 @@ type AppPropsWithLayout = AppProps & {
 // This sub-component handles the logic so _app.tsx stays clean
 function AdminSettingsDataLoader() {
     const dispatch = useDispatch();
-    const { data: session } = useSession();
+    const [session] = useSession();
     const adminSettings = useSelector((state: any) => state.updatedAdminSettings || []);
     useEffect(() => {
         // If we have a session but NO settings in Redux, fetch them!


### PR DESCRIPTION
## Summary
- next-auth ^3.29.10's `useSession()` returns `[session, loading]`, not the v4 `{ data, status }` object.
- Two callsites used the v4 syntax and broke the production tsc build.

CodeBuild on `c977df3` (PR #679 merge) failed with TS2353 at `src/components/elements/Report/Report.tsx:28` — `Property 'data' does not exist on type '[Session, boolean]'`. `_app.tsx:61` had the same latent bug; fixed pre-emptively in the same commit.

The rest of the codebase (`SideNavbar`, `Header`, `Profile`, `usePermissions`, `NestedListItem`) already uses the correct v3 tuple form.

## Test plan
- [ ] CodeBuild on `dev_Upd_NextJS14SNode18` reaches the docker-build phase
- [ ] reciter-pm-dev rolls a new image