### PR TITLE
fix: restore setIsVisible and setReportFilterKeyNames in constants

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -34,6 +34,11 @@ export const numberFormation = (number)=> {
 	return formatedNumber
 }
 
+export const setReportFilterKeyNames = (allFilters, filterLabel) => {
+	let filteredLabel = allFilters?.length > 0 && allFilters?.find((allLabels) => allLabels.labelUserKey === filterLabel)
+	return filteredLabel?.labelUserKey || ""
+}
+
 export const setReportFilterLabels = (allFilters, filterLabel) => {
 	let filteredLabel = allFilters?.length > 0 && allFilters?.find((allLabels) => allLabels.labelUserKey === filterLabel)
 	return filteredLabel?.labelUserView || ""
@@ -47,6 +52,11 @@ export const setReportFilterDisplayRank = (allFilters, filterLabel) => {
 export const setHelptextInfo = (allFilters, filterLabel) => {
 	let filteredLabel = allFilters?.length > 0 && allFilters?.find((allLabels) => allLabels.labelUserKey === filterLabel)
 	return filteredLabel?.helpTextUserView || ""
+}
+
+export const setIsVisible = (allFilters, filterLabel) => {
+	let filteredLabel = allFilters?.length > 0 && allFilters?.find((allLabels) => allLabels.labelUserKey === filterLabel)
+	return filteredLabel?.isVisible || false
 }
 
 export const dropdownItemsSuper = [


### PR DESCRIPTION
## Summary
- The dev_v2 re-restore in 2a0a747 dropped two exported helpers (`setIsVisible`, `setReportFilterKeyNames`) from `src/utils/constants.js`.
- `ReportsResultPane.tsx` and `SearchSummary.tsx` still import and call both, so the production tsc build fails:  
  `Module '"../../../utils/constants"' has no exported member 'setIsVisible'`.
- Restored from `ca7983d` (the commit that originally added them) with the same arity and return shape; dropped the redundant `Array.isArray()` guard since the optional chaining already handles non-array inputs.

## Test plan
- [ ] CodeBuild on `dev_Upd_NextJS14SNode18` reaches the docker-build phase
- [ ] reciter-pm-dev rolls a new image