### PR TITLE
fix: drop invalid controlId prop from ScopeFilterCheckbox Form.Check

### DIFF
--- a/src/components/elements/Search/ScopeFilterCheckbox.tsx
+++ b/src/components/elements/Search/ScopeFilterCheckbox.tsx
@@ -11,7 +11,6 @@ const ScopeFilterCheckbox: React.FC<ScopeFilterCheckboxProps> = ({ checked, onCh
     <Form.Check
       type="checkbox"
       id="scopeFilterCheckbox"
-      controlId="scopeFilterCheckbox"
       label="Show only people I can curate"
       checked={checked}
       onChange={(e) => onChange(e.target.checked)}


### PR DESCRIPTION
## Summary
- `<Form.Check>` does not accept a `controlId` prop; that prop belongs on `<Form.Group>`.
- The `id` prop on the previous line already gives the element the same identifier, so the bad line is just a duplicate that needs deletion.
- Without this the production tsc build fails at `src/components/elements/Search/ScopeFilterCheckbox.tsx:14`:  
  `Property 'controlId' does not exist on type [Form.Check props]`.

This is the third file flagged by the predicted local-tsc list (Report.tsx, _app.tsx, ScopeFilterCheckbox.tsx). Hopefully the last.

## Test plan
- [ ] CodeBuild on `dev_Upd_NextJS14SNode18` reaches the docker-build phase
- [ ] reciter-pm-dev rolls a new image