### PR TITLE
fix: restore fetchAdminSettingsAction thunk dropped in dev_v2 re-restore

### DIFF
--- a/src/redux/actions/actions.js
+++ b/src/redux/actions/actions.js
@@ -2268,6 +2268,37 @@ export const adminSettingsListAction = (adminSettingsList) => dispatch => {
     })
 }
 
+export const fetchAdminSettingsAction = () => (dispatch) => {
+    return fetchWithTimeout('/api/db/admin/settings', {
+        credentials: "same-origin",
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            "Content-Type": "application/json",
+            "Authorization": reciterConfig.backendApiKey
+        }
+    })
+    .then(response => {
+        if (!response.ok) throw new Error("Failed to load settings");
+        return response.json();
+    })
+    .then(data => {
+        dispatch({
+            type: methods.ADMIN_SETTINGS_UPDATED_LIST,
+            payload: data
+        });
+    })
+    .catch(error => {
+        console.error("Admin Settings API failed:", error);
+        toast.error("Failed to load Admin Settings", {
+            position: "top-right",
+            autoClose: 2000,
+            theme: 'colored'
+        });
+        dispatch(addError(error));
+    });
+};
+
 export const saveNotification = (payload) => dispatch => {
       fetch(`/api/db/admin/notifications`, {
         credentials: "same-origin",


### PR DESCRIPTION
## Summary
- The dev_v2 re-restore in `2a0a747` dropped `fetchAdminSettingsAction` from `src/redux/actions/actions.js`, but `src/pages/_app.tsx`'s `AdminSettingsDataLoader` still imports and dispatches it.
- Without it the production tsc build fails: `'"../redux/actions/actions"' has no exported member named 'fetchAdminSettingsAction'`.
- Restored the thunk verbatim from `8e2033c` (its original commit). POSTs to `/api/db/admin/settings`, dispatches `ADMIN_SETTINGS_UPDATED_LIST` on success, toasts + dispatches `addError` on failure — matches what `_app.tsx` expects.

## Test plan
- [ ] CodeBuild on `dev_Upd_NextJS14SNode18` reaches the docker-build phase
- [ ] reciter-pm-dev rolls a new image
- [ ] Admin settings load on first session render (state.updatedAdminSettings populated)