### PR TITLE
fix(types): type AppProps generic so pageProps.session compiles

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -51,7 +51,7 @@ type NextPageWithLayout = NextPage & {
   getLayout?: (page: ReactElement) => ReactNode
 }
 
-type AppPropsWithLayout = AppProps & {
+type AppPropsWithLayout = AppProps<{ session?: any }> & {
   Component: NextPageWithLayout
 }
 


### PR DESCRIPTION
## Summary
- `_app.tsx` destructures `session` out of `pageProps` and passes it to `<SessionProvider>`, but `AppPropsWithLayout` was declared as plain `AppProps` — which defaults its pageProps generic to `{}`.
- Production tsc build fails at `src/pages/_app.tsx:73`: `Property 'session' does not exist on type '{}'`.
- Pass `{ session?: any }` as the `AppProps` generic so pageProps includes `session`.

## Test plan
- [ ] CodeBuild on `dev_Upd_NextJS14SNode18` reaches the docker-build phase
- [ ] reciter-pm-dev rolls a new image