### PR TITLE
fix(types): add initialReduxState to AppProps generic

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -51,7 +51,7 @@ type NextPageWithLayout = NextPage & {
   getLayout?: (page: ReactElement) => ReactNode
 }
 
-type AppPropsWithLayout = AppProps<{ session?: any }> & {
+type AppPropsWithLayout = AppProps<{ session?: any; initialReduxState?: any }> & {
   Component: NextPageWithLayout
 }
 


### PR DESCRIPTION
## Summary
- After PR #684 typed `pageProps` with `{ session?: any }`, the production tsc build surfaced the next property used downstream: `pageProps.initialReduxState` on `_app.tsx:74`.
- Same root cause: `AppProps` generic must declare every field the App component reads off pageProps.

## Test plan
- [ ] CodeBuild on `dev_Upd_NextJS14SNode18` reaches the docker-build phase
- [ ] reciter-pm-dev rolls a new image