### PR TITLE
fix: alias next-auth v3 Provider as SessionProvider in _app.tsx

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { Provider as ReduxProvider } from 'react-redux'
 import { useStore } from '../redux/store/store'
 import type { Page } from '../../types/pages'
 import type { AppProps } from 'next/app'
-import { SessionProvider } from "next-auth/client"
+import { Provider as SessionProvider } from "next-auth/client"
 import type { NextPage } from 'next'
 import type { ReactElement, ReactNode } from 'react'
 // Header removed — brand is in sidebar, user info in content area


### PR DESCRIPTION
## Summary
- next-auth `^3.29.10` exports `Provider` from `next-auth/client`. The `SessionProvider` name (and the `next-auth/react` path) is v4-only.
- `_app.tsx:7` imported `SessionProvider` from `next-auth/client`, which is `undefined` at runtime and a type-only symbol at build time.
- Production tsc build failed at `_app.tsx:80`: `'SessionProvider' only refers to a type, but is being used as a value here`.
- Aliasing the v3 export keeps the JSX call site unchanged.

## Test plan
- [ ] CodeBuild on `dev_Upd_NextJS14SNode18` reaches the docker-build phase
- [ ] reciter-pm-dev rolls a new image