### PR TITLE
fix(types): cast pageProps to any when spreading into <Component>

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -85,7 +85,7 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
       <ThemeProvider theme={theme}>
         <ReduxProvider store={store}>
         <AdminSettingsDataLoader/>
-          {getLayout(<Component {...pageProps} />)}
+          {getLayout(<Component {...(pageProps as any)} />)}
         </ReduxProvider>
       </ThemeProvider>
     </SessionProvider>


### PR DESCRIPTION
## Summary
- After PR #685 typed `pageProps` with `{ session, initialReduxState }`, the JSX spread `<Component {...pageProps} />` on `_app.tsx:88` can no longer match the Component's `IntrinsicAttributes` overload — Next.js Page components are typed as `({})` or `({ children })` and our typed pageProps has extra properties.
- The Component's actual prop shape is per-page and not knowable at the `_app.tsx` layer, so casting the spread to `any` is the idiomatic fix and matches what most Next.js TypeScript apps do at the App layer.

## Test plan
- [ ] CodeBuild on `dev_Upd_NextJS14SNode18` reaches the docker-build phase
- [ ] reciter-pm-dev rolls a new image