### PR TITLE
fix(deps): add react-datepicker (^4.25.0 for React 16 compat)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "nodemailer-smtp-transport": "^2.7.4",
     "react": "^16.14.0",
     "react-bootstrap": "^2.0.3",
+    "react-datepicker": "^4.25.0",
     "react-dates": "^21.8.0",
     "react-dom": "^16.14.0",
     "react-dropdown-date": "2.2.7",


### PR DESCRIPTION
## Summary
- `TabAddPublication.tsx` imports `DatePicker` from `react-datepicker`, but the package was missing from `package.json` after the dev_v2 re-restore in `2a0a747`.
- The webpack build now fails: `Module not found: Can't resolve 'react-datepicker'`.
- Pinned to `^4.25.0` (the last v4) for React 16 compatibility — this project still ships `react@^16.14.0`. v5+ dropped React 16 support; v8 (the version in `e3f2e7f`) requires React 18 and uses `useId` which would crash at runtime under React 16.

**Build progress note:** this is the first webpack/runtime error — TypeScript validation now passes after the eight prior tsc fixes (PRs #680, #681, #682, #683, #684, #685, #686, #687).

## Test plan
- [ ] `npm install --legacy-peer-deps` resolves react-datepicker without conflict
- [ ] CodeBuild on `dev_Upd_NextJS14SNode18` reaches the docker-build phase
- [ ] reciter-pm-dev rolls a new image
- [ ] TabAddPublication's year picker renders without runtime errors