### PR TITLE
fix: use v3 getSession in search/index.js

### DIFF
--- a/src/pages/search/index.js
+++ b/src/pages/search/index.js
@@ -1,11 +1,10 @@
 import Search from '../../components/elements/Search/Search'
 import { AppLayout } from "../../components/layouts/AppLayout"
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "../api/auth/[...nextauth]"; 
+import { getSession } from "next-auth/client";
 
  export async function getServerSideProps(ctx) {
-    try {						  
-    const session = await getServerSession(ctx.req,ctx.res, authOptions);
+    try {
+    const session = await getSession(ctx);
 
     if (!session || !session?.data) {
         console.log('Search page - No session or session.data, redirecting to login');


### PR DESCRIPTION
## Summary
- `src/pages/search/index.js` was the last page still using the v4 server session API: `import { getServerSession } from "next-auth/next"` + `authOptions`.
- next-auth `^3.29.10` doesn't export `"next-auth/next"`, so webpack failed: `Module not found: Package path ./next is not exported from package /app/node_modules/next-auth`.
- Aligned with the rest of the pages (`index.js`, `app/[uid].js`, `curate/*`, `report/index.js`, etc.) which all use `getSession(ctx)` from `next-auth/client`.

Session shape (`session.data.userRoles`, `session.data.permissions`, etc.) matches the project's custom `[...nextauth]` callback and is unchanged.

## Test plan
- [ ] CodeBuild on `dev_Upd_NextJS14SNode18` reaches the docker-build phase
- [ ] reciter-pm-dev rolls a new image
- [ ] /search redirects to login when unauthenticated and renders for authenticated users