### PR TITLE
fix(saml): restore SP-init handler at /api/saml/assert

### DIFF
--- a/src/pages/api/saml/assert.js
+++ b/src/pages/api/saml/assert.js
@@ -1,0 +1,33 @@
+import saml2 from "saml2-js"
+import { reciterSamlConfig } from "../../../../config/saml"
+
+// SP-initiated SSO entry point. Unauthenticated users land here (via the
+// redirect in src/pages/index.js when NEXT_PUBLIC_LOGIN_PROVIDER=SAML),
+// we build the AuthnRequest with saml2-js and bounce to the IdP. The IdP
+// POSTs the SAMLResponse to /api/auth/saml-acs, which forwards into
+// NextAuth's credentials callback at /api/auth/callback/saml.
+
+export default async function handler(req, res) {
+    if (req.method !== "GET") {
+        return res.status(405).send("Method not allowed");
+    }
+
+    const sp = new saml2.ServiceProvider(reciterSamlConfig.saml_options);
+    const idp = new saml2.IdentityProvider(reciterSamlConfig.saml_idp_options);
+
+    const createLoginRequestUrl = (identityProvider, options = {}) =>
+        new Promise((resolve, reject) => {
+            sp.create_login_request_url(identityProvider, options, (error, loginUrl) => {
+                if (error) reject(error);
+                else resolve(loginUrl);
+            });
+        });
+
+    try {
+        const loginUrl = await createLoginRequestUrl(idp);
+        return res.redirect(loginUrl);
+    } catch (error) {
+        console.error("SAML AuthnRequest build failed:", error);
+        return res.status(500).send("SAML login error");
+    }
+}


### PR DESCRIPTION
## Summary
- Incognito landing on `reciter-dev` returned 307 → **404 on `/api/saml/assert?callbackUrl=/search`**.
- `src/pages/index.js:12` redirects unauthenticated SAML users to `/api/saml/assert?callbackUrl=/search`, but the dev_v2 re-restore in `2a0a747` deleted `src/pages/api/saml/assert.js`.
- The original handler had two branches:
  - **GET**: build AuthnRequest via `saml2-js`, redirect user to IdP (SP-init)
  - **POST**: CSRF-wrap SAMLResponse, forward to NextAuth (ACS)
- The POST/ACS branch was correctly migrated to `/api/auth/saml-acs` in `2a0a747`'s earlier work — only the GET/SP-init branch was lost. This restores just the GET branch (POST returns 405 so `/api/auth/saml-acs` remains the single ACS endpoint).

## Test plan
- [ ] CodeBuild green
- [ ] Incognito tab on `reciter-dev` → IdP login form (no 404)
- [ ] After IdP login, lands on `/search` authenticated