### PR TITLE
fix(saml): rename config keys to saml_options / saml_idp_options

### DIFF
--- a/config/saml.ts
+++ b/config/saml.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 export const reciterSamlConfig = {
-   samlOptions : {
+   saml_options : {
       assert_endpoint: process.env.ACS_URL, // ACS URL
       entity_id: process.env.ENTITY_ID, // Your SP entity ID
       certificate: fs.readFileSync(process.cwd() + "/config/certs/reciter-saml.crt").toString(),
@@ -21,7 +21,7 @@ export const reciterSamlConfig = {
   digest_algorithm: "http://www.w3.org/2001/04/xmlenc#sha256"
     },
 
-   idpOptions : {
+   saml_idp_options : {
       sso_login_url: process.env.SSO_LOGIN_URL,
       sso_logout_url: process.env.SSO_LOGOUT_URL,
       certificates: [


### PR DESCRIPTION
## Summary
- After PR #690 restored the SP-init handler at `/api/saml/assert`, incognito on `reciter-dev` got "Internal Server Error".
- Pod logs: `TypeError: Cannot read properties of undefined (reading 'entity_id') at new ServiceProvider`.
- The dev_v2 re-restore in `2a0a747` renamed the wrapper keys in `config/saml.ts`:
  - `saml_options` → `samlOptions`
  - `saml_idp_options` → `idpOptions`
- But every consumer still references snake_case:
  - `src/pages/api/auth/[...nextauth].jsx` (authorize callback)
  - `src/pages/api/saml/assert.js` (SP-init, restored in #690)
- Bug was latent: without SP-init, the authorize callback never ran. Renaming the keys back. The inner SAML2-js v4 config fields (Mahender's work — `allow_unencrypted_assertion: true`, `notbefore_skew`, `signature_algorithm`, etc.) are unchanged.

## Test plan
- [ ] CodeBuild green
- [ ] Incognito on `reciter-dev` redirects to IdP login (no 500)
- [ ] After IdP login, lands on `/search` authenticated