### PR TITLE
fix: use next-auth v3 tuple destructuring in AppLayout.jsx

### DIFF
--- a/src/components/layouts/AppLayout.jsx
+++ b/src/components/layouts/AppLayout.jsx
@@ -17,16 +17,16 @@ export const AppLayout = ({ children }) => {
   const router = useRouter();
   const dispatch = useDispatch();
 
-  const { data: session, status } = useSession();
+  const [session, loading] = useSession();
   const errors = useSelector((state) => state.errors);
 
   useEffect(() => {
-    if (status === "unauthenticated") {
+    if (!loading && !session) {
       router.push("/");
     } else if (errors.length) {
       router.push("/_error");
     }
-  }, [status, errors, router]);
+  }, [loading, session, errors, router]);
 
   useEffect(() => {
     if (router?.pathname !== "/report") {
@@ -53,7 +53,7 @@ export const AppLayout = ({ children }) => {
     setExpandedNav(!expandedNav);
   };
 
-  if (status === "loading") {
+  if (loading) {
     return <Loader />;
   }
 


### PR DESCRIPTION
## Summary
- Authenticated users (session JSON shows `Superuser` + 7 permissions + `databaseUser.status: 1`) saw "Sorry, you don't have access" after SAML login.
- Root cause: `AppLayout.jsx:20` used v4 destructuring against next-auth `^3.29.10`:
  ```js
  const { data: session, status } = useSession();
  ```
  In v3, `useSession()` returns `[session, loading]` — so `session` was always undefined, and `session?.data?.databaseUser?.status === 1` was always false. AppLayout fell into the `<NoAccess />` branch on every render.
- Same pattern as PR #680 (Report.tsx, _app.tsx). CodeBuild's tsc didn't flag this because AppLayout is JSX — no strict typing on the useSession return.
- Also converted `status === "loading"` → `loading` and `status === "unauthenticated"` → `!loading && !session` for the same semantics under v3.

## Test plan
- [ ] CodeBuild green
- [ ] After SAML login, authenticated user lands on /search with full UI (no NoAccess)
- [ ] Loader shows while session resolves; user is redirected to / on logout