### PR TITLE
fix: drop AppLayout's blanket redirect-to-/_error on transient API errors

### DIFF
--- a/src/components/layouts/AppLayout.jsx
+++ b/src/components/layouts/AppLayout.jsx
@@ -10,7 +10,7 @@ import NoAccess from "../elements/NoAccess/NoAccess";
 import Loader from "../elements/Common/Loader";
 import ToastContainerWrapper from "../elements/ToastContainerWrapper/ToastContainerWrapper";
 import { reciterConfig } from "../../../config/local";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { clearPubSearchFilters, getAdminDepartments, getAdminRoles, notificationEmail } from "../../redux/actions/actions";
 
 export const AppLayout = ({ children }) => {
@@ -18,15 +18,12 @@ export const AppLayout = ({ children }) => {
   const dispatch = useDispatch();
 
   const [session, loading] = useSession();
-  const errors = useSelector((state) => state.errors);
 
   useEffect(() => {
     if (!loading && !session) {
       router.push("/");
-    } else if (errors.length) {
-      router.push("/_error");
     }
-  }, [loading, session, errors, router]);
+  }, [loading, session, router]);
 
   useEffect(() => {
     if (router?.pathname !== "/report") {


### PR DESCRIPTION
## Summary
- After PR #693 unblocked the actual UI, every click on a sidebar nav item showed "We encountered an unexpected error. Please refresh the page or try again later."
- Root cause: `AppLayout.jsx` watched `state.errors` and forcibly navigated to `/_error` whenever the array was non-empty. With 19+ `addError` callsites in actions.js, any single failing background fetch crashed the entire authenticated UX. The only failing call observed in pod logs was the (non-critical) ASMS user-tracker hitting an unreachable telemetry endpoint.
- This was masked while the v4-destructure bug (PR #693) forced AppLayout to always render `<NoAccess />`.
- Toast notifications via `ToastContainerWrapper` are the right surface for transient errors; a blanket layout-level redirect is wrong.
- Removed the `errors.length → /_error` redirect (and the now-unused `useSelector` import). The unauthenticated → `/` redirect is unchanged. The ASMS telemetry call itself is intentionally left in place.

## Test plan
- [ ] CodeBuild green
- [ ] After SAML login, all sidebar nav links work without crashing
- [ ] Transient API failures show as toasts (or are silent), do not redirect to /_error
- [ ] Logout still routes through /api/auth/saml-logout