### PR TITLE
fix: parse viewAttributes JSON in fetchAdminSettingsAction

### DIFF
--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -90,7 +90,9 @@ const Search = () => {
     if (updatedAdminSettings.length > 0) {
       // updated settings from manage settings page
       let updatedData = updatedAdminSettings.find(obj => obj.viewName === "findPeople")
-      viewAttributes = updatedData.viewAttributes;
+      viewAttributes = typeof updatedData.viewAttributes === "string"
+        ? JSON.parse(updatedData.viewAttributes)
+        : updatedData.viewAttributes;
 
       let cwidLabel = viewAttributes.find(data => data.labelUserKey === "personIdentifier")
       setNameOrcwidLabel(cwidLabel)

--- a/src/redux/actions/actions.js
+++ b/src/redux/actions/actions.js
@@ -2283,9 +2283,20 @@ export const fetchAdminSettingsAction = () => (dispatch) => {
         return response.json();
     })
     .then(data => {
+        // Sequelize returns viewAttributes as a JSON-encoded string. Parse it
+        // here so every consumer of state.updatedAdminSettings sees the same
+        // already-parsed shape (matches what JSON.parse(session.adminSettings)
+        // followed by JSON.parse(item.viewAttributes) yields in the cold-start
+        // path).
+        const normalized = Array.isArray(data) ? data.map(item => ({
+            ...item,
+            viewAttributes: typeof item.viewAttributes === "string"
+                ? JSON.parse(item.viewAttributes)
+                : item.viewAttributes
+        })) : data;
         dispatch({
             type: methods.ADMIN_SETTINGS_UPDATED_LIST,
-            payload: data
+            payload: normalized
         });
     })
     .catch(error => {


### PR DESCRIPTION
## Summary
- Click /search → click away → click /search again crashed with `TypeError: t.find is not a function` from `search-...js`.
- Root cause: `/api/db/admin/settings` returns `viewAttributes` as a JSON-encoded string. `fetchAdminSettingsAction` dispatched the raw payload, so `state.updatedAdminSettings` had stringified viewAttributes.
- Cold-start consumers (`Search.js`, `Report.tsx`) parse the string themselves in their else branches (`JSON.parse(session.adminSettings)` + per-item `JSON.parse`). The if branches (which run on re-mount once Redux state is populated) assumed already-parsed objects and crashed when calling `.find()` on a string.
- Normalized once at the source: parse each `viewAttributes` field in the action thunk before dispatching. Every downstream consumer now sees the same already-parsed shape.
- Defensive `typeof === "string"` check in `Search.js` remains as a safety belt for any path that bypasses the normalized action.

## Test plan
- [ ] CodeBuild green
- [ ] /search loads on first visit
- [ ] Click away to /curate or /report, click back to /search → no client-side crash
- [ ] /report loads (it has the same if/else pattern, would have crashed similarly on second visit)