### PR TITLE
fix: restore rich CurateIndividual UI from pre-re-restore state

### DIFF
--- a/src/components/elements/CurateIndividual/CurateIndividual.tsx
+++ b/src/components/elements/CurateIndividual/CurateIndividual.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from 'next/router';
-import { useDispatch, useSelector, RootStateOrAny } from "react-redux";
-import { identityFetchData, reciterFetchData,reCalcPubMedPubCount, fetchFeedbacklog } from "../../../redux/actions/actions";
-import SkeletonProfile from "../Common/SkeletonProfile";
-import SkeletonCard from "../Common/SkeletonCard";
+import { useDispatch, useSelector } from "react-redux";
+import { RootStateOrAny } from "../../../types/redux";
+import { identityFetchData, reciterFetchData, reCalcPubMedPubCount, fetchFeedbacklog, addError } from "../../../redux/actions/actions";
+import Loader from "../Common/Loader";
 import fullName from "../../../utils/fullName";
-import { Container, Button, Row,Toast } from "react-bootstrap";
+import { Container, Button, Row, Toast } from "react-bootstrap";
 import appStyles from '../App/App.module.css';
 import styles from "./CurateIndividual.module.css";
 import InferredKeywords from "./InferredKeywords"
@@ -15,11 +15,11 @@ import Image from "next/image";
 import Profile from "../Profile/Profile";
 import { useSession } from "next-auth/client";
 import { allowedPermissions, toastMessage, getCapabilities } from "../../../utils/constants";
-import { isProxyFor } from "../../../utils/scopeResolver";
 import ToastContainerWrapper from "../ToastContainerWrapper/ToastContainerWrapper";
-import GrantProxyModal from './GrantProxyModal';
-import ProxyBadge from '../Search/ProxyBadge';
 import { reciterConfig } from "../../../../config/local";
+import { toast } from "react-toastify";
+import { reportError } from "../../../utils/reportError";
+import GrantProxyModal from './GrantProxyModal';
 
 
 
@@ -33,12 +33,14 @@ interface PrimaryName {
 
 const CurateIndividual = () => {
   const router = useRouter()
-  const  id  = router.query.id
-  const [newId, setNewId ] = useState<any>();
+  const { id } = router.query;
+  const [newId, setNewId] = useState<any>();
   const dispatch = useDispatch();
   const identityData = useSelector((state: RootStateOrAny) => state.identityData)
   const identityFetching = useSelector((state: RootStateOrAny) => state.identityFetching)
   const reciterData = useSelector((state: RootStateOrAny) => state.reciterData)
+  const identityORFeatureGenError = useSelector((state: RootStateOrAny) => state.identityORFeatureGenError)
+
   const reciterFetching = useSelector((state: RootStateOrAny) => state.reciterFetching)
   const [displayImage, setDisplayImage] = useState<boolean>(true);
   const [modalShow, setModalShow] = useState(false);
@@ -46,29 +48,35 @@ const CurateIndividual = () => {
   const updatedAdminSettings = useSelector((state: RootStateOrAny) => state.updatedAdminSettings)
   const [viewProfileLabels, setViewProfileLabels] = useState([])
   const [isLoading, setLoading] = useState(false);
-  const [headShot, setHeadShot] = useState<any>([])
-  const [showGrantProxy, setShowGrantProxy] = useState(false);
+  const [headShot, setHeadShot] = useState<any>([]);
+  const [showNoPermitError, setShowNoPermitError] = useState(false)
+  const [headShotLoaded, setHeadShotLoaded] = useState(false)
+  const [showGrantProxy, setShowGrantProxy] = useState(false)
 
-  // Proxy state
-  const userRoles = session?.data?.userRoles ? JSON.parse(session.data.userRoles) : [];
+  // Derive capabilities from session roles
+  const userRoles = (() => {
+    try {
+      if (session?.data?.userRoles) {
+        return JSON.parse(session.data.userRoles as string);
+      }
+    } catch (e) { /* ignore parse errors */ }
+    return [];
+  })();
   const caps = getCapabilities(userRoles);
-  const proxyPersonIds = session?.data?.proxyPersonIds
-    ? JSON.parse(session.data.proxyPersonIds)
-    : [];
-  const personIdentifier = (id as string) || '';
-  const isProxied = isProxyFor(proxyPersonIds, personIdentifier);
-  const canCurateThisPerson = caps.canCurate.all || caps.canCurate.scoped || isProxied;
-
+  const canGrantProxy = caps.canCurate.all || caps.canManageUsers;
 
   useEffect(() => {
-    let userPermissions = JSON.parse(session.data?.userRoles);
-    let routerUserId = router.query.id ;
+
+    if (!id) {
+      return;
+    }
+    setHeadShotLoaded(false);
     fetchAllAdminSettings();
     let nextPersonIdentifier = "";
-     setNewId(routerUserId);
-     dispatch(identityFetchData(routerUserId));
-     fetchData();
-  }, [])
+    setNewId(id);
+    dispatch(identityFetchData(id));
+    fetchData();
+  }, [id])
 
   const fetchData = () => {
     dispatch(reciterFetchData(id, false));
@@ -93,9 +101,9 @@ const CurateIndividual = () => {
         data.map((obj, index1) => {
           let a = JSON.stringify(obj.viewAttributes)
           let b = JSON.parse(a);
-          let c = typeof(b) === "string" ? JSON.parse(b) : b
+          let c = typeof (b) === "string" ? JSON.parse(b) : b
           let parsedSettings = {
-            viewName : obj.viewName,
+            viewName: obj.viewName,
             viewAttributes: c,
             viewLabel: obj.viewLabel
           }
@@ -113,104 +121,145 @@ const CurateIndividual = () => {
         setHeadShot(headShotViewAttributes)
       })
       .catch(error => {
-        // setLoading(false);
+        console.error("[ERR-9010]", error);
+        reportError("ERR-9010", "Unable to load display settings", error);
+        toast.error("Unable to load display settings. Please try again. (ERR-9010)", {
+          position: "top-right",
+          autoClose: 2000,
+          theme: 'colored'
+        });
       });
   }
 
-  const DisplayName = ({ name }: { name: PrimaryName }) => {
-    let formattedName = fullName(name);
-    return (
-      <h2 className="mb-1">{formattedName}</h2>
-    )
-  }
+  const personFullName = identityData ? fullName(identityData.primaryName) : '';
 
   const handleClose = () => setModalShow(false);
   const handleShow = () => setModalShow(true);
 
   if (identityFetching || reciterFetching) {
     return (
-      <><SkeletonProfile /><SkeletonCard /></>
+      <div className={appStyles.mainContainer}>
+        <div className={styles.loadingRow}>
+          <div className={styles.loadingSpinner} />
+          <span>Loading publications…</span>
+        </div>
+        <div className={styles.skeletonCard}><div className={styles.skTitle} /><div className={styles.skAuthors} /><div className={styles.skMeta} /></div>
+        <div className={styles.skeletonCard}><div className={styles.skTitle} style={{ width: '60%' }} /><div className={styles.skAuthors} style={{ width: '50%' }} /><div className={styles.skMeta} style={{ width: '38%' }} /></div>
+        <div className={styles.skeletonCard}><div className={styles.skTitle} style={{ width: '74%' }} /><div className={styles.skAuthors} style={{ width: '44%' }} /><div className={styles.skMeta} style={{ width: '32%' }} /></div>
+      </div>
+    )
+  }
+
+  if (identityORFeatureGenError) {
+    return (
+      <div className={appStyles.mainContainer}>
+        <ToastContainerWrapper />
+        <div style={{ padding: '40px 24px', textAlign: 'center', color: '#8a94a6', fontSize: 14 }}>
+          Unable to load publication data. The page may be temporarily unavailable.
+        </div>
+      </div>
     )
   }
 
   return (
-      <div className={appStyles.mainContainer}>
-       <ToastContainerWrapper />
-        <h1 className={styles.header}>Curate Publications</h1>
-        {
-          identityData &&
-          <Container className={styles.indentityDataContainer} fluid={true}>
-            <div className="d-flex">
-              {
-                displayImage && identityData.identityImageEndpoint && headShot && headShot.length > 0 && headShot[0].isVisible &&
-                <div className={styles.profileImgWrapper}>
-                  <Image
-                    src={headShot.length > 0 && headShot[0]?.syntax?.replace("{personIdentifier}", identityData.uid)}
-                    alt={fullName(identityData.primaryName)}
-                    width={144}
-                    height={217}
-                    onError={() => setDisplayImage(false)}
+    <div className={appStyles.mainContainer}>
+      <ToastContainerWrapper />
+      {
+        showNoPermitError ? <p className="text-center">{`${id} does not have an identity to view this page. Please contact system administartor`}</p> : <>
+          {identityData &&
+            <div className={styles.personHeader}>
+              <div className={styles.personPhotoWrap}>
+                <svg className={styles.personPhotoPlaceholder} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.2"><circle cx="8" cy="5.5" r="3"/><path d="M2 14c0-3.31 2.69-6 6-6s6 2.69 6 6"/></svg>
+                {identityData.uid && (
+                  <img
+                    className={`${styles.personPhoto}${headShotLoaded ? ` ${styles.personPhotoLoaded}` : ''}`}
+                    src={`https://directory.weill.cornell.edu/api/v1/person/profile/${identityData.uid.replace(/^_/, '')}.png?returnGenericOn404=false`}
+                    alt=""
+                    loading="lazy"
+                    onLoad={() => setHeadShotLoaded(true)}
+                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
                   />
-                </div>
-              }
-              <div className="flex-grow-1">
-                <div className="d-flex align-items-center mb-1">
-                  <DisplayName
-                    name={identityData.primaryName}
-                  />
-                  {isProxied && <ProxyBadge />}
-                </div>
-                <b>{identityData.title}</b>
-                <p className={`${styles.greyText} mb-1`}>{identityData.primaryOrganizationalUnit}</p>
-                {reciterData && reciterData.reciter &&
-                  <InferredKeywords
-                    reciter={reciterData.reciter}
-                  />
+                )}
+              </div>
+              <div className={styles.personInfo}>
+                <h2 className={styles.personName}>{personFullName}</h2>
+                {identityData.title && <div className={styles.personRole}>{identityData.title}</div>}
+                {identityData.primaryOrganizationalUnit && <div className={styles.personDept}>{identityData.primaryOrganizationalUnit}</div>}
+                {reciterData && reciterData.reciter && reciterData.reciter.articleKeywordsAcceptedArticles &&
+                  reciterData.reciter.articleKeywordsAcceptedArticles.length > 0 && (() => {
+                    const keywords = reciterData.reciter.articleKeywordsAcceptedArticles;
+                    const allArticles = reciterData.reciter.reCiterArticleFeatures || [];
+                    const totalAccepted = allArticles.filter((a: any) => a.userAssertion === 'ACCEPTED').length;
+                    const counts = keywords.map((kw: any) => kw.count || 0);
+                    const sorted = [...counts].sort((a: number, b: number) => b - a);
+                    const n = keywords.length;
+                    const maxTier = totalAccepted < 5 ? 'low' : totalAccepted < 10 ? 'medium' : 'high';
+                    return (
+                      <div className={styles.personKeywords}>
+                        <span className={styles.kwLabel}>Keywords</span>
+                        {keywords.map((kw: any, i: number) => {
+                          const count = kw.count || 0;
+                          const rank = sorted.indexOf(count) / n;
+                          let tier = rank < 0.25 ? 'high' : rank < 0.75 ? 'medium' : 'low';
+                          if (maxTier === 'low') tier = 'low';
+                          else if (maxTier === 'medium' && tier === 'high') tier = 'medium';
+                          const tierClass = tier === 'high' ? styles.kwHigh : tier === 'medium' ? styles.kwMedium : styles.kwLow;
+                          return (
+                            <span key={i} className={`${styles.kwTag} ${tierClass}`}>
+                              {kw.keyword}
+                              <span className={styles.kwTip}>
+                                <strong>{count}</strong> of {totalAccepted} accepted publications
+                              </span>
+                            </span>
+                          );
+                        })}
+                      </div>
+                    );
+                  })()
                 }
-                <div className="d-flex align-items-center" style={{ gap: '8px' }}>
-                  <Button className="transparent-btn mx-0" onClick={handleShow}>View Profile</Button>
-                  {canCurateThisPerson && (
-                    <Button
-                      variant="outline-secondary"
-                      onClick={() => setShowGrantProxy(true)}
-                      style={{ minHeight: '44px' }}
-                    >
-                      Grant Proxy Access
-                    </Button>
-                  )}
-                </div>
+              </div>
+              <div className={styles.personActions}>
+                <button className={styles.viewProfileBtn} onClick={handleShow}>View Profile</button>
+                {canGrantProxy && (
+                  <button
+                    type="button"
+                    className={styles.viewProfileBtn}
+                    onClick={() => setShowGrantProxy(true)}
+                  >
+                    Grant Proxy
+                  </button>
+                )}
               </div>
             </div>
-          </Container>
-        }
+          }
 
-      {reciterData.reciterPending && reciterData.reciterPending.length > 0 &&
-        <SuggestionsBanner
-          uid={newId}
-          count={reciterData.reciterPending.length}
-        />
+          <ReciterTabs
+            reciterData={reciterData}
+            fullName={personFullName}
+            fetchOriginalData={fetchData}
+          />
+          <Profile
+            uid={identityData.uid}
+            modalShow={modalShow}
+            handleShow={handleShow}
+            handleClose={handleClose}
+            viewProfileLabels={viewProfileLabels}
+            headShotLabelData={headShot}
+            reciterData={reciterData}
+          />
+          {canGrantProxy && (
+            <GrantProxyModal
+              show={showGrantProxy}
+              onHide={() => setShowGrantProxy(false)}
+              personIdentifier={id as string}
+              personName={personFullName}
+              onSave={() => {
+                // Proxy changes saved; no additional refresh needed on curate page
+              }}
+            />
+          )}
+        </>
       }
-
-      <ReciterTabs
-        reciterData={reciterData}
-        fullName={fullName(identityData.primaryName)}
-        fetchOriginalData={fetchData}
-      />
-      <Profile
-        uid={identityData.uid}
-        modalShow={modalShow}
-        handleShow={handleShow}
-        handleClose={handleClose}
-        viewProfileLabels={viewProfileLabels}
-        headShotLabelData = {headShot}
-      />
-      <GrantProxyModal
-        show={showGrantProxy}
-        onHide={() => setShowGrantProxy(false)}
-        personIdentifier={personIdentifier}
-        personName={`${identityData?.primaryName?.firstName || ''} ${identityData?.primaryName?.lastName || ''}`}
-        onSave={() => { /* optional refresh */ }}
-      />
     </div>
   )
 }

--- a/src/components/elements/CurateIndividual/GrantProxyModal.tsx
+++ b/src/components/elements/CurateIndividual/GrantProxyModal.tsx
@@ -1,225 +1,326 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Modal, Button, Spinner } from 'react-bootstrap';
+import { Modal } from 'react-bootstrap';
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
+import { Spinner } from 'react-bootstrap';
 import { toast } from 'react-toastify';
 import Loader from '../Common/Loader';
 import { reciterConfig } from '../../../../config/local';
+import styles from './GrantProxyModal.module.css';
 
 interface ProxyUser {
-  userID: number;
-  personIdentifier: string;
-  nameFirst: string;
-  nameMiddle: string;
-  nameLast: string;
+    userID: number;
+    personIdentifier: string;
+    nameFirst: string;
+    nameMiddle: string;
+    nameLast: string;
 }
 
 interface GrantProxyModalProps {
-  show: boolean;
-  onHide: () => void;
-  personIdentifier: string;
-  personName: string;
-  onSave: () => void;
+    show: boolean;
+    onHide: () => void;
+    personIdentifier: string;
+    personName: string;
+    onSave: () => void;
 }
 
 const GrantProxyModal: React.FC<GrantProxyModalProps> = ({
-  show,
-  onHide,
-  personIdentifier,
-  personName,
-  onSave,
+    show,
+    onHide,
+    personIdentifier,
+    personName,
+    onSave,
 }) => {
-  const [searchResults, setSearchResults] = useState<ProxyUser[]>([]);
-  const [searchLoading, setSearchLoading] = useState(false);
-  const [selectedUsers, setSelectedUsers] = useState<ProxyUser[]>([]);
-  const [existingUsers, setExistingUsers] = useState<ProxyUser[]>([]);
-  const [loadingExisting, setLoadingExisting] = useState(false);
-  const [loadError, setLoadError] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const [searchResults, setSearchResults] = useState<ProxyUser[]>([]);
+    const [searchLoading, setSearchLoading] = useState(false);
+    const [selectedUsers, setSelectedUsers] = useState<ProxyUser[]>([]);
+    const [existingUsers, setExistingUsers] = useState<ProxyUser[]>([]);
+    const [loadingExisting, setLoadingExisting] = useState(false);
+    const [loadError, setLoadError] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => {
-    if (show) {
-      loadExisting();
-    } else {
-      // Reset state when modal closes
-      setSearchResults([]);
-      setSelectedUsers([]);
-      setExistingUsers([]);
-      setLoadError(false);
-    }
-  }, [show, personIdentifier]);
-
-  const loadExisting = async () => {
-    setLoadingExisting(true);
-    setLoadError(false);
-    try {
-      const res = await fetch(
-        `/api/db/admin/proxy?personIdentifier=${personIdentifier}`,
-        { headers: { Authorization: reciterConfig.backendApiKey } }
-      );
-      const data = await res.json();
-      setExistingUsers(data);
-      setSelectedUsers(data);
-    } catch (err) {
-      console.log('[PROXY] Error loading existing proxies:', err);
-      setLoadError(true);
-    }
-    setLoadingExisting(false);
-  };
-
-  const handleSearch = (query: string) => {
-    if (searchTimer.current) {
-      clearTimeout(searchTimer.current);
-    }
-
-    if (query.length < 2) {
-      setSearchResults([]);
-      return;
-    }
-
-    searchTimer.current = setTimeout(async () => {
-      setSearchLoading(true);
-      try {
-        const res = await fetch(
-          `/api/db/admin/proxy/search-users?q=${encodeURIComponent(query)}`,
-          { headers: { Authorization: reciterConfig.backendApiKey } }
-        );
-        const data = await res.json();
-        // Flatten nested Sequelize response to flat ProxyUser objects
-        const flatUsers: ProxyUser[] = data.map((u: any) => ({
-          userID: u.userID,
-          personIdentifier: u.personIdentifier || '',
-          nameFirst: u.nameFirst || '',
-          nameMiddle: u.nameMiddle || '',
-          nameLast: u.nameLast || '',
-        }));
-        setSearchResults(flatUsers);
-      } catch (err) {
-        console.log('[PROXY] Error searching users:', err);
-        setSearchResults([]);
-      }
-      setSearchLoading(false);
-    }, 300);
-  };
-
-  const formatUserLabel = (user: ProxyUser) => {
-    const name = [user.nameLast, user.nameFirst].filter(Boolean).join(', ');
-    return user.personIdentifier ? `${name} (${user.personIdentifier})` : name;
-  };
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      const res = await fetch('/api/db/admin/proxy/grant', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: reciterConfig.backendApiKey,
-        },
-        body: JSON.stringify({
-          personIdentifier,
-          userIds: selectedUsers.map((u) => u.userID),
-        }),
-      });
-
-      if (!res.ok) {
-        throw new Error('Save failed');
-      }
-
-      toast.success('Proxy access granted. Changes take effect on the user\'s next login.', {
-        position: 'top-right',
-        autoClose: 5000,
-        theme: 'colored',
-      });
-      onSave();
-      onHide();
-    } catch (err) {
-      console.log('[PROXY] Error saving proxy assignments:', err);
-      toast.error('Unable to save proxy assignments. Please try again.', {
-        position: 'top-right',
-        autoClose: 5000,
-        theme: 'colored',
-      });
-    }
-    setSaving(false);
-  };
-
-  return (
-    <Modal show={show} onHide={onHide} size="lg" aria-labelledby="grantProxyModalTitle">
-      <Modal.Header closeButton>
-        <Modal.Title id="grantProxyModalTitle" style={{ fontSize: '20px', fontWeight: 400 }}>
-          Grant Proxy Access
-        </Modal.Title>
-      </Modal.Header>
-      <Modal.Body style={{ padding: '16px' }}>
-        <p style={{ fontSize: '14px', color: '#777777', marginBottom: '16px' }}>
-          Select users who can curate publications for {personName}
-        </p>
-        {loadingExisting ? (
-          <Loader />
-        ) : loadError ? (
-          <div role="alert" style={{ color: '#dc3545', fontSize: '14px' }}>
-            Unable to load proxy data. Please close and try again.
-          </div>
-        ) : (
-          <Autocomplete
-            multiple
-            options={searchResults}
-            value={selectedUsers}
-            onChange={(_event, newValue) => setSelectedUsers(newValue as ProxyUser[])}
-            onInputChange={(_event, value, reason) => {
-              if (reason === 'input') {
-                handleSearch(value);
-              }
-            }}
-            getOptionLabel={(option) => formatUserLabel(option as ProxyUser)}
-            isOptionEqualToValue={(option, value) =>
-              (option as ProxyUser).userID === (value as ProxyUser).userID
+    useEffect(() => {
+        if (show && personIdentifier) {
+            loadExisting();
+        }
+        if (!show) {
+            // Reset state when modal closes
+            setSearchResults([]);
+            setSearchLoading(false);
+            setSelectedUsers([]);
+            setExistingUsers([]);
+            setLoadingExisting(false);
+            setLoadError(false);
+            setSaving(false);
+            if (searchTimer.current) {
+                clearTimeout(searchTimer.current);
+                searchTimer.current = null;
             }
-            noOptionsText="No users found matching your search."
-            loading={searchLoading}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                placeholder="Search users..."
-                variant="outlined"
-                size="small"
-                InputProps={{
-                  ...params.InputProps,
-                  endAdornment: (
+        }
+    }, [show, personIdentifier]);
+
+    const loadExisting = async () => {
+        setLoadingExisting(true);
+        setLoadError(false);
+        try {
+            const res = await fetch(
+                `/api/db/admin/proxy?personIdentifier=${encodeURIComponent(personIdentifier)}`,
+                {
+                    headers: {
+                        'Authorization': reciterConfig.backendApiKey,
+                    },
+                }
+            );
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const data: ProxyUser[] = await res.json();
+            setExistingUsers(data);
+            setSelectedUsers(data);
+        } catch (err) {
+            console.error('[GrantProxyModal] loadExisting error:', err);
+            setLoadError(true);
+        } finally {
+            setLoadingExisting(false);
+        }
+    };
+
+    const handleSearch = (query: string) => {
+        if (searchTimer.current) {
+            clearTimeout(searchTimer.current);
+        }
+        if (!query || query.length < 2) {
+            setSearchResults([]);
+            setSearchLoading(false);
+            return;
+        }
+        setSearchLoading(true);
+        searchTimer.current = setTimeout(async () => {
+            try {
+                const res = await fetch(
+                    `/api/db/admin/proxy/search-users?q=${encodeURIComponent(query)}`,
+                    {
+                        headers: {
+                            'Authorization': reciterConfig.backendApiKey,
+                        },
+                    }
+                );
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const data = await res.json();
+                // Handle both flat and nested Sequelize response formats
+                const users: ProxyUser[] = data.map((item: any) => ({
+                    userID: item.userID,
+                    personIdentifier: item.personIdentifier || '',
+                    nameFirst: item.nameFirst || '',
+                    nameMiddle: item.nameMiddle || '',
+                    nameLast: item.nameLast || '',
+                }));
+                setSearchResults(users);
+            } catch (err) {
+                console.error('[GrantProxyModal] search error:', err);
+                setSearchResults([]);
+            } finally {
+                setSearchLoading(false);
+            }
+        }, 300);
+    };
+
+    const formatUserLabel = (user: ProxyUser): string => {
+        const name = [user.nameLast, user.nameFirst].filter(Boolean).join(', ');
+        return user.personIdentifier ? `${name} (${user.personIdentifier})` : name;
+    };
+
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            const res = await fetch('/api/db/admin/proxy/grant', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': reciterConfig.backendApiKey,
+                },
+                body: JSON.stringify({
+                    personIdentifier,
+                    userIds: selectedUsers.map((u) => u.userID),
+                }),
+            });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            toast.success(
+                'Proxy access updated. Changes take effect on the user\'s next login.',
+                { position: 'top-right', autoClose: 5000, theme: 'colored' }
+            );
+            onSave();
+            onHide();
+        } catch (err) {
+            console.error('[GrantProxyModal] save error:', err);
+            toast.error(
+                'Failed to update proxy access. Please try again.',
+                { position: 'top-right', autoClose: 5000, theme: 'colored' }
+            );
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDiscard = () => {
+        onHide();
+    };
+
+    // Filter out already-selected users from search results
+    const filteredResults = searchResults.filter(
+        (sr) => !selectedUsers.some((su) => su.userID === sr.userID)
+    );
+
+    return (
+        <Modal show={show} onHide={onHide} centered size="lg">
+            <Modal.Header closeButton>
+                <Modal.Title style={{ fontSize: 13, fontWeight: 600, color: '#1a2133' }}>
+                    Manage Proxy Access
+                </Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <div className={styles.subtitle}>for {personName}</div>
+
+                {loadingExisting ? (
+                    <div style={{ display: 'flex', justifyContent: 'center', padding: '40px 0' }}>
+                        <Loader />
+                    </div>
+                ) : loadError ? (
+                    <div className={styles.errorState}>
+                        Unable to load proxy data. Please close and try again.
+                    </div>
+                ) : (
                     <>
-                      {searchLoading ? <Spinner animation="border" size="sm" /> : null}
-                      {params.InputProps.endAdornment}
+                        <Autocomplete
+                            multiple
+                            disablePortal
+                            options={filteredResults}
+                            getOptionLabel={formatUserLabel}
+                            filterOptions={(x) => x}
+                            value={selectedUsers}
+                            loading={searchLoading}
+                            noOptionsText="No users found matching your search."
+                            isOptionEqualToValue={(option, value) => option.userID === value.userID}
+                            onChange={(_event, newValue) => {
+                                setSelectedUsers(newValue as ProxyUser[]);
+                            }}
+                            onInputChange={(_event, value, reason) => {
+                                if (reason === 'input') {
+                                    handleSearch(value);
+                                }
+                            }}
+                            renderTags={(value, getTagProps) =>
+                                value.map((user, index) => {
+                                    const { key, ...tagProps } = getTagProps({ index });
+                                    return (
+                                        <span
+                                            key={key}
+                                            {...tagProps}
+                                            style={{
+                                                display: 'inline-flex',
+                                                alignItems: 'center',
+                                                gap: 4,
+                                                background: '#1a2133',
+                                                color: '#fff',
+                                                borderRadius: 20,
+                                                padding: '3px 10px',
+                                                fontSize: 12,
+                                                fontWeight: 500,
+                                                margin: '2px 4px 2px 0',
+                                            }}
+                                        >
+                                            {formatUserLabel(user)}
+                                            <button
+                                                type="button"
+                                                onClick={tagProps.onDelete}
+                                                aria-label="Remove"
+                                                style={{
+                                                    cursor: 'pointer',
+                                                    fontSize: 16,
+                                                    lineHeight: 1,
+                                                    marginLeft: 4,
+                                                    opacity: 0.7,
+                                                    background: 'none',
+                                                    border: 'none',
+                                                    padding: 0,
+                                                    color: 'inherit',
+                                                    minWidth: 24,
+                                                    minHeight: 24,
+                                                }}
+                                            >
+                                                &times;
+                                            </button>
+                                        </span>
+                                    );
+                                })
+                            }
+                            renderInput={(params) => (
+                                <TextField
+                                    {...params}
+                                    variant="outlined"
+                                    placeholder="Search users by name or CWID..."
+                                    size="small"
+                                    sx={{
+                                        '& .MuiOutlinedInput-root': {
+                                            background: '#fff',
+                                            '& fieldset': {
+                                                borderColor: '#ddd7ce',
+                                            },
+                                            '&:hover fieldset': {
+                                                borderColor: '#ddd7ce',
+                                            },
+                                            '&.Mui-focused fieldset': {
+                                                borderColor: '#2563a8',
+                                                borderWidth: 2,
+                                            },
+                                        },
+                                    }}
+                                />
+                            )}
+                        />
+                        {existingUsers.length === 0 && selectedUsers.length === 0 && (
+                            <div className={styles.emptyState}>
+                                No users currently have proxy access for this person.
+                            </div>
+                        )}
+                        <div className={styles.loginNote}>
+                            Any user who has logged in can be assigned as a proxy. Access takes effect on their next login.
+                        </div>
                     </>
-                  ),
-                }}
-              />
-            )}
-          />
-        )}
-      </Modal.Body>
-      <Modal.Footer>
-        <Button variant="secondary" onClick={onHide}>
-          Discard Changes
-        </Button>
-        <Button
-          variant="primary"
-          onClick={handleSave}
-          disabled={saving || loadingExisting || loadError}
-        >
-          {saving ? (
-            <>
-              <Spinner animation="border" size="sm" className="me-2" />
-              Saving...
-            </>
-          ) : (
-            'Save Proxy Assignments'
-          )}
-        </Button>
-      </Modal.Footer>
-    </Modal>
-  );
+                )}
+            </Modal.Body>
+            <div className={styles.footer}>
+                <button
+                    type="button"
+                    className={styles.btnDiscard}
+                    onClick={handleDiscard}
+                >
+                    Discard Changes
+                </button>
+                <button
+                    type="button"
+                    className={styles.btnSave}
+                    onClick={handleSave}
+                    disabled={saving || loadingExisting || loadError}
+                >
+                    {saving ? (
+                        <>
+                            <Spinner
+                                as="span"
+                                animation="border"
+                                size="sm"
+                                role="status"
+                                aria-hidden="true"
+                                style={{ marginRight: 6 }}
+                            />
+                            Saving...
+                        </>
+                    ) : (
+                        'Save Changes'
+                    )}
+                </button>
+            </div>
+        </Modal>
+    );
 };
 
 export default GrantProxyModal;

--- a/src/components/elements/CurateIndividual/ReciterTabContent.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabContent.tsx
@@ -1,13 +1,16 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import Publication from "../Publication/Publication";
-import Divider from "../Common/Divider";
 import FilterPubSection from "./FilterPubSection";
 import filterPublicationsBySearchText from "../../../utils/filterPublicationsBySearchText";
 import sortPublications from "../../../utils/sortPublications";
 import Pagination from '../Pagination/Pagination';
 import { useSession } from "next-auth/client";
-import { curateSearchtextAction, reciterUpdatePublication } from "../../../redux/actions/actions";
-import { RootStateOrAny, useDispatch, useSelector } from "react-redux";
+import { curateSearchtextAction, reciterUpdatePublication, reciterFetchData } from "../../../redux/actions/actions";
+import { useDispatch, useSelector } from "react-redux";
+import { RootStateOrAny } from "../../../types/redux";
+import styles from "./CurateIndividual.module.css";
+import CheckIcon from '@mui/icons-material/Check';
+
 
 interface TabContentProps {
   tabType: string,
@@ -21,6 +24,8 @@ interface TabContentProps {
   showEvidenceDefault?:any,
   activeKey:any,
   totalCount:any,
+  onAssertionChange?: (pmid: number, newAssertion: string) => void,
+  onTabChange?: (key: string) => void,
 }
 
 const ReciterTabContent: React.FC<TabContentProps> = (props) => {
@@ -29,18 +34,10 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
   const [searchtextCarier, setSearchtextCarier] = useState<any>("");
 
   const [page, setPage] = useState(1)
-  const [count, setCount] = useState(50)
+  const [count, setCount] = useState(20)
   const [session, loading] = useSession();
   const [totalCount, setTotalCount] = useState<number>(publications.length || 0);
   const dispatch = useDispatch();
-
-  if (!props.publications.length) {
-    return (
-      <div className="text-center">
-        <p>No articles found</p>
-      </div>
-    )
-  }
 
   const searchTextUpdate = (searchText: string) => {
     let filteredPublications = filterPublicationsBySearchText(props.publications, searchText.trim());
@@ -57,6 +54,18 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
     let sortedPublications = sortPublications(props.publications, sort);
     setPublications(sortedPublications);
   }
+
+  // Re-sync local publications whenever the parent's filtered list changes (e.g. after an
+  // assertion propagates up through ReciterTabs.updatePublicationAssertion).  The parent now
+  // produces a new array reference on every update (immutable), so this effect reliably fires.
+  // We re-apply any active text filter so the displayed subset stays consistent.
+  useEffect(() => {
+    const filtered = searchtextCarier
+      ? filterPublicationsBySearchText(props.publications, searchtextCarier)
+      : props.publications;
+    setPublications(filtered);
+    setTotalCount(filtered.length);
+  }, [props.publications]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update the page
   const handlePaginationUpdate = (page) => {
@@ -110,7 +119,6 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
       userID: userId,
       personIdentifier: uid,
     }
-    // TODO: send request
 
     let SearchInfo = {
       searchedText:searchtextCarier,
@@ -118,6 +126,7 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
     }
     dispatch(curateSearchtextAction(SearchInfo));
 
+    // Always call the API
     dispatch(reciterUpdatePublication(uid, request));
 
     // update user assertion of the publication
@@ -130,8 +139,16 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
       };
     }
 
-    // move updated data to the right Tab
+    // Suggested tab: immediately remove actioned card and track for undo
+    if (isSuggested && userAssertion !== 'NULL') {
+      const article = publications.find((p: any) => p.pmid === pmid);
+      setPublications(prev => prev.filter((p: any) => p.pmid !== pmid));
+      lastActioned.current = { pmid, prevState: 'NULL', article };
+    }
+
+    // Update parent filteredData so clearing a filter reflects the change
     props.updatePublicationAssertion(updatedPublication, userAssertion, props.tabType);
+    props.onAssertionChange?.(pmid, userAssertion);
   }
 
   const handleUpdatePublicationAll = (userAssertion: string) => {
@@ -166,8 +183,155 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
     })
 
     props.updatePublicationAssertionBulk(updatedPublications, userAssertion, props.tabType);
+    pmids.forEach((pmid) => props.onAssertionChange?.(pmid, userAssertion));
   }
 
+
+  // ── Keyboard shortcut state (Suggested tab only) ──
+  const isSuggested = props.tabType === 'NULL';
+  const isArticleTab = props.tabType === 'NULL' || props.tabType === 'ACCEPTED' || props.tabType === 'REJECTED';
+  const [focusedIndex, setFocusedIndex] = useState<number>(isArticleTab ? 0 : -1);
+  const lastActioned = useRef<{ pmid: number; prevState: string; article?: any } | null>(null);
+
+  // Find next pending card index from a given start
+  const findNextPending = useCallback((startIdx: number, data: any[]) => {
+    for (let i = startIdx; i < data.length; i++) {
+      if (data[i].userAssertion === 'NULL') return i;
+    }
+    return -1;
+  }, []);
+
+  // Count pending cards
+  const pendingCount = publicationsPaginatedData.filter((p: any) => p.userAssertion === 'NULL').length;
+
+  // Keyboard handler
+  useEffect(() => {
+    if (!isArticleTab) return;
+
+    const handler = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+
+      const key = e.key.toLowerCase();
+      const focusedPub = publicationsPaginatedData[focusedIndex];
+
+      if (key === 'a' && focusedPub && focusedPub.userAssertion !== 'ACCEPTED') {
+        e.preventDefault();
+        lastActioned.current = { pmid: focusedPub.pmid, prevState: focusedPub.userAssertion };
+        handleUpdatePublication(props.personIdentifier, focusedPub.pmid, 'ACCEPTED');
+        if (isSuggested) {
+          const next = findNextPending(focusedIndex + 1, publicationsPaginatedData);
+          if (next >= 0) setFocusedIndex(next);
+        }
+      } else if (key === 'r' && focusedPub && focusedPub.userAssertion !== 'REJECTED') {
+        e.preventDefault();
+        lastActioned.current = { pmid: focusedPub.pmid, prevState: focusedPub.userAssertion };
+        handleUpdatePublication(props.personIdentifier, focusedPub.pmid, 'REJECTED');
+        if (isSuggested) {
+          const next = findNextPending(focusedIndex + 1, publicationsPaginatedData);
+          if (next >= 0) setFocusedIndex(next);
+        }
+      } else if (key === 'u' && lastActioned.current) {
+        e.preventDefault();
+        const { pmid: undoPmid, prevState, article } = lastActioned.current;
+        if (isSuggested && article) {
+          setPublications(prev =>
+            prev.some((p: any) => p.pmid === undoPmid)
+              ? prev
+              : [...prev, { ...article, userAssertion: prevState }]
+          );
+        }
+        handleUpdatePublication(props.personIdentifier, undoPmid, prevState);
+        lastActioned.current = null;
+      } else if (key === 'e' && focusedPub) {
+        e.preventDefault();
+        const el = document.querySelector(`[data-pmid="${focusedPub.pmid}"]`);
+        if (el) {
+          const btn = el.querySelector('button[data-evidence-toggle]') as HTMLButtonElement;
+          if (btn) btn.click();
+        }
+      } else if (key === 'arrowdown') {
+        e.preventDefault();
+        setFocusedIndex(prev => Math.min(prev + 1, publicationsPaginatedData.length - 1));
+      } else if (key === 'arrowup') {
+        e.preventDefault();
+        setFocusedIndex(prev => Math.max(prev - 1, 0));
+      }
+    };
+
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isArticleTab, isSuggested, focusedIndex, publicationsPaginatedData, props.personIdentifier]);
+
+  // Scroll focused card into view
+  useEffect(() => {
+    if (!isArticleTab || focusedIndex < 0) return;
+    const focusedPub = publicationsPaginatedData[focusedIndex];
+    if (!focusedPub) return;
+    const el = document.querySelector(`[data-pmid="${focusedPub.pmid}"]`);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }, [focusedIndex, isArticleTab]);
+
+  if (!props.publications.length) {
+    if (props.tabType === 'NULL') {
+      return (
+        <div className={styles.emptyState}>
+          <div className={styles.emptyIconGreen}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="#1a7a4a" strokeWidth="2" strokeLinecap="round" width="22" height="22"><path d="M20 6L9 17l-5-5"/></svg>
+          </div>
+          <div className={styles.emptyTitle}>All caught up</div>
+          <div className={styles.emptyBody}>There are no new suggested publications to review. ReCiter will surface new suggestions the next time the system runs.</div>
+          <div className={styles.emptyActions}>
+            <button className={styles.emptyActionPrimary} onClick={() => dispatch(reciterFetchData(props.personIdentifier, true))}>
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" width="13" height="13"><path d="M13.5 8a5.5 5.5 0 11-1.1-3.3M13.5 2v3h-3"/></svg>
+              Run ReCiter now
+            </button>
+            <button className={styles.emptyActionSecondary} onClick={() => props.onTabChange?.('ACCEPTED')}>
+              View accepted publications
+            </button>
+          </div>
+        </div>
+      );
+    }
+    if (props.tabType === 'ACCEPTED') {
+      return (
+        <div className={styles.emptyState}>
+          <div className={styles.emptyIconMuted}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="#8a94a6" strokeWidth="2" strokeLinecap="round" width="22" height="22"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 12h6M9 8h4"/></svg>
+          </div>
+          <div className={styles.emptyTitle}>No accepted publications yet</div>
+          <div className={styles.emptyBody}>Publications you accept will appear here. Review the suggested tab to get started.</div>
+          <div className={styles.emptyActions}>
+            <button className={styles.emptyActionPrimary} onClick={() => props.onTabChange?.('NULL')}>
+              Go to Suggested
+            </button>
+          </div>
+        </div>
+      );
+    }
+    if (props.tabType === 'REJECTED') {
+      return (
+        <div className={styles.emptyState}>
+          <div className={styles.emptyIconMuted}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="#8a94a6" strokeWidth="2" strokeLinecap="round" width="22" height="22"><circle cx="12" cy="12" r="9"/><path d="M9 9l6 6M15 9l-6 6"/></svg>
+          </div>
+          <div className={styles.emptyTitle}>No rejected publications</div>
+          <div className={styles.emptyBody}>Publications you reject will be recorded here. You can undo a rejection at any time.</div>
+          <div className={styles.emptyActions}>
+            <button className={styles.emptyActionSecondary} onClick={() => props.onTabChange?.('NULL')}>
+              Go to Suggested
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="text-center" style={{padding: '40px'}}>
+        <p>No articles found</p>
+      </div>
+    )
+  }
 
   return (
     <>
@@ -178,17 +342,30 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
         updateAll={handleUpdatePublicationAll}
         tabType={props.tabType}
         isSearchText={props.isSearchText}
-      />
-      <Pagination total={totalCount} page={page}
+        page={page}
         count={count}
-        onChange={handlePaginationUpdate}
-        onCountChange={handleCountUpdate}
+        totalCount={totalCount}
+        handlePaginationUpdate={handlePaginationUpdate}
+        handleCountUpdate={handleCountUpdate}
       />
-      {publicationsPaginatedData.map((publication: any, index: number) => {
-        return (
-          <div key={publication.pmid}>
+
+      {/* Keyboard hint bar — Suggested tab only */}
+      {isArticleTab && (
+        <div className={styles.kbdHint}>
+          <span><span className={styles.kbd}>A</span> Accept</span>
+          <span><span className={styles.kbd}>R</span> Reject</span>
+          <span><span className={styles.kbd}>U</span> Undo last</span>
+          <span><span className={styles.kbd}>E</span> Toggle Evidence</span>
+          <span><span className={styles.kbd}>&uarr;</span><span className={styles.kbd}>&darr;</span> Navigate</span>
+        </div>
+      )}
+
+      <div className={styles.articleList}>
+        {publicationsPaginatedData.map((publication: any, index: number) => {
+          return (
             <Publication
-              index={ `page${page}${index+1}`}
+              key={publication.pmid}
+              index={`page${page}${index+1}`}
               reciterArticle={publication}
               personIdentifier={props.personIdentifier}
               fullName={props.fullName}
@@ -198,11 +375,21 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
               showEvidenceDefault={props.showEvidenceDefault}
               page={page}
               paginatedPubsCount={publication.userAssertion === "NULL" ? totalNullCount : publication.userAssertion === "ACCEPTED" ? totalAcceptedCount : totalRejectedCount}
+              isFocused={isArticleTab && index === focusedIndex}
+              onCardMouseDown={() => { if (isArticleTab) setFocusedIndex(index); }}
             />
-            <Divider />
-          </div>
-        )
-      })}
+          )
+        })}
+      </div>
+
+      {/* All caught up state */}
+      {isSuggested && pendingCount === 0 && publicationsPaginatedData.length > 0 && (
+        <div className={styles.allDone}>
+          <div className={styles.allDoneCheck}><CheckIcon /></div>
+          <p><strong>All caught up!</strong></p>
+          <p>No pending suggestions remaining on this page.</p>
+        </div>
+      )}
     </>
   )
 }

--- a/src/components/elements/CurateIndividual/ReciterTabs.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabs.tsx
@@ -1,13 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import filterPublications from "../../../utils/filterPublications";
 import { Tab, Tabs, Badge } from "react-bootstrap";
 import ReciterTabContent from "./ReciterTabContent";
 import styles from "./CurateIndividual.module.css";
-import { RootStateOrAny, useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { RootStateOrAny } from "../../../types/redux";
 import TabAddPublication from "../TabAddPublication/TabAddPublication";
 import { allowedPermissions } from "../../../utils/constants";
 import { useSession } from "next-auth/client";
-import { clearPubMedData, showEvidenceByDefault } from "../../../redux/actions/actions";
+import { clearPubMedData, showEvidenceByDefault, reciterFetchData } from "../../../redux/actions/actions";
 
 
 const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData: any, fullName: string, fetchOriginalData: any }) => {
@@ -20,6 +21,11 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
   const isSearchText = useSelector((state: RootStateOrAny) => state.curateSearchtext)
   const showEvidenceDefault = useSelector((state: RootStateOrAny) => state.showEvidenceDefault)
   const [pubSearchFilters, setPubSearchFilters] = useState();
+  const [refreshState, setRefreshState] = useState<'idle' | 'loading' | 'done'>('idle');
+
+  // Smart change tracking: compare current assertions to originals
+  const originalAssertions = useRef<Map<number, string>>(new Map());
+  const [changedAssertions, setChangedAssertions] = useState<Map<number, string>>(new Map());
 
 
   const addnewtabName = <p id="addnewtabName" className="noSpace" >Add New record:</p>
@@ -40,118 +46,188 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
       publicationsPerTabs.push({ value: tab.value, name: tab.name, data: filteredReciterData, count: filteredReciterData.length, allowedRoleNames: tab.allowedRoleNames})
     })
     setFilteredData(publicationsPerTabs);
+
+    // Build map of original assertions for smart change tracking
+    const origMap = new Map<number, string>();
+    publicationsPerTabs.forEach((tab: any) => {
+      if (tab.value === 'NULL' || tab.value === 'ACCEPTED' || tab.value === 'REJECTED') {
+        tab.data.forEach((article: any) => {
+          origMap.set(article.pmid, article.userAssertion);
+        });
+      }
+    });
+    originalAssertions.current = origMap;
   }, [])
 
   const updatePublicationAssertion = (reciterArticle: any, userAssertion: string, prevUserAssertion: string) => {
-    let updatedFilteredData = [...filteredData];
-
-    updatedFilteredData.forEach((tabData) => {
-      // If Tab matches the updated user assertion, add the article in the tab
-      if (tabData.value == userAssertion) {
-        tabData.data.push(reciterArticle);
-        tabData.count = tabData.count + 1;
-      } else if (tabData.value == prevUserAssertion) {
-        // If Tab matches the previous user assertion, remove from that tab
-        let index = tabData.data.findIndex(i => i.pmid === reciterArticle.pmid);
-        if (index > -1) { tabData.data.splice(index, 1) }
-        if (tabData.count > 0) { tabData.count = tabData.count - 1; }
+    setFilteredData(prev => prev.map((tabData: any) => {
+      if (tabData.value === userAssertion) {
+        return { ...tabData, data: [...tabData.data, reciterArticle], count: tabData.count + 1 };
       }
-    })
-
-    setFilteredData(updatedFilteredData);
-    // setKey(prevUserAssertion)
+      if (tabData.value === prevUserAssertion) {
+        const newData = tabData.data.filter((i: any) => i.pmid !== reciterArticle.pmid);
+        return { ...tabData, data: newData, count: Math.max(0, tabData.count - 1) };
+      }
+      return tabData;
+    }));
   }
 
   const updatePublicationAssertionBulk = (reciterArticles: any, userAssertion: string, prevUserAssertion: string) => {
-    let updatedFilteredData = [...filteredData];
-    updatedFilteredData.forEach((tabData) => {
-      // If Tab matches the updated user assertion, add the article in the tab
-      if (tabData.value == userAssertion) {
-        tabData.data.push(...reciterArticles);
-        tabData.count = tabData.count + reciterArticles.length;
-      } else if (tabData.value == prevUserAssertion) {
-        // If Tab matches the previous user assertion, remove from that tab
-        let count = tabData.count;
-        reciterArticles.forEach((reciterArticle) => {
-          let index = tabData.data.findIndex(i => i.pmid === reciterArticle.pmid);
-          if (index > -1) { tabData.data.splice(index, 1) }
-          if (count > 0) { count--; }
-        })
-        tabData.count = count;
+    const pmids = new Set(reciterArticles.map((a: any) => a.pmid));
+    setFilteredData(prev => prev.map((tabData: any) => {
+      if (tabData.value === userAssertion) {
+        return { ...tabData, data: [...tabData.data, ...reciterArticles], count: tabData.count + reciterArticles.length };
       }
-    })
-    setFilteredData(updatedFilteredData);
-    // setKey(userAssertion)
+      if (tabData.value === prevUserAssertion) {
+        const newData = tabData.data.filter((i: any) => !pmids.has(i.pmid));
+        const removed = tabData.data.length - newData.length;
+        return { ...tabData, data: newData, count: Math.max(0, tabData.count - removed) };
+      }
+      return tabData;
+    }));
   }
   const handleUpdateSearchFilters = (pubFilters : any)=>{
     setPubSearchFilters(pubFilters);
   }
 
+  // Track assertion changes: each article counted at most once, net-zero = 0
+  const handleAssertionChange = (pmid: number, newAssertion: string) => {
+    setChangedAssertions(prev => {
+      const next = new Map(prev);
+      const original = originalAssertions.current.get(pmid);
+      if (original === newAssertion) {
+        // Back to original state — no net change
+        next.delete(pmid);
+      } else {
+        // Changed from original — counts as 1 change (regardless of intermediate states)
+        next.set(pmid, newAssertion);
+      }
+      return next;
+    });
+  };
+
+  const netChangedCount = changedAssertions.size;
+
   const onTabChange = (k)=>{
     setKey(k)
-    if(k === "AddPub"){
-      document.getElementById('addnewtabName').innerHTML = "<i>Adding New record from</i>";
-      document.getElementById('pubMedTabName').innerHTML = '<span style="color:black ; font-style:italic; font-weight: normal">PubMed...</span>';
-    }else{
-      document.getElementById('addnewtabName').innerHTML = "Add New record:";
-      document.getElementById('pubMedTabName').innerHTML = 'PubMed'
-    }
     dispatch(showEvidenceByDefault(false));
-    // dispatch(clearPubMedData());
   }
+
+  const handleRefresh = () => {
+    if (refreshState !== 'idle') return;
+    setRefreshState('loading');
+    // In production: dispatch(reciterFetchData(reciterData.reciter?.personIdentifier, true));
+    // For now, simulate the network call with animation states
+    setTimeout(() => {
+      setRefreshState('done');
+      setChangedAssertions(new Map()); // Changes submitted — reset tracking
+      setTimeout(() => setRefreshState('idle'), 2000);
+    }, 2500);
+  };
+
+  const countBadgeClass = (value: string) => {
+    const count = getCount(value);
+    if (count === 0) return styles.tabCountZero;
+    if (value === 'NULL') return styles.tabCountSuggested;
+    if (value === 'ACCEPTED') return styles.tabCountAccepted;
+    if (value === 'REJECTED') return styles.tabCountRejected;
+    return '';
+  };
+
+  const getCount = (value: string) => {
+    const tab = filteredData.find((t: any) => t.value === value);
+    return tab ? tab.count : 0;
+  };
+
+  const activeTabData = filteredData.find((t: any) => t.value === key);
 
   return (
     <>
-      <Tabs
-        id="controlled-tab-example"
-        activeKey={key}
-        onSelect={(k) => onTabChange (k)}
-        className={`${styles.tabsContainer}`}
-      > {
-          filteredData.map((tabData: any, index: number) => {
-            let userPermissions = JSON.parse(session.data.userRoles);
-            const matchedRoles = userPermissions.filter(role => tabData.allowedRoleNames.includes(role.roleLabel));
-            if(matchedRoles.length >= 1){
-            return (
-              <Tab
-                eventKey={tabData.value}
-                key={tabData.value}
-                className={tabData.value === "AddPub" ? `${styles.curateTabsMainPub}` : `${styles.curateTabsMain}`}
-                disabled={tabData.value === "addNewRecord" ? true : false}
-                tabClassName={tabData.value === "addNewRecord" ? `${styles.tabDisplayNone}` : tabData.value === "AddPub" ? `${styles.pubMadeTab}` : `${styles.tabsMain}`}
-                title={
-                  <div className={key === tabData.value ? `${styles.activeTab} ${styles.tabTitle}` : styles.tabTitle}>{tabData.name} {tabData.value === "addNewRecord" || tabData.value === "AddPub" ? "" : <div className={key === tabData.value ? `${styles.active} ${styles.circle}` : styles.circle}><span className={key === tabData.value ? `${styles.activeCount} ${styles.count}` : styles.count}>{tabData.count}</span></div>}</div>
-                }>
-                {
-                  key === "AddPub" ?
-                    <TabAddPublication 
-                    updatePublicationAssertion={updatePublicationAssertion}
-                    tabType={tabData.value}
-                    personIdentifier={reciterData.reciter?.personIdentifier}
-                    pubSearchFilters={pubSearchFilters}
-                    handleUpdateSearchFilters = {handleUpdateSearchFilters}
-                     />
-                    :
-                    <ReciterTabContent
-                      tabType={tabData.value}
-                      publications={tabData.data}
-                      index={index}
-                      personIdentifier={reciterData.reciter?.personIdentifier}
-                      fullName={fullName}
-                      updatePublicationAssertion={updatePublicationAssertion}
-                      updatePublicationAssertionBulk={updatePublicationAssertionBulk}
-                      isSearchText={isSearchText}
-                      showEvidenceDefault = {showEvidenceDefault}
-                      activeKey = {key}
-                      totalCount={tabData.value === "NULL" ? tabData.count : tabData.value === "ACCEPTED" ? tabData.count : tabData.value ==="REJECTED" ?  tabData.count : ""}
-                    />
+      {/* Custom tab bar */}
+      <div className={styles.tabsBar}>
+        {['NULL', 'ACCEPTED', 'REJECTED'].map((value) => {
+          const label = value === 'NULL' ? 'Suggested' : value === 'ACCEPTED' ? 'Accepted' : 'Rejected';
+          return (
+            <button
+              key={value}
+              className={key === value ? styles.tabActive : styles.tab}
+              onClick={() => onTabChange(value)}
+            >
+              {label}
+              <span className={countBadgeClass(value)}>{getCount(value)}</span>
+            </button>
+          );
+        })}
+        <div className={styles.tabSpacer} />
+        <div className={styles.tabBarActions}>
+          {(netChangedCount > 0 || refreshState !== 'idle') && (
+            <button
+              className={`${styles.refreshBtn} ${refreshState === 'loading' ? styles.refreshBtnLoading : ''} ${refreshState === 'done' ? styles.refreshBtnDone : ''}`}
+              onClick={handleRefresh}
+              title="Re-run ReCiter to generate new suggestions"
+            >
+              <svg
+                className={`${styles.refreshIcon} ${refreshState === 'loading' ? styles.refreshIconSpin : ''}`}
+                viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" width="11" height="11"
+              >
+                {refreshState === 'done'
+                  ? <path d="M2 8l4 4 8-8" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+                  : <path d="M13.5 8a5.5 5.5 0 11-1.1-3.3M13.5 2v3h-3" />
                 }
-              </Tab>
-            )
-              }
-          })
-        }
-      </Tabs>
+              </svg>
+              <span className={refreshState === 'loading' ? styles.refreshLabelPulse : ''}>
+                {refreshState === 'loading' ? 'Refreshing\u2026' : refreshState === 'done' ? 'Done' : 'Refresh Suggestions'}
+              </span>
+              {refreshState === 'idle' && netChangedCount > 0 && (
+                <span className={styles.unsavedBadge} title={`${netChangedCount} unsaved change(s) will be submitted`}>
+                  {netChangedCount}
+                </span>
+              )}
+            </button>
+          )}
+          {key === 'AddPub' ? (
+            <div className={styles.addRecordIndicator}>
+              <span className={styles.addRecordPulse} />
+              Adding record from PubMed
+            </div>
+          ) : (
+            <button
+              className={styles.addRecordBtn}
+              onClick={() => onTabChange('AddPub')}
+            >
+              + Add record via PubMed
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Tab content */}
+      {key === 'AddPub' ? (
+        <TabAddPublication
+          updatePublicationAssertion={updatePublicationAssertion}
+          tabType="AddPub"
+          personIdentifier={reciterData.reciter?.personIdentifier}
+          pubSearchFilters={pubSearchFilters}
+          handleUpdateSearchFilters={handleUpdateSearchFilters}
+        />
+      ) : activeTabData ? (
+        <ReciterTabContent
+          key={activeTabData.value}
+          tabType={activeTabData.value}
+          publications={activeTabData.data}
+          index={filteredData.indexOf(activeTabData)}
+          personIdentifier={reciterData.reciter?.personIdentifier}
+          fullName={fullName}
+          updatePublicationAssertion={updatePublicationAssertion}
+          updatePublicationAssertionBulk={updatePublicationAssertionBulk}
+          isSearchText={isSearchText}
+          showEvidenceDefault={showEvidenceDefault}
+          activeKey={key}
+          totalCount={activeTabData.count}
+          onAssertionChange={handleAssertionChange}
+          onTabChange={onTabChange}
+        />
+      ) : null}
     </>
   )
 }


### PR DESCRIPTION
## Summary
Restore the four CurateIndividual files from `b7210e6` (the state before the dev_v2 re-restore in `2a0a747`) and patch only the v4-specific bits that motivated the re-restore in the first place.

The re-restore in `2a0a747` replaced these files with leaner dev_v2 versions to fix `next-auth/react` import crashes (v4-only path), but it dropped the rich UI work that produced the screenshots the user has from before:
- score chips per article (numeric, colored)
- Refresh Suggestions button (with badge)
- Add record via PubMed action
- Accept All / Reject All bulk actions
- Inline Accept/Reject buttons per article
- Filter / Sort / Show / Pagination controls
- Keyboard shortcut help row (A/R/U/E/arrows)
- Feedback-based scores panel (evidence weights bar chart) on the detail view

This PR restores the four files verbatim from `b7210e6` and patches only the v3 incompatibility:
```
- import { useSession } from "next-auth/react";
+ import { useSession } from "next-auth/client";
- const { data: session, status } = useSession(); const loading = status === "loading";
+ const [session, loading] = useSession();
```

GrantProxyModal didn't use useSession so no patch needed there.

All upstream dependencies are present on this branch (`InferredKeywords`, `SuggestionsBanner`, `getCapabilities`/`allowedPermissions`/`toastMessage` in constants.js, the redux thunks in actions.js).

Files changed:
- `CurateIndividual.tsx`: 269 lines diff
- `GrantProxyModal.tsx`: 493 lines diff
- `ReciterTabContent.tsx`: 241 lines diff
- `ReciterTabs.tsx`: 264 lines diff

## Test plan
- [ ] CodeBuild green
- [ ] /curate/[id] shows: profile header, tabs with counts, Refresh Suggestions, Accept All/Reject All, score chips, inline Accept/Reject, filter/sort/pagination, keyboard help row
- [ ] Single article curate detail shows the Feedback-based scores panel
- [ ] Accept/Reject still POSTs to backend and updates state (regression check on 064a91f's immutable update fix)