### PR TITLE
fix: restore rich SideNavbar + Search + supporting files

### DIFF
--- a/src/components/elements/Header/Header.tsx
+++ b/src/components/elements/Header/Header.tsx
@@ -6,11 +6,11 @@ import { getSigninUrl } from '../../../utils/loginHelper'
 
 const Header = () => {
     const [session, loading] = useSession()
-    //console.log("session", session);
     return (
         <Navbar bg="primary" className={styles.topNav}>
           <div>
               <Navbar.Brand className={styles.headerText}>
+                  <span className={styles.brandDot}></span>
                   <b>ReCiter Publication Manager</b>
               </Navbar.Brand>
           </div>
@@ -18,8 +18,8 @@ const Header = () => {
           <ul className={`nav navbar-nav ${styles.navbarRight}`}>
               {(session && session.data) ? 
               <>
-                  <li className={styles.headerNavSignedInAs}><p><b>Signed in as {session.data.username}</b></p></li> 
-                  <li><button type="button" className={`btn btn-link ${styles.logout}`} onClick={()=>{signOut({ callbackUrl: getSigninUrl() })}}>Logout</button></li>
+                  <li className={styles.headerNavSignedInAs}><p>{session.data.username}</p></li>
+                  <li><button type="button" className={styles.logout} onClick={()=>{signOut({ redirect: false }).then(() => { window.location.href = '/api/auth/saml-logout'; })}} style={{ background: 'none', border: 'none', padding: 0, font: 'inherit', color: 'inherit', cursor: 'pointer' }}>Logout</button></li>
               </> : null}
               
           </ul>

--- a/src/components/elements/Navbar/SideNavbar.tsx
+++ b/src/components/elements/Navbar/SideNavbar.tsx
@@ -3,8 +3,21 @@ import { styled, useTheme } from '@mui/material/styles';
 import MuiDrawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
 import Divider from '@mui/material/Divider';
+import Typography from '@mui/material/Typography';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+// Custom inline SVG icons matching the design mockup
+const NavIcon = ({ children }: { children: React.ReactNode }) => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ flexShrink: 0 }}>
+    {children}
+  </svg>
+);
+const IconSearch = () => <NavIcon><circle cx="6.5" cy="6.5" r="4"/><path d="M11 11l2.5 2.5"/></NavIcon>;
+const IconCurate = () => <NavIcon><rect x="2" y="2" width="12" height="12" rx="1.5"/><path d="M5 8h6M5 5.5h6M5 10.5h4"/></NavIcon>;
+const IconReports = () => <NavIcon><path d="M2 12V4l5-2 5 2v8"/><path d="M7 14V9h2v5"/></NavIcon>;
+const IconPerson = () => <NavIcon><circle cx="8" cy="5" r="2.5"/><path d="M3 13c0-2.76 2.24-5 5-5s5 2.24 5 5"/></NavIcon>;
+const IconManageUsers = () => <NavIcon><path d="M8 2a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM3 10a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM13 10a2 2 0 1 1 0 4 2 2 0 0 1 0-4z"/><path d="M8 6v2M5.5 11H3.5M10.5 11h2"/></NavIcon>;
+const IconConfig = () => <NavIcon><circle cx="8" cy="8" r="2"/><path d="M8 2v1M8 13v1M2 8h1M13 8h1M3.5 3.5l.7.7M11.8 11.8l.7.7M11.8 4.2l-.7.7M4.2 11.8l-.7.7"/></NavIcon>;
 import SettingsIconGare from '../../../../public/images/settingsIconGare.png';
 import SettingsGareIconActive from '../../../../public/images/settingsWhite.png';
 import NestedListItem from './NestedListItem';
@@ -20,10 +33,11 @@ import facultyIconActive from '../../../../public/images/icon-side-faculty_index
 import settingsIconActive from '../../../../public/images/icon-side-faculty_admin-active.png';
 import chartIconActive from '../../../../public/images/icon-side-faculty_report-active.png';
 import checkMarkIconActive from '../../../../public/images/icon-side-check_mark-active.png';
-import { useSelector, RootStateOrAny } from "react-redux";
+import { useSelector } from "react-redux";
+import { RootStateOrAny } from "../../../types/redux";
 import { useSession } from 'next-auth/client';
-import { getCapabilities } from '../../../utils/constants';
 import ScopeLabel from './ScopeLabel';
+import { getCapabilities } from '../../../utils/constants';
 
 
 type SideNavBarProps = {
@@ -35,20 +49,31 @@ type drawer = {
     open: any
 }
 
-const drawerWidth = 240;
+const drawerWidth = 220;
 
 const openedMixin = (theme: any) => ({
-  top: 60,
+  top: 0,
   width: drawerWidth,
+  height: '100vh',
+  paddingTop: 0,
+  zIndex: 999,
   transition: theme.transitions.create('width', {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.enteringScreen,
   }),
-  backgroundColor: '#f5f5f5',
+  paddingBottom: '16px',
+  backgroundColor: '#1e2d3d',
+  borderRight: 'none',
+  boxShadow: 'none',
+  display: 'flex',
+  flexDirection: 'column' as const,
 });
 
 const closedMixin = (theme: any) => ({
-  top: 60,
+  top: 0,
+  height: '100vh',
+  paddingTop: 0,
+  zIndex: 999,
   transition: theme.transitions.create('width', {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen,
@@ -65,7 +90,12 @@ const closedMixin = (theme: any) => ({
   '& .MuiListItemText-root': {
     display: 'none'
   },
-  backgroundColor: '#f5f5f5',
+  paddingBottom: '16px',
+  backgroundColor: '#1e2d3d',
+  borderRight: '1px solid #2e4050',
+  boxShadow: 'none',
+  display: 'flex',
+  flexDirection: 'column' as const,
 });
 
 const DrawerHeader = styled('div')(({ theme }) => ({
@@ -80,16 +110,16 @@ const DrawerHeader = styled('div')(({ theme }) => ({
 
 const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' })(
   ({ theme, open }: drawer) => ({
-    width: drawerWidth,
-    flexShrink: 0,
-    whiteSpace: 'nowrap',
-    boxSizing: 'border-box',
+    // Root element: invisible, takes no space in layout
+    width: 0,
+    height: 0,
+    overflow: 'visible',
+    position: 'fixed' as const,
+    // Paper element: the actual visible sidebar
     ...(open && {
-      ...openedMixin(theme),
       '& .MuiDrawer-paper': openedMixin(theme),
     }),
     ...(!open && {
-      ...closedMixin(theme),
       '& .MuiDrawer-paper': closedMixin(theme),
     }),
   }),
@@ -97,43 +127,61 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
 
 const StyledList = styled(List)({
   paddingTop: '0px',
-  // selected and (selected + hover) states
+  backgroundColor: '#1e2d3d',
+  // Link wrappers: fill background to prevent subpixel seams
+  '& > a': {
+    display: 'block',
+    backgroundColor: '#1e2d3d',
+  },
+  // selected: active bg, white text, red left accent
   '&& .Mui-selected': {
-    backgroundColor: '#e87722',
-    '&, & .MuiListItemIcon-root': {
-      color: 'white',
-    },
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    borderLeft: '2px solid #e05a5a',
+    color: '#ffffff',
+    fontWeight: 500,
+    '& .MuiListItemIcon-root': { color: '#ffffff' },
+    '& .MuiListItemIcon-root svg': { opacity: 1 },
   },
   '&& .Mui-selected:hover': {
-    backgroundColor: '#bd5d16',
-    '&, & .MuiListItemIcon-root': {
-      color: 'white',
-    },
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    color: '#ffffff',
+    '& .MuiListItemIcon-root': { color: '#ffffff' },
   },
-  '& .MuiButtonBase-root:hover': {
-    backgroundColor: '#eee',
-    '&, & .MuiListItemIcon-root': {
-      color: '#222',
-    },
-  },
-  '& .MuiButtonBase-root': {
-    borderBottom: '1px solid #ccc',
-      '&, & .MuiListItemIcon-root': {
-        minWidth: '30px',
-    },
+  // hover: lighter bg, text goes white
+  '& .MuiListItem-root:hover': {
+    backgroundColor: 'rgba(255,255,255,0.07)',
+    color: '#ffffff',
+    '& .MuiListItemText-primary': { color: '#ffffff' },
+    '& .MuiListItemIcon-root': { color: '#ffffff' },
+    '& .MuiListItemIcon-root svg': { opacity: 1 },
   },
   '& .MuiListItem-root': {
-    fontSize: '14px',
-    borderBottom: '1px solid #ccc',
-      '&, & .MuiListItemIcon-root': {
-        minWidth: '30px',
+    color: '#8aa8c0',
+    cursor: 'pointer',
+    transition: 'background 0.15s, color 0.15s',
+    padding: '9px 20px',
+    backgroundColor: '#1e2d3d',
+    borderTop: 'none',
+    borderRight: 'none',
+    borderBottom: 'none',
+    borderLeft: '2px solid transparent',
+    '& .MuiListItemIcon-root': {
+      minWidth: '16px',
+      color: '#8aa8c0',
+      marginRight: '10px',
+    },
+    '& .MuiListItemIcon-root svg': {
+      opacity: 0.7,
     },
   },
+  '& .MuiListItemText-root': {
+    margin: 0,
+    padding: 0,
+  },
   '& .MuiListItemText-primary': {
-    fontSize: '14px',
-    marginTop: '0px',
-    marginBottom: '0px',
-    fontFamily: 'Helvetica Neue',
+    fontSize: '13px',
+    lineHeight: 'normal',
+    fontFamily: '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
   },
   '& .MuiBox-root': {
     '.MuiListItem-root': {
@@ -146,9 +194,22 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
   const theme = useTheme();
   const [open, setOpen] = React.useState(true);
   const filters = useSelector((state: RootStateOrAny) => state.filters)
-   
+  const updatedAdminSettings = useSelector((state: RootStateOrAny) => state.updatedAdminSettings)
+
   const [isCurateSelf, setIsCurateSelf] = React.useState(false);
+  const [isVisibleNotification, setVisibleNotification] = React.useState(true);
+
+
   const [session, loading] = useSession();
+
+  const userPermissions = JSON.parse(session.data.userRoles);
+  const isSuperuser = userPermissions.some((role: any) => role.roleLabel === "Superuser");
+
+  // Phase 9: Parse scope/proxy data and derive capabilities
+  const scopeData = session?.data?.scopeData ? JSON.parse(session.data.scopeData) : null;
+  const proxyPersonIds = session?.data?.proxyPersonIds ? JSON.parse(session.data.proxyPersonIds) : [];
+  const caps = getCapabilities(userPermissions);
+  const isScopedCurator = caps.canCurate.scoped && !caps.canCurate.all;
 
   const menuItems: Array<MenuItem> = [
     {
@@ -156,49 +217,106 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
       to: '/search',
       imgUrl: facultyIcon,
       imgUrlActive: facultyIconActive,
+      muiIcon: <IconSearch />,
       disabled: false,
-      capabilityKey: 'canSearch',
+      allowedRoleNames: ["Superuser", "Curator_All","Reporter_All","Curator_Scoped"],
+      isRequired:true
     },
     {
       title: 'Curate Publications',
       to: '/curate',
       imgUrl: SettingsIconTools,
       imgUrlActive: settingsIconActive,
-      disabled: (Object.keys(filters).length === 0),
-      capabilityKey: 'canCurate',
+      muiIcon: <IconCurate />,
+      disabled: isSuperuser ? false : (Object.keys(filters).length === 0),
+      allowedRoleNames: ["Superuser", "Curator_All","Curator_Self","Curator_Scoped"],
+      isRequired:true
     },
     {
       title: 'Create Reports',
       to: '/report',
       imgUrl: chartIcon,
       imgUrlActive: chartIconActive,
+      muiIcon: <IconReports />,
       disabled: false,
-      capabilityKey: 'canReport',
+      allowedRoleNames: ["Superuser","Reporter_All" ],
+      isRequired:true
     },
     {
       title: 'Manage Notifications',
-      to: '/notifications',
+      to: `/notifications/${session.data.username}`,
       imgUrl: chartIcon,
       imgUrlActive: chartIconActive,
+      muiIcon: <IconCurate />,
       disabled: false,
-      capabilityKey: 'canNotifications',  // Not yet implemented -- hidden for now
+      allowedRoleNames: ["Department_user","Curator_Self","Superuser", "Curator_All"],
+      isRequired: isSuperuser ? true : (isVisibleNotification && session.data.email ? true : false)
     },
     {
-      title: 'Manage Users',
+      title: 'Manage Profile',
+      to: `/manageprofile/${session.data.username}`,
+      imgUrl: chartIcon,
+      imgUrlActive: chartIconActive,
+      muiIcon: <IconPerson />,
+      disabled: false,
+      allowedRoleNames: ["Department_user","Curator_Self","Superuser", "Curator_All"],
+      isRequired: true
+    },
+    {title: 'Manage Users',
       to: '/manageusers',
       imgUrl: facultyIcon,
       imgUrlActive: facultyIconActive,
+      muiIcon: <IconManageUsers />,
       disabled: false,
-      capabilityKey: 'canManageUsers',
+      allowedRoleNames: ["Superuser"],
+      isRequired:true
     },
-    {
-      title: 'Configuration',
-      to: '/configuration',
-      imgUrl: SettingsIconGare,
-      imgUrlActive: SettingsGareIconActive,
-      disabled: false,
-      capabilityKey: 'canConfigure',
-    },
+    {title: 'Configuration',
+    to: '/configuration',
+    imgUrl: SettingsIconGare,
+    imgUrlActive: SettingsGareIconActive,
+    muiIcon: <IconConfig />,
+    disabled: false,
+    allowedRoleNames: ["Superuser"],
+    isRequired:true
+  },
+    // {
+    //   title: 'Manage Users',
+    //   to: '/manageUsers',
+    //   imgUrl: chartIcon,
+    //   imgUrlActive: chartIconActive,
+    //   disabled: false,
+    //   allowedRoleNames: ["Superuser","" ],
+    // },
+    // {
+    //   title: 'Perform Analysis',
+    //   to: '/login',
+    //   imgUrl: checkMarkIcon,
+    //   imgUrlActive: checkMarkIconActive,
+    //   disabled: false,
+    //   allowedRoleNames: ["Superuser","Reporter_All" ],
+    // },
+  //   {
+  //     title: 'Manage Module',
+  //     imgUrl: SettingsIconTools,
+  //     imgUrlActive: settingsIconActive,
+  //     nestedMenu: [{title: 'Manage Users', 
+  //     to: '/admin/manage/users', 
+  //     imgUrl: facultyIcon, 
+  //     imgUrlActive: facultyIconActive, 
+  //     disabled: false,
+  //     allowedRoleNames: ["Superuser"],
+  //   },
+  //   {title: 'Settings', 
+  //   to: '/admin/manage/settings', 
+  //   imgUrl: SettingsIconGare, 
+  //   imgUrlActive: SettingsGareIconActive, 
+  //   disabled: false,
+  //   allowedRoleNames: ["Superuser"],
+  // }],
+  //     allowedRoleNames: ["Superuser"],
+
+  //   }
   ]
 
   const expandNavCotext = React.useContext(ExpandNavContext);
@@ -207,71 +325,112 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
     expandNavCotext.updateExpand();
     setOpen(!open);
   };
+  
+
+  React.useEffect(()=>{
+    var manageNotifications = [];
+    if (updatedAdminSettings.length > 0) {
+      let updatedData = updatedAdminSettings.find(obj => obj.viewName === "EmailNotifications")
+      manageNotifications = updatedData?.viewAttributes || [];
+    } else if (session?.adminSettings) {
+      let adminSettings = JSON.parse(JSON.stringify(session.adminSettings));
+      let data = JSON.parse(adminSettings).find(obj => obj.viewName === "EmailNotifications")
+      manageNotifications = data ? JSON.parse(data.viewAttributes) : [];
+    }
+    let settingsObj = manageNotifications.find(data=> data.isVisible)
+    setVisibleNotification(settingsObj && settingsObj.isVisible || false)
+  },[])
+
+  // Re-derive notification visibility when admin settings arrive in Redux (async)
+  React.useEffect(() => {
+    if (updatedAdminSettings && updatedAdminSettings.length > 0) {
+      let updatedData = updatedAdminSettings.find(obj => obj.viewName === "EmailNotifications")
+      let manageNotifications = updatedData?.viewAttributes || [];
+      let settingsObj = manageNotifications.find(data => data.isVisible)
+      setVisibleNotification(settingsObj && settingsObj.isVisible || false)
+    }
+  }, [updatedAdminSettings])
 
   return (
     <Drawer variant="permanent" className='drawer-container' open={open} theme={theme}>
-      <DrawerHeader className={styles.drawerHeader}>
-        <div onClick={handleDrawerToggle} className={styles.sidebarControl}>
-          {open ? <span className={styles.hideSidebar}>compact mode</span> : ''}
-          {open ? <ChevronLeftIcon /> : <ChevronRightIcon /> }
+      {open && (
+        <div style={{ padding: '16px 20px 12px', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%', background: '#c44040', flexShrink: 0 }} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: '#fff' }}>ReCiter</span>
         </div>
-      </DrawerHeader>
-      <Divider />
-      {(() => {
-        const userRoles = session?.data?.userRoles ? JSON.parse(session.data.userRoles) : [];
-        const caps = getCapabilities(userRoles);
-        const scopeData = session?.data?.scopeData ? JSON.parse(session.data.scopeData) : null;
-        const proxyPersonIds = session?.data?.proxyPersonIds
-          ? JSON.parse(session.data.proxyPersonIds)
-          : [];
-
-        return (
-          <>
-            {open && caps.canCurate.scoped && !caps.canCurate.all && (
-              <ScopeLabel scopeData={scopeData} proxyCount={proxyPersonIds.length} />
-            )}
-            <StyledList>
-              {menuItems.map((item: MenuItem, index: number) => {
-                const capKey = item.capabilityKey;
-                let hasAccess = false;
-                if (capKey === 'canCurate') {
-                  hasAccess = caps.canCurate.all || caps.canCurate.self || caps.canCurate.scoped;
-                } else if (capKey === 'canNotifications') {
-                  hasAccess = false; // Notifications not yet implemented
-                } else if (capKey && caps[capKey]) {
-                  hasAccess = true;
-                }
-
-                if (hasAccess) {
-                  // For scoped curators, route "Curate Publications" to /search?scopeFilter=true
-                  const itemTo = (capKey === 'canCurate' && caps.canCurate.scoped && !caps.canCurate.all)
-                    ? '/search?scopeFilter=true'
-                    : item.to;
-
-                  return item.nestedMenu ?
-                    <NestedListItem
-                      header={item.title}
-                      menuItems={item.nestedMenu}
-                      key={index}
-                      imgUrl={item.imgUrl}
-                    />
-                    :
-                    <MenuListItem
-                      title={item.title}
-                      key={index}
-                      id={index}
-                      to={itemTo}
-                      imgUrl={item.imgUrl}
-                      imgUrlActive={item.imgUrlActive}
-                      disabled={item.disabled}
-                    />
-                }
-                return null;
-              })}
-            </StyledList>
-          </>
-        );
-      })()}
+      )}
+      <StyledList sx={{ flexGrow: 1, paddingTop: '4px' }}>
+          {open && (
+            <Typography sx={{ padding: '4px 20px 6px', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#5a7a94' }}>
+              Navigation
+            </Typography>
+          )}
+          {isScopedCurator && open && (
+            <ScopeLabel
+              scopeData={scopeData}
+              proxyCount={proxyPersonIds.length}
+            />
+          )}
+          {
+            menuItems.slice(0, 5).map((item: MenuItem, index: number) => {
+              const matchedRoles = userPermissions.filter(role => item.allowedRoleNames.includes(role.roleLabel));
+              if(matchedRoles.length >= 1 && item.isRequired){
+              return item.nestedMenu ?
+                <NestedListItem
+                  header={item.title}
+                  menuItems={item.nestedMenu}
+                  key={index}
+                  imgUrl={item.imgUrl}
+                />
+                :
+                <MenuListItem
+                  title={item.title}
+                  key={index}
+                  id={index}
+                  to={item.to}
+                  imgUrl={item.imgUrl}
+                  imgUrlActive={item.imgUrlActive}
+                  muiIcon={item.muiIcon}
+                  disabled={item.disabled}
+                />
+              }
+            })
+          }
+          {open && (
+            <Typography sx={{ padding: '12px 20px 6px', marginTop: '8px', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#5a7a94' }}>
+              Admin
+            </Typography>
+          )}
+          {
+            menuItems.slice(5).map((item: MenuItem, index: number) => {
+              const matchedRoles = userPermissions.filter(role => item.allowedRoleNames.includes(role.roleLabel));
+              if(matchedRoles.length >= 1 && item.isRequired){
+              return item.nestedMenu ?
+                <NestedListItem
+                  header={item.title}
+                  menuItems={item.nestedMenu}
+                  key={index + 5}
+                  imgUrl={item.imgUrl}
+                />
+                :
+                <MenuListItem
+                  title={item.title}
+                  key={index + 5}
+                  id={index + 5}
+                  to={item.to}
+                  imgUrl={item.imgUrl}
+                  imgUrlActive={item.imgUrlActive}
+                  muiIcon={item.muiIcon}
+                  disabled={item.disabled}
+                />
+              }
+            })
+          }
+      </StyledList>
+      <button type="button" className={styles.compactToggle} onClick={handleDrawerToggle} style={{ marginTop: 'auto', borderTop: '1px solid #2e4050', background: 'none', border: 'none', padding: 0, font: 'inherit', color: 'inherit', cursor: 'pointer', width: '100%' }} aria-label={open ? 'Collapse sidebar' : 'Expand sidebar'}>
+        {open && <span>Compact mode</span>}
+        {open ? <ChevronLeftIcon sx={{ fontSize: 16, color: '#4a5568' }} /> : <ChevronRightIcon sx={{ fontSize: 16, color: '#4a5568' }} />}
+      </button>
     </Drawer>
   )
 }

--- a/src/components/elements/Search/FilterReview.tsx
+++ b/src/components/elements/Search/FilterReview.tsx
@@ -45,18 +45,28 @@ const FilterReview = ({
   }
 
   const StyledToggleButtonGroup = styled(ToggleButtonGroup)(({ theme }) => ({
-    marginLeft: '20px',
-    marginRight: '20px',
-    maxHeight: '40px',
+    marginLeft: '8px',
+    borderRadius: '5px',
+    overflow: 'hidden',
+    border: '1px solid #ddd7ce',
     '& .MuiToggleButtonGroup-grouped': {
       textTransform: 'none',
+      border: 'none',
+      borderRadius: '0 !important',
+      fontSize: '12px',
+      fontWeight: 600,
+      fontFamily: '"DM Sans", sans-serif',
+      padding: '5px 12px',
+      minHeight: 'auto',
+      lineHeight: 'normal',
+      color: '#8a94a6',
+      backgroundColor: '#eeeae4',
     },
     '& .MuiToggleButton-root.MuiButtonBase-root.Mui-selected': {
       color: '#fff',
-
-      backgroundColor: '#337ab7',
+      backgroundColor: '#1a2133',
       '&:hover': {
-        backgroundColor: '#549ad8',
+        backgroundColor: '#252d42',
       }
     }
   }));
@@ -199,28 +209,28 @@ const FilterReview = ({
 }
 
   return (
-    <Row className="pb-2 pt-2">
-      <Col className="d-flex my-auto"><h4><strong>{`${count}`} people found using filters</strong></h4></Col>
-      <Col>
-      {
-        <RoleSplitDropdown></RoleSplitDropdown>
-
-      }
-      </Col>
+    <div className={styles.resultsHeader}>
+      <div className={styles.resultsCount}>
+        <span className={styles.resultsCountNumber}>{count.toLocaleString()}</span>{' '}
+        people found using filters
+      </div>
+      <div>
+        <RoleSplitDropdown />
+      </div>
       {showPendingToggle ?
-      <Col className="d-flex flex-row">
-      <div>Show only people with <br /> pending suggestions</div>
-      <StyledToggleButtonGroup
-        color="primary"
-        value={filterByPending}
-        exclusive
-        onChange={handleChange}
-      >
-        <ToggleButton value={false}>No</ToggleButton>
-        <ToggleButton value={true}>Yes</ToggleButton>
-      </StyledToggleButtonGroup>
-      </Col> : ""}
-    </Row>
+      <div className={styles.pendingFilter}>
+        <span className={styles.pendingFilterLabel}>Show only people with pending suggestions</span>
+        <StyledToggleButtonGroup
+          color="primary"
+          value={filterByPending}
+          exclusive
+          onChange={handleChange}
+        >
+          <ToggleButton value={false}>No</ToggleButton>
+          <ToggleButton value={true}>Yes</ToggleButton>
+        </StyledToggleButtonGroup>
+      </div> : ""}
+    </div>
   )
 }
 

--- a/src/components/elements/Search/ProxyBadge.tsx
+++ b/src/components/elements/Search/ProxyBadge.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 import Badge from 'react-bootstrap/Badge';
 
 const ProxyBadge: React.FC = () => (
-  <Badge
-    pill
-    style={{
-      backgroundColor: '#17a2b8',
-      color: '#fff',
-      fontSize: '10px',
-      fontWeight: 600,
-      marginLeft: '8px',
-      verticalAlign: 'middle',
-    }}
-  >
-    PROXY
-  </Badge>
+    <Badge
+        pill
+        style={{
+            backgroundColor: '#2563a8',
+            color: '#fff',
+            fontSize: '11px',
+            fontWeight: 600,
+            marginLeft: '8px',
+            verticalAlign: 'middle',
+        }}
+    >
+        Proxy
+    </Badge>
 );
 
 export default ProxyBadge;

--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { identityFetchAllData, curateIdsFromSearch, identityFetchPaginatedData, updateFilters, clearFilters, updateFilteredIds, updateFilteredIdentities, identityClearAllData, F, updateIndividualPersonReportCriteria, showEvidenceByDefault, updateAuthorFilter, updateScopeFilter } from '../../../redux/actions/actions'
+import { identityFetchAllData, curateIdsFromSearch, identityFetchPaginatedData, updateFilters, clearFilters, updateFilteredIds, updateFilteredIdentities, identityClearAllData, F, updateIndividualPersonReportCriteria, showEvidenceByDefault, updateAuthorFilter } from '../../../redux/actions/actions'
 import styles from './Search.module.css'
 import { useSelector, useDispatch } from "react-redux";
 import { useRouter } from "next/router";
@@ -8,26 +8,34 @@ import appStyles from '../App/App.module.css';
 import publicationStyles from '../Publication/Publication.module.css';
 import { useSession } from 'next-auth/client';
 import SearchBar from "./SearchBar";
-import FilterReview from "./FilterReview";
-import ScopeFilterCheckbox from './ScopeFilterCheckbox';
 import fetchWithTimeout from "../../../utils/fetchWithTimeout";
+import { updatePubFiltersFromSearch } from "../../../redux/actions/actions";
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import { styled } from '@mui/material/styles';
 import { Table,Button} from "react-bootstrap";
-import SkeletonTable from "../Common/SkeletonTable";
+import SplitDropdown from "../Dropdown/SplitDropdown";
+import Loader from "../Common/Loader";
 import { reciterConfig } from "../../../../config/local";
-import { useHistory } from "react-router-dom";
 import { allowedPermissions, allowedSettings, dropdownItemsReport, dropdownItemsSuper, numberFormation, getCapabilities } from "../../../utils/constants"
-import { isPersonInScope, isProxyFor } from '../../../utils/scopeResolver';
-import ProxyBadge from './ProxyBadge';
-import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
-import Tooltip from '@mui/material/Tooltip';
 //import {RoleManagerHelper} from  "../../../utils/RoleManagerHelper"
+import Profile from "../Profile/Profile";
+import ProxyBadge from './ProxyBadge';
+import ScopeFilterCheckbox from './ScopeFilterCheckbox';
+import { isProxyFor } from '../../../utils/scopeResolver';
 
 const Search = () => {
 
   const [session, loading] = useSession();
 
+  // Phase 9: Parse scope/proxy data and derive capabilities
+  const scopeData = session?.data?.scopeData ? JSON.parse(session.data.scopeData) : null;
+  const proxyPersonIds = session?.data?.proxyPersonIds ? JSON.parse(session.data.proxyPersonIds) : [];
+  const userRoles = session?.data?.userRoles ? JSON.parse(session.data.userRoles) : [];
+  const caps = getCapabilities(userRoles);
+  const showScopeFilter = caps.canCurate.scoped && !caps.canCurate.all;
+
   const router = useRouter()
-  const history = useHistory();
   const dispatch = useDispatch()
 
   const identityAllData = useSelector((state) => state.identityAllData)
@@ -37,7 +45,7 @@ const Search = () => {
   const identityPaginatedFetching = useSelector((state) => state.identityPaginatedFetching)
   const filters = useSelector((state) => state.filters)
   const updatedAdminSettings = useSelector((state) => state.updatedAdminSettings)
-
+  
 
   const errors = useSelector((state) => state.errors)
 
@@ -50,7 +58,7 @@ const Search = () => {
   const [isUserRole, setIsuserRole] = useState([])
 
   const [page, setPage] = useState(1)
-  const [count, setCount] = useState(20)
+  const [count, setCount] = useState(100)
   const [filterByPending, setFilterByPending] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
   const [countAllData, setCountAllData] = useState(0);
@@ -66,38 +74,30 @@ const Search = () => {
   const [findPeopleLabels, setFindPeopleLabels] = useState([])
   const [nameOrcwidLabel, setNameOrcwidLabel] = useState()
 
-  // Scope filter state from Redux
-  const showOnlyScopeFiltered = useSelector((state) => state.showOnlyScopeFiltered);
-
-  // Derive scope capabilities from session
-  const userRoles = session?.data?.userRoles ? JSON.parse(session.data.userRoles) : [];
-  const caps = getCapabilities(userRoles);
-  const scopeData = session?.data?.scopeData ? JSON.parse(session.data.scopeData) : null;
-  const proxyPersonIds = session?.data?.proxyPersonIds
-    ? JSON.parse(session.data.proxyPersonIds)
-    : [];
-  const showScopeCheckbox = caps.canCurate.scoped && !caps.canCurate.all;
+  const [showProfile, setShowprofile] = useState(false);
+  const [showProfileID, setShowprofileID] = useState("");
+  const [headShot, setHeadShot] = useState([]);
+  const [viewProfileLabels, setViewProfileLabels] = useState([])
+  const [selectedAction, setSelectedAction] = useState("Curate Publications")
+  const [scopeFilterChecked, setScopeFilterChecked] = useState(true); // Default checked for scoped curators (D-14)
 
   //ref
   const searchValue = useRef()
 
   useEffect(() => {
     dispatch(showEvidenceByDefault(null))
-
     dispatch(clearFilters())
-    let adminSettings = JSON.parse(session.adminSettings);
     var viewAttributes = [];
     if (updatedAdminSettings.length > 0) {
       // updated settings from manage settings page
       let updatedData = updatedAdminSettings.find(obj => obj.viewName === "findPeople")
-      viewAttributes = typeof updatedData.viewAttributes === "string"
-        ? JSON.parse(updatedData.viewAttributes)
-        : updatedData.viewAttributes;
+      viewAttributes = updatedData.viewAttributes;
 
       let cwidLabel = viewAttributes.find(data => data.labelUserKey === "personIdentifier")
       setNameOrcwidLabel(cwidLabel)
-    } else {
+    } else if (session?.adminSettings) {
       // regular settings from session
+      let adminSettings = JSON.parse(session.adminSettings);
       let data = adminSettings.find(obj => obj.viewName === "findPeople")
       viewAttributes = JSON.parse(data.viewAttributes)
       let cwidLabel = viewAttributes.find(data => data.labelUserKey === "personIdentifier")
@@ -108,85 +108,228 @@ const Search = () => {
     setFindPeopleLabels(viewAttributes)
 
     let userPermissions = JSON.parse(session.data.userRoles);
-
-    // Use capability model from Plan 01
-    const caps = getCapabilities(userPermissions);
-    setIsCuratorSelf(caps.canCurate.self && !caps.canCurate.all);
-    setIsCuratorAll(caps.canCurate.all);
-    setIsReporterAll(caps.canReport);
-    setIsSuperUser(caps.canManageUsers);
-
-    if (caps.canCurate.self && !caps.canCurate.all) {
-      setLoggedInPersonIdentifier(caps.canCurate.personIdentifier);
+    //RoleManagerHelper.showOrHideCurateReportMenu(userPermissions,allowedPermissions);
+    if (userPermissions && userPermissions.length === 1 && userPermissions.some(role => role.roleLabel === allowedPermissions.Reporter_All)) {
+        setDropdownTitle("Create Report");
+        setDropdownMenuItems([]);
+        setIsReporterAll(true);
+        setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    } else if (userPermissions && userPermissions.length === 1 && userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_All)) {
+        setDropdownTitle("Curate Publications");
+        let dropDownMenuItems = [{ title: 'Create Reports', to: ''},{title: 'View Profile', to:''}];
+        setDropdownMenuItems(dropDownMenuItems);
+        setIsCuratorAll(true);
+        setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    }else if (userPermissions && userPermissions.length === 1 && userPermissions.some(role => role.roleLabel === allowedPermissions.Superuser)) {
+        setDropdownTitle("Curate Publications");
+        let dropDownMenuItems = [{ title: 'Create Reports', to: ''},{title: 'View Profile', to:''}];
+        setDropdownMenuItems(dropDownMenuItems);
+        setIsSuperUser(true)
+        setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
     }
-
-    // UIBUG-01: No "Curate publications" in dropdown for ANY user
-    // Dropdown shows only "Create Reports" as a simple button
-    setDropdownTitle("Create Reports");
-    setDropdownMenuItems([]);
+    else if (userPermissions && userPermissions.length === 1 && userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self)) {
+      setDropdownTitle("Curate Publications");
+      setDropdownMenuItems([{title: 'View Profile', to:''}]);
+      setIsCuratorSelf(true)
+      setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    }
+    else if(userPermissions.some(role => role.roleLabel === allowedPermissions.Superuser ))
+    {
+      setDropdownTitle("Curate Publications");
+      let dropDownMenuItems = [{ title: 'Create Reports', to: ''},{title: 'View Profile', to:''}];
+      setDropdownMenuItems(dropDownMenuItems);
+      setIsCuratorSelf(true);
+      setIsReporterAll(true);
+      setIsSuperUser(true);
+      setIsCuratorAll(true);
+      setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    }
+    else if (userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self ) 
+      && userPermissions.some(role => role.roleLabel === allowedPermissions.Reporter_All )
+      && userPermissions.some(role => role.roleLabel === allowedPermissions.Superuser )) {
+      setDropdownTitle("Curate Publications");
+      let dropDownMenuItems = [{ title: 'Create Reports', to: ''},{title: 'View Profile', to:''}];
+      setDropdownMenuItems(dropDownMenuItems);
+      setIsCuratorSelf(true);
+      setIsReporterAll(true);
+      setIsSuperUser(true);
+      setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    } 
+    else if (userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self ) 
+      && userPermissions.some(role => role.roleLabel === allowedPermissions.Reporter_All )
+      && userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_All )) {
+      setDropdownTitle("Curate Publications");
+      let dropDownMenuItems = [{ title: 'Create Reports', to: ''},{title: 'View Profile', to:''}];
+      setDropdownMenuItems(dropDownMenuItems);
+      setIsCuratorSelf(true);
+      setIsReporterAll(true);
+      setIsCuratorAll(true);
+      setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    }
+    else if (userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_All ) 
+      && userPermissions.some(role => role.roleLabel === allowedPermissions.Reporter_All) 
+      && userPermissions.some(role => role.roleLabel === allowedPermissions.Superuser  )) {
+      setDropdownTitle("Curate Publications");
+      let dropDownMenuItems = [{ title: 'Create Reports', to: ''},{title: 'View Profile', to:''}];
+      setDropdownMenuItems(dropDownMenuItems);
+      setIsReporterAll(true)  
+      setIsCuratorAll(true);
+      setIsSuperUser(true);
+      setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    }  
+    else if (userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_All ) 
+      && userPermissions.some(role => role.roleLabel === allowedPermissions.Reporter_All )) {
+        setDropdownTitle("Curate Publications");
+        let dropDownMenuItems = [{ title: 'Create Reports', to: ''},{title: 'View Profile', to:''}];
+        setDropdownMenuItems(dropDownMenuItems);
+        setIsReporterAll(true)  
+        setIsCuratorAll(true);
+        setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    }
+    else if (userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self ) 
+      && userPermissions.some(role => role.roleLabel === allowedPermissions.Reporter_All )) {
+      setDropdownTitle("Curate Publications");
+      let dropDownMenuItems = [{ title: 'View Profile', to: ''}];
+      setDropdownMenuItems(dropDownMenuItems);
+      setIsCuratorSelf(true);
+      setIsReporterAll(true)
+      setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    } 
+    else if (userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self )
+    && userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_All )) {
+    setDropdownTitle("Curate Publications");
+      let dropDownMenuItems = [{title: 'View Profile', to:''}];
+      setDropdownMenuItems(dropDownMenuItems);
+      setIsCuratorSelf(true);
+      setIsCuratorAll(true)
+      }
+    // Phase 9: Curator_Scoped handling -- same dropdown behavior as Curator_All
+    else if (userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Scoped)) {
+      setDropdownTitle("Curate Publications");
+      let dropDownMenuItems = [{ title: 'Create Reports', to: ''},{title: 'View Profile', to:''}];
+      setDropdownMenuItems(dropDownMenuItems);
+      setIsCuratorAll(true); // Scoped curators get same dropdown actions as Curator_All
+      setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    }
+    else { // when CWID has more than 1 role or multiple roles
+      setDropdownTitle("Curate Publications");
+      let dropDownMenuItems = [{ title: 'Create Reports', to: ''},{title: 'View Profile', to:''}];
+      setDropdownMenuItems(dropDownMenuItems);
+      setIsSuperUser(true);
+      setLoggedInPersonIdentifier(userPermissions[0].personIdentifier);
+    }
 
     // if (identityAllData.length === 0) {
       fetchPaginatedData()
       fetchCount()
     // }
+    fetchAllAdminSettings()
   }, [])
 
-  // Pre-check scope filter from query param (e.g., from "Curate Publications" nav link)
+  // Re-derive labels when admin settings arrive in Redux (async)
   useEffect(() => {
-    if (router.query.scopeFilter === 'true' && showScopeCheckbox) {
-      dispatch(updateScopeFilter(true));
+    if (updatedAdminSettings && updatedAdminSettings.length > 0) {
+      let updatedData = updatedAdminSettings.find(obj => obj.viewName === "findPeople")
+      if (updatedData) {
+        let viewAttributes = updatedData.viewAttributes;
+        let cwidLabel = viewAttributes.find(data => data.labelUserKey === "personIdentifier")
+        setNameOrcwidLabel(cwidLabel)
+        setFindPeopleLabels(viewAttributes)
+      }
     }
-  }, [router.query.scopeFilter])
+  }, [updatedAdminSettings])
 
-  const handleScopeFilterChange = (checked) => {
-    dispatch(updateScopeFilter(checked));
-    // Re-fetch with scope filter applied
-    if (checked && scopeData) {
-      let scopeFilters = {};
-      if (scopeData.personTypes) {
-        scopeFilters = { ...scopeFilters, personTypes: scopeData.personTypes };
-      }
-      if (scopeData.orgUnits) {
-        scopeFilters = { ...scopeFilters, orgUnits: scopeData.orgUnits };
-      }
-      // Include proxy matches via OR logic
-      if (proxyPersonIds.length > 0) {
-        scopeFilters = { ...scopeFilters, proxyPersonIds: proxyPersonIds };
-      }
-      let updatedFilters = { ...filters, ...scopeFilters };
-      let request = {
-        filters: { ...updatedFilters },
-        limit: count,
-        offset: 0
-      };
-      dispatch(updateFilters(updatedFilters));
-      dispatch(identityFetchAllData(request));
-      setPage(1);
-    } else if (!checked) {
-      // Reset to unfiltered paginated data
-      dispatch(clearFilters());
-      fetchPaginatedData();
-      fetchCount();
+  // Phase 9: Re-trigger search when scope filter checkbox is toggled
+  const scopeFilterInitRef = useRef(true);
+  useEffect(() => {
+    // Skip the initial render (the main useEffect handles initial load)
+    if (scopeFilterInitRef.current) {
+      scopeFilterInitRef.current = false;
+      return;
     }
-  };
+    // Build scope-aware filters and re-search
+    let updatedFilters = { ...filters };
+    if (showScopeFilter && scopeFilterChecked && scopeData) {
+      updatedFilters = {
+        ...updatedFilters,
+        scopeOrgUnits: scopeData.orgUnits || [],
+        scopePersonTypes: scopeData.personTypes || [],
+        proxyPersonIds: proxyPersonIds,
+      };
+    } else {
+      // Remove scope filters when unchecked
+      const { scopeOrgUnits, scopePersonTypes, proxyPersonIds: _p, ...rest } = updatedFilters;
+      updatedFilters = rest;
+    }
+    let request = {
+      filters: { ...updatedFilters },
+      limit: count,
+      offset: 0
+    };
+    dispatch(updateFilters(updatedFilters));
+    dispatch(identityFetchAllData(request));
+    setPage(1);
+  }, [scopeFilterChecked])
+
+  const fetchAllAdminSettings = () => {
+    const request = {};
+    fetch(`/api/db/admin/settings`, {
+      credentials: "same-origin",
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        "Content-Type": "application/json",
+        'Authorization': reciterConfig.backendApiKey
+      },
+      body: JSON.stringify(request),
+    }).then(response => response.json())
+      .then(data => {
+        let parsedSettingsArray = [];
+        data.map((obj, index1) => {
+          let a = JSON.stringify(obj.viewAttributes)
+          let b = JSON.parse(a);
+          let c = typeof(b) === "string" ? JSON.parse(b) : b
+          let parsedSettings = {
+            viewName : obj.viewName,
+            viewAttributes: c,
+            viewLabel: obj.viewLabel
+          }
+          parsedSettingsArray.push(parsedSettings)
+        })
+        var viewAttributes = [];
+        var headShotViewAttributes = [];
+
+        let updatedData = parsedSettingsArray.find(obj => obj.viewName === "viewProfile")
+        let headShotData = parsedSettingsArray.find(obj => obj.viewName === "headshot")
+
+        viewAttributes = updatedData.viewAttributes;
+        headShotViewAttributes = headShotData.viewAttributes
+        setViewProfileLabels(viewAttributes)
+        setHeadShot(headShotViewAttributes)
+      })
+      .catch(error => {
+        // setLoading(false);
+      });
+  }
+
 
   const fetchIdentityData = () => {
     dispatch(identityFetchAllData(filters));
   }
 
   const fetchPaginatedData = (newCount) => {
-    const options = showScopeCheckbox ? { includeScopeData: true } : {};
-    dispatch(identityFetchPaginatedData(page, newCount ? newCount : count, filters, options))
+    if (newCount === 'reset') {
+      let filters = {}
+      dispatch(identityFetchPaginatedData(1, count, filters))
+    } else {
+      dispatch(identityFetchPaginatedData(page, newCount ? newCount : count, filters))
+    }
   }
 
 
   const handlePaginationUpdate = (page) => {
     setPage(page)
-
-    if (Object.keys(filters).length === 0) {
-      const options = showScopeCheckbox ? { includeScopeData: true } : {};
-      dispatch(identityFetchPaginatedData(page, count, filters, options))
-    }
+      dispatch(identityFetchPaginatedData(page, count, filters))
   }
 
   const handleCountUpdate = (count) => {
@@ -282,18 +425,14 @@ const Search = () => {
       updatedFilters = { ...updatedFilters, personTypes: [...personTypes] };
     }
 
-    // Apply scope filters when scope checkbox is checked
-    if (showOnlyScopeFiltered && scopeData) {
-      if (scopeData.personTypes) {
-        updatedFilters = { ...updatedFilters, personTypes: scopeData.personTypes };
-      }
-      if (scopeData.orgUnits) {
-        updatedFilters = { ...updatedFilters, orgUnits: scopeData.orgUnits };
-      }
-      // Include proxy matches via OR logic
-      if (proxyPersonIds.length > 0) {
-        updatedFilters = { ...updatedFilters, proxyPersonIds: proxyPersonIds };
-      }
+    // Phase 9: Add scope filter parameters when scope filter is active
+    if (showScopeFilter && scopeFilterChecked && scopeData) {
+      updatedFilters = {
+        ...updatedFilters,
+        scopeOrgUnits: scopeData.orgUnits || [],
+        scopePersonTypes: scopeData.personTypes || [],
+        proxyPersonIds: proxyPersonIds,
+      };
     }
 
     let request = {
@@ -305,6 +444,7 @@ const Search = () => {
     dispatch(updateFilters(updatedFilters));
     dispatch(identityFetchAllData(request));
     setPage(1);
+    setFilterByPending(false);
   }
 
   const handlePendingFilterUpdate = (value) => {
@@ -322,6 +462,9 @@ const Search = () => {
   }
 
   const onClickProfile = (personIdentifier) => {
+    // setShowprofile(true);
+    // setShowprofileID(personIdentifier)
+   
     router.push(`/curate/${personIdentifier}`);
     if (identityAllData && !identityAllFetching) {
       dispatch(identityClearAllData())
@@ -329,9 +472,51 @@ const Search = () => {
     }
   }
 
+  const handleClose = () => setShowprofile(false);
+  const handleShow = () => setShowprofile(true);
+
+  const handleGoAction = () => {
+    dispatch(updatePubFiltersFromSearch());
+    if (selectedAction === "Curate Publications") {
+      dispatch(curateIdsFromSearch(identities.paginatedIdentities))
+      router.push({ pathname: '/curate' })
+    } else if (selectedAction === "Create Reports") {
+      router.push('/report');
+    }
+  }
+
+  const StyledToggleButtonGroup = styled(ToggleButtonGroup)(({ theme }) => ({
+    marginLeft: '8px',
+    borderRadius: '5px',
+    overflow: 'hidden',
+    border: '1px solid #ddd7ce',
+    '& .MuiToggleButtonGroup-grouped': {
+      textTransform: 'none',
+      border: 'none',
+      borderRadius: '0 !important',
+      fontSize: '12px',
+      fontWeight: 600,
+      fontFamily: '"DM Sans", sans-serif',
+      padding: '5px 12px',
+      minHeight: 'auto',
+      lineHeight: 'normal',
+      color: '#8a94a6',
+      backgroundColor: '#eeeae4',
+    },
+    '& .MuiToggleButton-root.MuiButtonBase-root.Mui-selected': {
+      color: '#fff',
+      backgroundColor: '#1a2133',
+      '&:hover': {
+        backgroundColor: '#252d42',
+      }
+    }
+  }));
+
   const resetData = () => {
     dispatch(clearFilters())
-    fetchPaginatedData()
+    setPage(1)
+    setCount(100)
+    fetchPaginatedData('reset')
     fetchCount()
   }
 
@@ -363,9 +548,12 @@ const Search = () => {
     }
   }
 
-  const redirectToCurate = (isFor, data) => {
-
-    // if()
+  const redirectToCurate = (isFor, data, title) => {
+    if(title === "View Profile"){
+      // let isLoggedInUser =  data === loggedInPersonIdentifier
+      setShowprofile(true);
+      setShowprofileID(data.personIdentifier)
+    }else {
     if (isFor === "individual") {
       router.push({
         pathname: `/curate/${data}`,
@@ -384,6 +572,7 @@ const Search = () => {
       })
     }
   }
+  }
 
   // Spinner when navigating between pages
   const isDisplayLoaderTable = () => {
@@ -394,17 +583,51 @@ const Search = () => {
   }
   
   const RoleSplitDropdown = (identity) => {
-    // UIBUG-01: "Curate publications" removed from dropdown for ALL users
-    // Remaining action: Create Reports button only
-    return (
-      <Button
-        className="secondary"
-        variant="secondary"
-        onClick={() => redirectToCurate("report", identity.identity)}
-      >
-        {"Create Reports"}
-      </Button>
-    );
+    
+    if(dropdownTitle && dropdownTitle =='Curate Publications' && isCuratorSelf && !isReporterAll && !isCuratorAll && !isSuperUser
+        && (loggedInPersonIdentifier === identity.identity.personIdentifier || isProxyFor(proxyPersonIds, identity.identity.personIdentifier)))
+    {
+        return <Button className="secondary" variant="secondary" onClick={() => redirectToCurate("individual", identity.identity.personIdentifier)}>{"Curate Publications"}</Button>
+    }
+    else if(dropdownTitle && dropdownTitle =='Create Report' && isReporterAll && !isCuratorAll && !isSuperUser && !isCuratorSelf)
+    {
+        if (isProxyFor(proxyPersonIds, identity.identity.personIdentifier)) {
+          return <Button className="secondary" variant="secondary" onClick={() => redirectToCurate("individual", identity.identity.personIdentifier)}>{"Curate Publications"}</Button>
+        }
+        return <Button className="secondary" variant="secondary" onClick={() => redirectToCurate("report", identity.identity)}>{"Create Reports"}</Button>
+    }
+    else if(dropdownTitle && dropdownTitle =='Curate Publications' && isCuratorAll && !isReporterAll && !isSuperUser && !isCuratorSelf) 
+    {
+        return <Button className="secondary" variant="secondary" onClick={() => redirectToCurate("individual", identity.identity.personIdentifier)}>{"Curate Publications"}</Button>
+    }
+    else if(isCuratorSelf && isReporterAll && !isCuratorAll && !isSuperUser)
+    {
+      const canCurateRow = identity && (identity.identity.personIdentifier === loggedInPersonIdentifier || isProxyFor(proxyPersonIds, identity.identity.personIdentifier));
+      return  <SplitDropdown
+        title={canCurateRow ? "Curate Publications" : "Create Reports"}
+        onDropDownClick={canCurateRow ? (e) => redirectToCurate("individual",identity.identity.personIdentifier,e) : (e) => redirectToCurate("report", identity.identity.personIdentifier,e)}
+        id={`curate-publications_${identity.identity.personIdentifier}`}
+        listItems={canCurateRow ? dropdownMenuItems : []}
+        secondary={true}
+        onClick={canCurateRow ? (e) => redirectToCurate("report", identity.identity,e): "undefined"}/>
+    }
+    else if((isCuratorAll && isReporterAll && isCuratorSelf) ||isSuperUser || (isCuratorAll && isReporterAll))
+    {
+      return  <SplitDropdown
+        title={"Curate Publications"}
+        //{isUserRole && isUserRole === allowedPermissions.Reporter_All ? "Create Reports" : "Curate Publications"}
+        // to={`/curate/${identity.personIdentifier}`}
+        //onDropDownClick={isUserRole && isUserRole === allowedPermissions.Reporter_All ? () => redirectToCurate("report",identity.personIdentifier) : () => redirectToCurate("individual", identity.personIdentifier)}
+        onDropDownClick={(e) => redirectToCurate("individual",identity.identity.personIdentifier,e)}
+        id={`curate-publications_${identity.identity.personIdentifier}`}
+        listItems={dropdownMenuItems} 
+        secondary={true}
+        onClick={(e) => redirectToCurate("report", identity.identity,e)}/>
+    }
+    else
+       return null;
+  
+  
   }
 
 
@@ -416,52 +639,36 @@ const Search = () => {
   if (paginatedIdentities?.length > 0) {
     // setCurateIds(paginatedIdentities);
     tableBody = paginatedIdentities.map(function (identity, identityIndex) {
-      // Determine if this person is in scope for scoped curators
-      const personInScope = caps.canCurate.all || isSuperUser || (caps.canCurate.scoped && scopeData && isPersonInScope(
-        scopeData,
-        identity.primaryOrganizationalUnit,
-        identity.PersonPersonTypes?.map(pt => pt.personType) || []
-      )) || isProxyFor(proxyPersonIds, identity.personIdentifier);
-
-      // Name click handler: in-scope goes to curate, out-of-scope goes to report
-      const handleNameClick = () => {
-        if (isCuratorSelf && identity.personIdentifier !== loggedInPersonIdentifier) {
-          redirectToCurate("report", identity);
-        } else if (caps.canCurate.all || isSuperUser || (caps.canCurate.scoped && personInScope)) {
-          onClickProfile(identity.personIdentifier);
-        } else {
-          redirectToCurate("report", identity);
-        }
-      };
-
       return <tr key={identityIndex}>
         <td key={`${identityIndex}__name`} width="30%">
-          <Name identity={identity} nameOrcwidLabel={nameOrcwidLabel?.labelUserView} onClickProfile={handleNameClick} isProxy={isProxyFor(proxyPersonIds, identity.personIdentifier)}></Name>
+        {
+
+          isCuratorSelf ?
+          <Name identity={identity} nameOrcwidLabel={nameOrcwidLabel?.labelUserView} onClickProfile={identity && identity.personIdentifier === loggedInPersonIdentifier ? ()=> onClickProfile(identity.personIdentifier): () => redirectToCurate("report", identity)} proxyPersonIds={proxyPersonIds}></Name>
+          :
+          <Name identity={identity} nameOrcwidLabel={nameOrcwidLabel?.labelUserView} onClickProfile={ dropdownTitle && dropdownTitle === 'Curate Publications' ? () => onClickProfile(identity.personIdentifier) :() => redirectToCurate("report", identity)} proxyPersonIds={proxyPersonIds}></Name>
+        }
         </td>
-        <td key={`${identityIndex}__orgUnit`} width="20%">
+        <td key={`${identityIndex}__orgUnit`} width="20%" className={styles.colOrg}>
           {identity.primaryOrganizationalUnit && <div>{identity.primaryOrganizationalUnit}</div>}
         </td>
-        <td key={`${identityIndex}__institution`} width="20%">
+        <td key={`${identityIndex}__institution`} width="20%" className={styles.colInst}>
           {identity.primaryInstitution && <div>{identity.primaryInstitution}</div>}
         </td>
         {isCuratorAll || isSuperUser  ?
-        <td key={`${identityIndex}__pending`} width="10%">
-          {identity.countPendingArticles && <div>{identity.countPendingArticles}</div>}
+        <td key={`${identityIndex}__pending`} width="10%" className={styles.colPending}>
+          {identity.countPendingArticles ?
+            <span className={styles.pendingBadgeHas}>{identity.countPendingArticles}</span> :
+            <span className={styles.pendingBadgeNone}>0</span>
+          }
         </td>
          : ""}
-        <td key={`${identityIndex}__dropdown`} width="20%">
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            {personInScope && (caps.canCurate.all || caps.canCurate.scoped || isSuperUser) && (
-              <Tooltip title="Curate publications">
-                <EditOutlinedIcon
-                  titleAccess="Curate publications"
-                  sx={{ color: '#337ab7', fontSize: 20, cursor: 'pointer', minWidth: 44, minHeight: 44, padding: '12px' }}
-                  onClick={() => router.push(`/curate/${identity.personIdentifier}`)}
-                />
-              </Tooltip>
-            )}
-            <RoleSplitDropdown identity={identity}></RoleSplitDropdown>
-          </div>
+        <td key={`${identityIndex}__dropdown`} width="20%" className={styles.actionsCell}>
+          <button type="button" className={styles.actionLink} style={{fontWeight:500}} onClick={() => onClickProfile(identity.personIdentifier)}>Curate</button>
+          <span className={styles.actionDot}>·</span>
+          <button type="button" className={styles.actionLink} onClick={() => redirectToCurate("report", identity)}>Reports</button>
+          <span className={styles.actionDot}>·</span>
+          <button type="button" className={styles.actionLink} onClick={() => { setShowprofileID(identity.personIdentifier); handleShow(); }}>Profile</button>
         </td>
       </tr>;
     })
@@ -470,7 +677,9 @@ const Search = () => {
       <tr>
         <td colSpan="5">
           <p className={styles.noitemsList}>
-            No records found
+            {showScopeFilter && scopeFilterChecked
+              ? 'No people found matching your scope. Try unchecking the scope filter to see all results.'
+              : 'No records found'}
           </p>
         </td>
       </tr>
@@ -482,34 +691,70 @@ const Search = () => {
     <div className={appStyles.mainContainer}>
       <div className={styles.searchContentContainer}>
         <div className={styles.searchBar}>
-          <h1>Find People</h1>
+          <h1 style={{ paddingBottom: 10, marginBottom: 0 }}>Find People</h1>
           <SearchBar searchData={searchData} resetData={resetData} findPeopleLabels = {findPeopleLabels}/>
+          {showScopeFilter && (
+            <ScopeFilterCheckbox
+              checked={scopeFilterChecked}
+              onChange={(checked) => {
+                setScopeFilterChecked(checked);
+              }}
+            />
+          )}
           {(isDisplayLoader()) ?
             (
-              <SkeletonTable />
+              <Loader />
             ) : (
               <div>
-                <br />
-                {!filtersOn &&
-                  <div className="row">
-                    <div className="col-md-4">
-                      <h3><strong>{ numberFormation(totalCountUpdated)}</strong> people</h3>
+                <div className={styles.resultsBar}>
+                  <div className={styles.resultsCount}>
+                    <span className={styles.resultsCountNumber}>{numberFormation(totalCountUpdated)}</span>
+                    <span className={styles.resultsCountLabel}>{filtersOn ? 'people found using filters' : 'people'}</span>
+                  </div>
+                  {filtersOn && (
+                    <div className={styles.resultsRight}>
+                      {(isCuratorAll || isSuperUser) && (
+                        <div className={styles.pendingFilter}>
+                          <span className={styles.pendingFilterLabel}>Show only pending</span>
+                          <StyledToggleButtonGroup
+                            color="primary"
+                            value={filterByPending}
+                            exclusive
+                            onChange={(e, val) => { handlePendingFilterUpdate(val); }}
+                          >
+                            <ToggleButton value={false}>No</ToggleButton>
+                            <ToggleButton value={true}>Yes</ToggleButton>
+                          </StyledToggleButtonGroup>
+                        </div>
+                      )}
+                      <span className={styles.actionLabel}>Go to</span>
+                      <div className={styles.actionSelectWrap}>
+                        <select
+                          className={styles.actionSelect}
+                          value={selectedAction}
+                          onChange={(e) => setSelectedAction(e.target.value)}
+                        >
+                          <option value="Curate Publications">Curate Publications</option>
+                          {dropdownMenuItems.filter(i => i.title).map(item => (
+                            <option key={item.title} value={item.title}>{item.title}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <button className={styles.btnGo} onClick={handleGoAction}>
+                        Go
+                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
+                      </button>
                     </div>
-                  </div>}
-                {showScopeCheckbox && (
-                  <ScopeFilterCheckbox
-                    checked={showOnlyScopeFiltered}
-                    onChange={handleScopeFilterChange}
-                  />
-                )}
-                {filtersOn && <FilterReview count={totalCountUpdated}  onCurate={redirectToCurate} filterByPending={filterByPending} onToggle={handlePendingFilterUpdate} showPendingToggle = {isCuratorAll || isSuperUser} />}
+                  )}
+                </div>
                 <React.Fragment>
                   <Pagination total={totalCountUpdated} page={page}
                     count={count}
                     onChange={handlePaginationUpdate}
                     onCountChange={handleCountUpdate}
+                    merged
                   />
-                  {isDisplayLoaderTable() ? <SkeletonTable /> :
+                  {isDisplayLoaderTable() ? <Loader /> :
                     <div className="table-responsive">
                       <Table className={`${publicationStyles.h6fnhWdegPublicationsEvidenceTable} ${styles.table} table`}>
                         <thead>
@@ -532,6 +777,15 @@ const Search = () => {
                     onChange={handlePaginationUpdate}
                     onCountChange={handleCountUpdate}
                   />
+
+                  <Profile
+                    uid={showProfileID}
+                    modalShow={showProfile}
+                    handleShow={handleShow}
+                    handleClose={handleClose}
+                    viewProfileLabels={viewProfileLabels}
+                    headShotLabelData = {headShot}
+                  />
                 </React.Fragment>
               </div>
             )
@@ -543,36 +797,28 @@ const Search = () => {
 }
 
 function Name(props) {
-  let nameArray = []
-  let imageUrl = ''
-  if (props.identity.identityImageEndpoint !== undefined) {
-    if (props.identity.identityImageEndpoint.length > 0)
-      imageUrl = props.identity.identityImageEndpoint
-    else
-      imageUrl = '../../../images/generic-headshot.png'
-  }
   let firstName = props.identity.firstName ?? ''
   let middleName = props.identity.middleName ?? ''
   let lastName = props.identity.lastName ?? ''
-  
 
-  if (props.identity.firstName !== undefined ) {
-    const nameString = `${firstName}  ${middleName} ${lastName}`
-    nameArray.push(<p key="0"> <button className={`text-btn ${styles.btnLink}`} onClick={props.onClickProfile}>
-      <b>{nameString}</b>
-    </button>
-      {props.isProxy && <ProxyBadge />}
-      <br />
-      {props.identity.title && <>{props.identity.title}<br /></>}
-      {props.nameOrcwidLabel}: {props.identity.personIdentifier}</p>)
-
+  if (props.identity.firstName !== undefined) {
+    const nameString = `${firstName} ${middleName} ${lastName}`.replace(/\s+/g, ' ').trim()
+    return (
+      <div>
+        <div className={styles.nameRow}>
+          <button className={styles.btnLink} onClick={props.onClickProfile}>
+            {nameString}
+          </button>
+          {isProxyFor(props.proxyPersonIds, props.identity.personIdentifier) && <ProxyBadge />}
+        </div>
+        {props.identity.title && <div className={styles.personRole}>{props.identity.title}</div>}
+        <div className={styles.personCwid}>
+          <span className={styles.cwidLabel}>{props.nameOrcwidLabel}:</span> {props.identity.personIdentifier}
+        </div>
+      </div>
+    )
   }
-  if (props.title) {
-    nameArray.push(<p key="1"><span>{props.title}</span></p>)
-  }
-  return (
-    nameArray
-  )
+  return null
 }
 
 export default Search


### PR DESCRIPTION
## Summary
Continuing the dev_v2-re-restore unwind started in #696/#697/#698 for CurateIndividual/Profile/Publication. This batch covers the **sidebar** and **Find People (search)** that the user flagged next.

Restored verbatim from `b7210e6`:
- `src/components/elements/Navbar/SideNavbar.tsx` (+397 net lines — full nav with permission-based items, scope label, proxy badges, etc.)
- `src/components/elements/Search/Search.js` (+626 net lines — Find People page)
- `src/components/elements/Search/FilterReview.tsx`
- `src/components/elements/Search/ProxyBadge.tsx` (styling)
- `src/components/elements/Header/Header.tsx`

Patched v3 incompatibility on the four files that import `next-auth`:
```
- from "next-auth/react"
+ from "next-auth/client"
- const { data: session, status } = useSession(); const loading = status === "loading";
+ const [session, loading] = useSession();
```

`NestedListItem.tsx` and `SearchBar.tsx` were also touched in `2a0a747` but are functionally identical to `b7210e6` after the v3 patch, so left alone.

## Test plan
- [ ] CodeBuild green
- [ ] Sidebar shows the rich nav (icons, scope label, proxy indicators, etc. — whatever was in the prior screenshots)
- [ ] /search renders the rich Find People UI (not just the basic form)
- [ ] Filters and pagination work end-to-end