### PR TITLE
fix: allow RECITER_PUBMED_API_URL override for pubmed search

### DIFF
--- a/config/local.js
+++ b/config/local.js
@@ -112,10 +112,16 @@ export const reciterConfig = {
     /**
      * This endpoint is used to search pubmed. You need to have ReCiter-Pubmed-Retrieval tool conifgured. See https://github.com/wcmc-its/ReCiter-PubMed-Retrieval-Tool.git
      * for details.
+     *
+     * On prod these /pubmed/query-* routes live behind the same ingress as the
+     * ReCiter Spring Boot service, so RECITER_API_BASE_URL is sufficient. On
+     * dev the two services are separate (reciter-dev vs reciter-pubmed-dev),
+     * so RECITER_PUBMED_API_URL can override just these routes. Falls back to
+     * RECITER_API_BASE_URL when not set, preserving prod behavior.
      */
     reciterPubmed: {
-        searchPubmedEndpoint: process.env.RECITER_API_BASE_URL + '/pubmed/query-complex/',
-        searchPubmedCountEndpoint: process.env.RECITER_API_BASE_URL + '/pubmed/query-number-pubmed-articles/',
+        searchPubmedEndpoint: (process.env.RECITER_PUBMED_API_URL || process.env.RECITER_API_BASE_URL) + '/pubmed/query-complex/',
+        searchPubmedCountEndpoint: (process.env.RECITER_PUBMED_API_URL || process.env.RECITER_API_BASE_URL) + '/pubmed/query-number-pubmed-articles/',
     },
     /**
      * ReCiter-Publication-Manager uses Json web token for session management and validating a valid sesssion. This secret will be used to sign the web token.

--- a/kubernetes/k8-deployment.yaml
+++ b/kubernetes/k8-deployment.yaml
@@ -66,10 +66,16 @@ spec:
                 name: reciter-pm-secrets
                 key: RECITER_DB_HOST
            - name: RECITER_API_BASE_URL
-            valueFrom: 
+            valueFrom:
               secretKeyRef:
                 name: reciter-pm-secrets
-                key: RECITER_API_BASE_URL                           
+                key: RECITER_API_BASE_URL
+          - name: RECITER_PUBMED_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: reciter-pm-secrets
+                key: RECITER_PUBMED_API_URL
+                optional: true
          - name: LOGIN_PROVIDER
             value: SAML
           - name : ENTITY_ID


### PR DESCRIPTION
## Summary
PubMed search ("Add record from PubMed" on /curate/[id]) has never worked on dev. The `/pubmed/query-complex/` and `/pubmed/query-number-pubmed-articles/` endpoints live on the **ReCiter-PubMed-Retrieval-Tool** service, not the main ReCiter Spring Boot backend.

| | URL | `/pubmed/query-number-pubmed-articles/` |
|---|---|---|
| dev | `http://reciter-dev` | **404** |
| prod | `https://reciter.weill.cornell.edu` | 400 (route exists; rejects malformed body) |

Prod's ingress fans out both ReCiter and PubMed Retrieval Tool routes behind one hostname; dev's `reciter-dev` is the bare backend. This bug has existed since the original commit (`8b5bfb2`) and only became visible after PR #696 restored the rich CurateIndividual which exposes the search button.

## Change
- `config/local.js`: read `RECITER_PUBMED_API_URL` first, fall back to `RECITER_API_BASE_URL` (preserves prod behavior)
- `kubernetes/k8-deployment.yaml`: wire the new var through `secretKeyRef` with `optional: true` so prod (where the key won't exist) doesn't crash

## Operator action on dev (after merge)
```sh
kubectl patch secret reciter-pm-dev-secrets -n reciter \
  --type=json \
  -p='[{"op":"add","path":"/data/RECITER_PUBMED_API_URL","value":"'$(echo -n 'http://reciter-pubmed-dev' | base64)'"}]'
kubectl rollout restart deployment/reciter-pm-dev -n reciter
```

## Test plan
- [ ] CodeBuild green
- [ ] After secret patch + rollout, /curate/[id] → Add record from PubMed → search "cole curtis[au]" returns results (no failed toast)
- [ ] Prod's PubMed search continues to work (env var unset → fallback to RECITER_API_BASE_URL)