### PR TITLE
fix(reports): use articlesCount API field, not count

### DIFF
--- a/src/redux/actions/actions.js
+++ b/src/redux/actions/actions.js
@@ -1912,7 +1912,7 @@ export const getReportsResults = (requestBody, paginationUpdate = false) => disp
         })
         .then(data => {
 
-            if (data.count == 0 || Object.keys(data).length == 0) {
+            if (data.articlesCount == 0 || Object.keys(data).length == 0) {
                 dispatch({
                     type: methods.REPORTS_SEARCH_UPDATE,
                     payload: data,
@@ -1925,7 +1925,7 @@ export const getReportsResults = (requestBody, paginationUpdate = false) => disp
                     type: methods.REPORTS_SEARCH_PAGINATED_CANCEL_FETCHING
                 })
             } else {
-               
+
                 if (data && data.rows && data.rows.length > 0) {
                     let updatePmidRespData  = {
                         pmids: data.pmidList,
@@ -1957,7 +1957,7 @@ export const getReportsResults = (requestBody, paginationUpdate = false) => disp
 
                         dispatch({
                             type: methods.REPORTS_SEARCH_UPDATE,
-                            payload: { count: data.count, rows: results },
+                            payload: { articlesCount: data.articlesCount, rows: results },
                         })
                         if (paginationUpdate) {
                             dispatch({
@@ -2043,7 +2043,7 @@ export const getReportsResultsInitial = (limit = 20, offset = 0) => dispatch => 
         })
         .then(data => {
 
-            if (data.count === 0) {
+            if (data.articlesCount === 0) {
                 dispatch({
                     type: methods.REPORTS_SEARCH_UPDATE,
                     payload: data,
@@ -2082,7 +2082,7 @@ export const getReportsResultsInitial = (limit = 20, offset = 0) => dispatch => 
 
                     dispatch({
                         type: methods.REPORTS_SEARCH_UPDATE,
-                        payload: { count: data.count, rows: results },
+                        payload: { articlesCount: data.articlesCount, rows: results },
                     })
 
                     dispatch({


### PR DESCRIPTION
## Summary
On `/report` (Create Reports), the page showed **"0 articles"** and the **CSV / RTF** buttons were disabled even when results were rendered, and the pagination indicator was missing for large result sets.

The `/api/db/reports/publication/search` endpoint returns `articlesCount` (see `controllers/db/reports/publication.report.search.controller.ts:1114`). The dev_v2 re-restore in `2a0a747` changed `actions.js` to read `data.count` instead, so:
- `reportsSearchResults.articlesCount` was always `undefined`
- `articlesCount && articlesCount > 0 ? format(articlesCount) : 0` → "0 articles"
- `disabled={articlesCount ? false : true}` on CSV/RTF → always disabled
- `Math.ceil(total / count)` for pagination → broken

Reverted the four call sites in `actions.js` to use `articlesCount`, matching the API response and the consumer (`Report.tsx`, `SearchSummary.tsx`).

## Test plan
- [ ] CodeBuild green
- [ ] /report shows real article count after search
- [ ] CSV and RTF buttons are clickable
- [ ] Pagination arrows show for >count results