### PR TITLE
fix(toasts): make wrapper reactive to displayMessages setting

### DIFF
--- a/src/components/elements/ToastContainerWrapper/ToastContainerWrapper.tsx
+++ b/src/components/elements/ToastContainerWrapper/ToastContainerWrapper.tsx
@@ -1,8 +1,37 @@
+import React, { useMemo } from "react";
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import { useSelector, RootStateOrAny } from "react-redux";
+import { useSession } from 'next-auth/client';
 
 const ToastContainerWrapper = () => {
-    return <ToastContainer />
-}
+  const [session] = useSession();
+  const updatedAdminSettings = useSelector((state: RootStateOrAny) => state.updatedAdminSettings);
 
-export default ToastContainerWrapper
+  const isToastVisible = useMemo(() => {
+    let displayToastMessages: any[] = [];
+    if (updatedAdminSettings && updatedAdminSettings.length > 0) {
+      const displayMessages = updatedAdminSettings.find((obj: any) => obj.viewName === "displayMessages");
+      // viewAttributes may be a parsed array (post fetchAdminSettingsAction
+      // normalization in actions.js) or still a JSON-encoded string. Handle
+      // both so a Configuration save flips the wrapper without a reload.
+      const raw = displayMessages?.viewAttributes;
+      displayToastMessages = typeof raw === "string" ? JSON.parse(raw) : (raw || []);
+    } else if ((session as any)?.adminSettings) {
+      try {
+        const parsed = JSON.parse((session as any).adminSettings);
+        const displayMessages = Array.isArray(parsed) && parsed.find((obj: any) => obj.viewName === "displayMessages");
+        const raw = displayMessages?.viewAttributes;
+        displayToastMessages = typeof raw === "string" ? JSON.parse(raw) : (raw || []);
+      } catch {
+        displayToastMessages = [];
+      }
+    }
+    const visibleEntry = displayToastMessages.find((obj: any) => obj?.isVisible);
+    return !!visibleEntry?.isVisible;
+  }, [updatedAdminSettings, session]);
+
+  return isToastVisible ? <ToastContainer /> : null;
+};
+
+export default ToastContainerWrapper;


### PR DESCRIPTION
## Summary
The "Controls the displaying of the success or error messages" toggle in /configuration didn't actually suppress toasts when toggled Off. Two problems in `ToastContainerWrapper.tsx`:

1. `useEffect` deps were `[]`, so `isToastVisible` was computed once at mount and never re-evaluated when `state.updatedAdminSettings` changed (e.g. after Save in /configuration). Toggling Off had no effect until full page reload.

2. The cold-start branch double-parsed `session.adminSettings` while the hot branch trusted the post-#695 normalized shape (parsed `viewAttributes`). If the wrapper mounted while state was empty (race with `fetchAdminSettingsAction`), it could read stale or wrong-shaped data.

Replaced the `useState`/`useEffect` with a `useMemo` over `[updatedAdminSettings, session]`. Both branches handle `viewAttributes` as either a parsed array (normalized) or a JSON-encoded string (defensive). Toggling now flips the wrapper immediately.

Closes #704 (which proposed dropping the gating instead of fixing it).

## Test plan
- [ ] CodeBuild green
- [ ] /configuration → toggle "Controls the displaying..." Off → save → toasts no longer render anywhere in the app (no reload required)
- [ ] Toggle back On → save → toasts resume rendering