### PR TITLE
fix(rtf): match generatePubsNoPeopleRTF procedure signature

### DIFF
--- a/controllers/db/reports/publication.report.controller.ts
+++ b/controllers/db/reports/publication.report.controller.ts
@@ -43,10 +43,17 @@ export const generatePubsRtf = async (
     } else {
 
 																	   
+      // Stored procedure reciterdb.generatePubsNoPeopleRTF accepts a single
+      // arg (pmids); apiBody.limit is not honored here because the procedure
+      // signature was never updated to accept it. Caller applies a limit when
+      // staging the pmid list if it cares about cap.
+      const cappedPmids = typeof apiBody.limit === 'number' && apiBody.limit > 0
+        ? apiBody.pmids.slice(0, apiBody.limit)
+        : apiBody.pmids;
       generatePubsRtfOutput = await sequelize.query(
-        "CALL generatePubsNoPeopleRTF ( :pmids, :limit)",
+        "CALL generatePubsNoPeopleRTF ( :pmids )",
         {
-          replacements: { pmids: apiBody.pmids.join(','), limit: apiBody.limit },
+          replacements: { pmids: cappedPmids.join(',') },
           raw: true,
         }
       );


### PR DESCRIPTION
## Summary
Export to RTF on /report failed when no people filter was applied:

```
SequelizeDatabaseError ER_SP_WRONG_NO_OF_ARGS (1318):
Incorrect number of arguments for PROCEDURE reciterdb.generatePubsNoPeopleRTF;
expected 1, got 2
sql: CALL generatePubsNoPeopleRTF ( '...', '4000' )
```

The stored procedure takes 1 arg (pmids); the controller was passing 2 (pmids, limit) — likely added when the people-version proc was extended to take limit, but the no-people proc was never updated to match.

Dropped `:limit` from the SQL call. The limit is still honored by slicing `apiBody.pmids` client-side before joining, so `reportingArticleRTFLimit` from admin_settings still caps the output.

The companion proc `generatePubsRTF` (3 args: uids, pmids, limit) is unaffected — only the no-people branch had the mismatch.

## Test plan
- [ ] CodeBuild green
- [ ] /report → no filters → Export to RTF → file generated, no DB error
- [ ] /report → with people filter → Export to RTF still works (separate code path, unchanged)