### PR TITLE
fix(reports): bound no-filter pmids fetch + COUNT for authorshipsCount

### DIFF
--- a/controllers/db/reports/publication.report.search.controller.ts
+++ b/controllers/db/reports/publication.report.search.controller.ts
@@ -1572,32 +1572,46 @@ export const publicationSearchWithFilterPmids = async (
       finalSearchOutput = { authorshipsCount, pmids }; 
     } 
     else {
-      let results = await models.AnalysisSummaryArticle.findAll({
-        subQuery:false,
-        include :[
-          { 
-            model: models.AnalysisSummaryAuthor,
-            as: "AnalysisSummaryAuthor",
-            required: true,
-            on: {
-              col: Sequelize.where(
-                Sequelize.col("AnalysisSummaryAuthor.pmid"),
-                "=",
-                Sequelize.col("AnalysisSummaryArticle.pmid")
-              ),
-            },
-            attributes: [],
+      // No-filter export: bound the join so we don't load every authorship row
+      // in the database into memory (caused OOM kills on the pod when called
+      // unbounded). apiBody.limit is set by the client per export type
+      // (CSV: 10000, RTF: 4000); fall back to 10000 for the pmids prefetch.
+      const noFilterLimit = (typeof apiBody.limit === 'number' && apiBody.limit > 0) ? apiBody.limit : 10000;
+      const includeJoin = [
+        {
+          model: models.AnalysisSummaryAuthor,
+          as: "AnalysisSummaryAuthor",
+          required: true,
+          on: {
+            col: Sequelize.where(
+              Sequelize.col("AnalysisSummaryAuthor.pmid"),
+              "=",
+              Sequelize.col("AnalysisSummaryArticle.pmid")
+            ),
           },
-        ],
-       
+          attributes: [],
+        },
+      ];
+
+      let results = await models.AnalysisSummaryArticle.findAll({
+        subQuery: false,
+        include: includeJoin,
         attributes: [`AnalysisSummaryAuthor.id`, `pmid`, `pmcid`, `publicationDateDisplay`, `publicationDateStandardized`, `datePublicationAddedToEntrez`, `articleTitle`, `articleTitleRTF`, `publicationTypeCanonical`, `publicationTypeNIH`, `journalTitleVerbose`, `issn`, `journalImpactScore1`, `journalImpactScore2`, `articleYear`, `doi`, `volume`, `issue`, `pages`, `citationCountScopus`, `citationCountNIH`, `percentileNIH`, `relativeCitationRatioNIH`, `readersMendeley`, `trendingPubsScore`],
+        limit: noFilterLimit,
         benchmark: true
       });
 
       let pmids = results.map(result => result.pmid);
-      let authorshipsCount = results && results.length || 0 ;
+      // True authorship count (uncapped) for the modal display, computed via
+      // an efficient COUNT(*) with the same INNER JOIN.
+      let totalAuthorships = await models.AnalysisSummaryArticle.count({
+        subQuery: false,
+        include: includeJoin,
+        benchmark: true,
+      });
+      let authorshipsCount = totalAuthorships || (results && results.length) || 0;
 
-      finalSearchOutput = { authorshipsCount, pmids }; 
+      finalSearchOutput = { authorshipsCount, pmids };
 
     }
     return finalSearchOutput;


### PR DESCRIPTION
## Summary
On /report with no filters, clicking Export to CSV/RTF showed **0 AUTHORSHIPS** in the modal even when 40+ articles were rendered.

Root cause: `publicationSearchWithFilterPmids` no-filter branch ran an unbounded `findAll` INNER JOIN across `analysis_summary_article × analysis_summary_author`. With 24k+ people and many authorships per article, the join exploded and the pod was killed (verified — direct request returned exit code 137 OOM). The client never got a response → modal stuck at default `0`.

Two coordinated changes:

1. Cap the `findAll` with `limit: apiBody.limit || 10000`. Client passes the per-export-type limit (CSV 10000 / RTF 4000); 10000 is the upper bound for the pmid prefetch.
2. Compute `authorshipsCount` separately via `count()` with the same INNER JOIN — efficient, returns the true unbounded total for display.

## Test plan
- [ ] CodeBuild green
- [ ] /report with no filters → click Export to CSV → modal shows non-zero AUTHORSHIPS count, no pod restart
- [ ] /report with filters → modal still shows correct counts (other branches untouched)
- [ ] Pod logs show no OOM kills