### PR TITLE
fix(types): drop subQuery option from count() call (paired with #707)

### DIFF
--- a/controllers/db/reports/publication.report.search.controller.ts
+++ b/controllers/db/reports/publication.report.search.controller.ts
@@ -1605,7 +1605,6 @@ export const publicationSearchWithFilterPmids = async (
       // True authorship count (uncapped) for the modal display, computed via
       // an efficient COUNT(*) with the same INNER JOIN.
       let totalAuthorships = await models.AnalysisSummaryArticle.count({
-        subQuery: false,
         include: includeJoin,
         benchmark: true,
       });


### PR DESCRIPTION
## Summary
PR #707's `count()` call inherited `subQuery: false` from the sibling `findAll`, but Sequelize's `CountOptions` type doesn't have that field. tsc rejected:

```
Type error: No overload matches this call.
  ... 'subQuery' does not exist in type CountOptions
```

Dropped it. The `findAll` above keeps it.