### PR TITLE
fix: restore rich ManageProfile + Notifications from b7210e6

### DIFF
--- a/src/components/elements/ManageProfile/ManageProfile.tsx
+++ b/src/components/elements/ManageProfile/ManageProfile.tsx
@@ -1,45 +1,159 @@
 import React, { useEffect, useState } from "react";
-import appStyles from '../App/App.module.css';
 import styles from './ManageProfile.module.css';
-import { useSelector, useDispatch, RootStateOrAny } from "react-redux";
-import { Form, Button, Spinner, Carousel, InputGroup } from "react-bootstrap";
+import { useSelector, useDispatch } from "react-redux";
+import { RootStateOrAny } from "../../../types/redux";
 import { useSession } from "next-auth/client";
 import { useRouter } from "next/router";
 import ToastContainerWrapper from '../ToastContainerWrapper/ToastContainerWrapper';
-import Radio from '@mui/material/Radio';
-import RadioGroup from '@mui/material/RadioGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormControl from '@mui/material/FormControl';
 import { reciterConfig } from "../../../../config/local";
 import { toast } from "react-toastify";
+import { reportError } from "../../../utils/reportError";
 import { allowedPermissions } from "../../../utils/constants";
+import Loader from "../Common/Loader";
 
-
-const ManageProfile = () => {
+const ManageProfle = () => {
     const dispatch = useDispatch()
     const [session, loading] = useSession();
     const router = useRouter()
     const [suggested, setSuggested] = useState<boolean>(false);
-    const [manualORCID, setManualORCID] = useState("")
+    const [manualORCID, setManualORCID] = useState('');
+    const [profileData, setProfileData] = useState([]);
+    const [selectedOrcidValue, setSelectOrcid] = useState('');
+    const [clearRadioBtns, setClearRadioBtns] = useState(false)
+    const [loadProfileData, setLoadProfileData] = useState(false)
+    const [errorMessage, setErrorMessage] = useState('');
+    const [isCuratorSelf, setIsCuratorSelf] = useState<boolean>(false);
+    const [isSuperUserORCuratorAll, SetIsSuperUserORCuratorAll] = useState<boolean>(false);
+    const [isReporterAll, setIsReporterAll] = useState<boolean>(false);
+    const [serverValue, setServerValue] = useState('');
+    const [identityOrcid, setIdentityOrcid] = useState<string | null>(null);
 
     useEffect(() => {
-        if (!session) return;
+        let userPermissions = JSON.parse(session.data.userRoles);
+        let curatorSelfRole = userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self);
+        let curatorAllfRole = userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_All);
+        let superUserRole = userPermissions.some(role => role.roleLabel === allowedPermissions.Superuser);
 
+        if (router.query.userId === session.data.username) {
+            if (!curatorSelfRole) {
+                if (superUserRole || curatorAllfRole) {
+                    SetIsSuperUserORCuratorAll(true)
+                } else {
+                    setIsReporterAll(true)
+                }
+            } else {
+                setIsCuratorSelf(true)
+            }
+        } else {
+            setIsCuratorSelf(true)
+        }
         let userId = null;
-        // Sometimes router query userId does not update correctly.
-        // Reading the userId from window location as a fallback.
         if (!router.query.userId && session.data.username)
             userId = window.location.pathname.substring(window.location.pathname.lastIndexOf('/') + 1)
         else
             userId = router.query.userId ? router.query.userId : session.data.username
         getManageProfileData(userId)
-    }, [session, router.query.userId])
+        fetchIdentityOrcid(userId)
+    }, [router.query.userId])
+
+    const fetchIdentityOrcid = (personIdentifier) => {
+        fetch(`/api/reciter/getidentity/${personIdentifier}`, {
+            credentials: "same-origin",
+            method: 'GET',
+            headers: {
+                Accept: 'application/json',
+                'Authorization': reciterConfig.backendApiKey
+            },
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data.statusCode === 200 && data.identity) {
+                    setIdentityOrcid(data.identity.orcid || null)
+                }
+            })
+            .catch(error => {
+                console.log('Failed to fetch Identity ORCID:', error)
+            })
+    }
 
     const onSave = () => {
+        const orcidValue = manualORCID || selectedOrcidValue;
+        const uid = router.query.userId as string;
+        // Save to DynamoDB via Identity API
+        fetch(`/api/reciter/saveIdentityOrcid`, {
+            credentials: "same-origin",
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                "Content-Type": "application/json",
+                'Authorization': reciterConfig.backendApiKey
+            },
+            body: JSON.stringify({ personIdentifier: uid, orcid: orcidValue })
+        }).then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                toast.success("ORCID Saved Successfully", {
+                    position: "top-right",
+                    autoClose: 2000,
+                    theme: 'colored'
+                });
+                setIdentityOrcid(orcidValue);
+                getManageProfileData(uid);
+            } else {
+                throw new Error(data.error || 'Save failed');
+            }
+        }).catch(error => {
+            console.error("[ERR-1010]", error);
+            reportError("ERR-1010", "Unable to save ORCID", error);
+            toast.error("Unable to save ORCID. Please try again. (ERR-1010)", {
+                position: "top-right",
+                autoClose: 2000,
+                theme: 'colored'
+            });
+        })
+    }
+
+    const onReset = () => {
+        const uid = router.query.userId as string;
+        fetch(`/api/reciter/saveIdentityOrcid`, {
+            credentials: "same-origin",
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                "Content-Type": "application/json",
+                'Authorization': reciterConfig.backendApiKey
+            },
+            body: JSON.stringify({ personIdentifier: uid, orcid: '' })
+        })
+            .then(res => res.json())
+            .then(data => {
+                if (data.success) {
+                    toast.success("ORCID has been deleted successfully", {
+                        position: "top-right",
+                        autoClose: 2000,
+                        theme: 'colored'
+                    });
+                    setManualORCID("");
+                    setSelectOrcid("");
+                    setIdentityOrcid(null);
+                } else {
+                    throw new Error(data.error || 'Remove failed');
+                }
+            })
+            .catch(error => {
+                console.error("[ERR-1011]", error);
+                reportError("ERR-1011", "Unable to remove ORCID", error);
+                toast.error("Unable to remove ORCID. Please try again. (ERR-1011)", {
+                    position: "top-right",
+                    autoClose: 2000,
+                    theme: 'colored'
+                });
+            });
     }
 
     const getManageProfileData = (personIdentifier) => {
-        let url = `/api/db/admin/manageProfile/getORCIDProfileDataByID?personIdentifier=${personIdentifier || ""}`
+        setLoadProfileData(true)
+        let url = `/api/db/admin/manageProfile/getORCIDProfileDataByID?personIdentifier=${personIdentifier}`
         fetch(url, {
             credentials: "same-origin",
             method: 'GET',
@@ -56,72 +170,271 @@ const ManageProfile = () => {
                         autoClose: 2000,
                         theme: 'colored'
                     });
+                    setLoadProfileData(false)
                 } else if (data.message === "No data found") {
-                    // No profile data yet
+                    setLoadProfileData(false)
                 } else {
-                    console.log("data", data)
+                    let orcidData = data?.data || ""
+                    let recentUpdatedOrcid = orcidData.find(value => value.recently_selected_orcid == value.orcid);
+                    if(recentUpdatedOrcid)
+                        setSelectOrcid(recentUpdatedOrcid?.recently_selected_orcid);
+                    else
+                       setManualORCID(orcidData && orcidData.length > 0?orcidData[0].recently_selected_orcid:"");
+                    setProfileData(orcidData);
+                    setLoadProfileData(false);
                 }
             })
             .catch(error => {
-                console.log(error)
+                setLoadProfileData(false)
+                console.error("[ERR-1012]", error);
+                reportError("ERR-1012", "Unable to load profile data", error);
+                toast.error("Unable to load profile data. Please try again. (ERR-1012)", {
+                    position: "top-right",
+                    autoClose: 2000,
+                    theme: 'colored'
+                });
             });
     }
 
-    const handleValueChange = () => {
-        setSuggested(!suggested)
+    const onManualOrcidChange = (e) => {
+        setClearRadioBtns(true);
+        setSelectOrcid("");
+        const value = e.target.value;
+        const numericValue = value.replace(/\D/g, '');
+        const formattedValue = formatInput(numericValue);
+        if (formattedValue.length === 19) {
+            setErrorMessage('');
+        } else {
+            setErrorMessage('Please enter the value in the format ####-####-####-####');
+        }
+        setManualORCID(formattedValue);
     }
 
+    const onRadioChange = (orcidValue) => {
+        if (orcidValue == selectedOrcidValue) {
+            setSelectOrcid('')
+        } else {
+            setSelectOrcid(orcidValue)
+            setManualORCID('');
+        }
+        setErrorMessage('');
+    }
+
+    const handleUseOrcid = (orcid) => {
+        setSelectOrcid(orcid);
+        setManualORCID('');
+        setErrorMessage('');
+        const uid = router.query.userId as string;
+        fetch(`/api/reciter/saveIdentityOrcid`, {
+            credentials: "same-origin",
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                "Content-Type": "application/json",
+                'Authorization': reciterConfig.backendApiKey
+            },
+            body: JSON.stringify({ personIdentifier: uid, orcid })
+        }).then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                toast.success("ORCID Saved Successfully", {
+                    position: "top-right",
+                    autoClose: 2000,
+                    theme: 'colored'
+                });
+                setIdentityOrcid(orcid);
+                getManageProfileData(uid);
+            } else {
+                throw new Error(data.error || 'Save failed');
+            }
+        }).catch(error => {
+            console.error("[ERR-1013]", error);
+            reportError("ERR-1013", "Unable to save ORCID", error);
+            toast.error("Unable to save ORCID. Please try again. (ERR-1013)", {
+                position: "top-right",
+                autoClose: 2000,
+                theme: 'colored'
+            });
+        });
+    }
+
+    const formatInput = (value) => {
+        const formattedValue = value
+            .replace(/(\d{4})/g, '$1-')
+            .slice(0, 19);
+        return formattedValue;
+    };
+
+    /* Current confirmed ORCID from ReCiter Identity (DynamoDB) */
+    const currentOrcid = identityOrcid || '';
+
     return (
-        <div className={appStyles.mainContainer}>
-            <h1>Manage Profile</h1>
-            <div className="pb-4">
-                <h5>ORCID</h5>
-                <p>Provide your unique ORCID ID to retrieve unclaimed PubMed publications. In the interests of streamlining your administrative tasks, your ORCID may be shared with select authorized parties.</p>
-            </div>
+        <>
+            <h1 className={styles.pageTitle}>Manage Profile</h1>
 
-            <div className="pb-4">
-                <h6>Suggested ORCID</h6>
-                <p className="pt-3">Here are your top suggestions. This is based on how often you have accepted or rejected publications associated with those ORCID values.</p>
-                <div>
-                    <FormControl>
-                        <RadioGroup
-                            aria-labelledby="orcid-suggestions-label"
-                            defaultValue="female"
-                            name="orcid-suggestions"
-                        >
-                            <FormControlLabel value="ORCID1" control={<Radio />} label="ORCID 1 accepted 0 null 0" />
-                            <FormControlLabel value="ORCID2" control={<Radio />} label="ORCID 2 accepted 0 null 0" />
-                            <FormControlLabel value="ORCID3" control={<Radio />} label="ORCID 3 accepted 0 null 0" />
-                            <FormControlLabel value="ORCID4" control={<Radio />} label="ORCID 4 accepted 0 null 0" />
-                        </RadioGroup>
-                    </FormControl>
-                </div>
-            </div>
+            {(isCuratorSelf || isSuperUserORCuratorAll) ? (
+                <>
+                    {/* ── ORCID section ── */}
+                    <div className={styles.section}>
+                        <div className={styles.sectionLabel}>ORCID</div>
 
-            <div>
-                <h6>Manually add your ORCID</h6>
-                <p>Alternatively, you can manually enter your ORCID ID in the field below: </p>
-                <div className="width400 pb-3">
-                    <InputGroup>
-                        <Form.Control
-                            type="input"
-                            value={manualORCID}
-                            onChange={(e) => setManualORCID(e.target.value)}
-                            aria-label="ORCID ID"
-                        />
-                    </InputGroup>
+                        {/* Intro card */}
+                        <div className={styles.orcidIntro}>
+                            <div className={styles.orcidLogo}>iD</div>
+                            <div>
+                                <div className={styles.orcidIntroTitle}>
+                                    ORCID Identifier
+                                    <a className={styles.orcidIntroLink} href="https://orcid.org/" target="_blank" rel="noreferrer">orcid.org</a>
+                                </div>
+                                <p className={styles.orcidIntroDesc}>
+                                    Provide your unique ORCID iD to retrieve unclaimed PubMed publications.
+                                    This persistent digital identifier distinguishes you from other researchers
+                                    and ensures your work is properly attributed.
+                                </p>
+                                <div className={styles.orcidPrivacyNote}>
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                                        <path d="M7 11V7a5 5 0 0110 0v4" />
+                                    </svg>
+                                    <span>Your ORCID may be shared with select authorized parties to streamline administrative tasks.</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* ── Suggested ORCIDs ── */}
+                    <div className={styles.section}>
+                        <div className={styles.suggestionsCard}>
+                            <div className={styles.suggestionsHead}>
+                                <div className={styles.suggestionsHeadTitle}>
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                        <circle cx="12" cy="12" r="10" />
+                                        <path d="M12 16v-4M12 8h.01" />
+                                    </svg>
+                                    Suggested ORCIDs
+                                </div>
+                                <span className={styles.suggestionsHeadDesc}>
+                                    Based on accepted &amp; rejected publication history
+                                </span>
+                            </div>
+                            <div className={styles.suggestionsBody}>
+                                {loadProfileData ? (
+                                    <div style={{ display: 'flex', justifyContent: 'center', padding: 20 }}><Loader /></div>
+                                ) : profileData && profileData.length > 0 ? (
+                                    profileData.map((values, i) => {
+                                        const { orcid, articleCount_accepted, articleCount_null, articleCount_rejected, pmids_accepted, pmids_null, pmids_rejected } = values;
+                                        return (
+                                            <div className={styles.suggestionRow} key={i}>
+                                                <label className={styles.suggestionRadioLabel}>
+                                                    <input
+                                                        type="radio"
+                                                        className={styles.suggestionRadio}
+                                                        name="orcid-suggestion"
+                                                        checked={selectedOrcidValue === orcid}
+                                                        onChange={() => onRadioChange(orcid)}
+                                                    />
+                                                    <span className={styles.suggestionOrcidId}>{orcid}</span>
+                                                </label>
+                                                <div className={styles.suggestionPills}>
+                                                    {articleCount_accepted > 0 && (
+                                                        <a href={pmids_accepted} target="_blank" rel="noreferrer" className={`${styles.pill} ${styles.pillAccepted}`}>
+                                                            {articleCount_accepted} accepted
+                                                        </a>
+                                                    )}
+                                                    {articleCount_rejected > 0 && (
+                                                        <a href={pmids_rejected} target="_blank" rel="noreferrer" className={`${styles.pill} ${styles.pillRejected}`}>
+                                                            {articleCount_rejected} rejected
+                                                        </a>
+                                                    )}
+                                                </div>
+                                                <button
+                                                    type="button"
+                                                    className={styles.btnUse}
+                                                    onClick={() => handleUseOrcid(orcid)}
+                                                >
+                                                    Use this iD
+                                                </button>
+                                            </div>
+                                        );
+                                    })
+                                ) : (
+                                    <div className={styles.emptyState}>
+                                        <div className={styles.emptyIcon}>
+                                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                                <circle cx="11" cy="11" r="8" />
+                                                <path d="M21 21l-4.35-4.35" />
+                                            </svg>
+                                        </div>
+                                        <div className={styles.emptyTitle}>No suggestions available</div>
+                                        <div className={styles.emptyDesc}>
+                                            We couldn&apos;t find any ORCID suggestions based on your publication history. You can manually enter your ORCID below.
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* ── Manual entry ── */}
+                    <div className={styles.section}>
+                        <div className={styles.manualCard}>
+                            <div className={styles.manualHead}>Manually Enter ORCID</div>
+                            <div className={styles.manualBody}>
+                                {currentOrcid && (
+                                    <div className={styles.currentOrcidBanner}>
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                            <path d="M20 6L9 17l-5-5" />
+                                        </svg>
+                                        Current ORCID: <strong>{currentOrcid}</strong>
+                                    </div>
+                                )}
+
+                                <div className={styles.fieldLabel}>ORCID iD</div>
+                                <div className={styles.fieldRow}>
+                                    <input
+                                        className={styles.fieldInput}
+                                        type="text"
+                                        value={manualORCID}
+                                        onChange={onManualOrcidChange}
+                                        placeholder="0000-0000-0000-0000"
+                                        maxLength={19}
+                                    />
+                                    <button
+                                        type="button"
+                                        className={styles.btnSave}
+                                        onClick={onSave}
+                                        disabled={selectedOrcidValue === "" && manualORCID === ""}
+                                    >
+                                        Save
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className={styles.btnRemove}
+                                        onClick={onReset}
+                                    >
+                                        Remove
+                                    </button>
+                                </div>
+                                {errorMessage && <div className={styles.errorText}>{errorMessage}</div>}
+
+                                <div className={styles.orcidFormatHint}>
+                                    Format: <code>####-####-####-####</code>
+                                    &middot;
+                                    <a href="https://orcid.org/" target="_blank" rel="noreferrer">Find your ORCID</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <ToastContainerWrapper />
+                </>
+            ) : (!isCuratorSelf || !isReporterAll) ? (
+                <div className={styles.noAccess}>
+                    <p>Your user does not have the Curator Self role. To edit the Manage Profile for another user, first click on the Manage Users tab.</p>
                 </div>
-            </div>
-            <div className="d-flex">
-                <Button variant="warning" className="m-2" onClick={() => onSave()}>
-                    Save
-                </Button>
-                <Button variant="warning" className="m-2" onClick={() => onSave()}>
-                    Reset
-                </Button>
-            </div>
-        </div>
+            ) : null}
+        </>
     )
 }
 
-export default ManageProfile;
+export default ManageProfle;

--- a/src/components/elements/Notifications/Notifications.tsx
+++ b/src/components/elements/Notifications/Notifications.tsx
@@ -1,95 +1,306 @@
 import React, { useEffect, useState } from "react";
 import styles from './Notifications.module.css';
 import appStyles from '../App/App.module.css';
-import { useSelector, useDispatch, RootStateOrAny } from "react-redux";
-import SkeletonForm from "../Common/SkeletonForm";
-import { Form,Button } from "react-bootstrap";
-import { saveNotification, sendNotification } from "../../../redux/actions/actions";
+import { useSelector, useDispatch } from "react-redux";
+import { RootStateOrAny } from "../../../types/redux";
+import Loader from "../Common/Loader";
+import { Spinner } from "react-bootstrap";
+import { saveNotification } from "../../../redux/actions/actions";
 import { useSession } from "next-auth/client";
+import { useRouter } from "next/router";
+import { reciterConfig } from "../../../../config/local";
+import ToastContainerWrapper from '../ToastContainerWrapper/ToastContainerWrapper';
+import { allowedPermissions } from "../../../utils/constants";
+import { toast } from "react-toastify";
+import { reportError } from "../../../utils/reportError";
+
 
 const Notifications = () => {
- const dispatch = useDispatch()
- const [session, loading] = useSession();
- const [state, setState] = useState({
-  frequency: 1,
-  minimumThreshold:8,
-})
+  const dispatch = useDispatch()
+  const [session, loading] = useSession();
+  const router = useRouter()
+  const [state, setState] = useState({
+    frequency: 70,
+    minimumThreshold: 80,
+  })
 
-const identityData = useSelector((state: RootStateOrAny) => state.identityData);
-const {frequency,minimumThreshold} = state
-const [formErrorsInst, setformErrInst] = useState<{[key: string]: any}>({});
-const [accepted, setAccepted] = useState<boolean>(false);
-const [status, setStatus] = useState<boolean>(false);
-const [evidence, setEvidance] = useState<boolean>(true)
-const [userId, setUserId] = useState<string>("")
+  const getNotificationsByIdLoading = useSelector((state: RootStateOrAny) => state.getNotificationsByIdLoading);
+  const saveNotificationsLoading = useSelector((state: RootStateOrAny) => state.saveNotificationsLoading);
 
-useEffect(()=>{
- setUserId( session.data.username)
-},[])
+  const { frequency, minimumThreshold } = state;
+  const [formErrorsInst, setformErrInst] = useState<{ [key: string]: any }>({});
+  const [accepted, setAccepted] = useState<boolean>(false);
+  const [status, setStatus] = useState<boolean>(true);
+  const [evidence, setEvidance] = useState<boolean>(false)
+  const [suggested, setSuggested] = useState<boolean>(false)
+  const [userId, setUserId] = useState<any>("");
+  const [email, setEmail] = useState<string>();
+  const [isCuratorSelf, setIsCuratorSelf] = useState<boolean>(false);
+  const [isSuperUserORCuratorAll, SetIsSuperUserORCuratorAll] = useState<boolean>(false);
+  const [isReporterAll, setIsReporterAll] = useState<boolean>(false);
+  const [userName, setUserName] = useState<string>();
+  const [disableSaveBtn, setDisableSaveBtn] = useState(false);
+  const [isExistingUser, setIsExistingUser] = useState(true);
 
- const handleAccept = ()=>{
-  setAccepted(!accepted)
- }
- const handleEvidence = ()=>{
-  setEvidance(!evidence)
- }
- const onSave = ()=>{
-  let payload = {frequency,accepted : accepted === true ? 1 : 0,status : status === true ? 1 : 0,minimumThreshold, userId}
-  dispatch(saveNotification(payload))
- }
- const handleStatus= ()=>{
-  setStatus(!status)
- }
- const handleValueChange = (field, value) => {
-  if(value != '') formErrorsInst[field] = '';
-  setState(state => ({ ...state, [field]: value }))
-}
- return (
-  <div className={appStyles.mainContainer}>
-   <h1 className={styles.header}>Manage Notifications</h1>
-   <Form.Group className="mb-3" controlId="disableNotifications">
-    <Form.Check type="checkbox" label="Disable all notifications"  onChange={()=>handleStatus()}/>
-   </Form.Group>
 
-   <Form.Label className="fw-bold">Frequency</Form.Label>
-   <Form.Select aria-label="Notification frequency" value={frequency} defaultValue={1} onChange={(e)=>handleValueChange("frequency",e.target.value)} className={styles.selectFrequecy}>
-    <option value = "1">Daily</option>
-    <option value="7">Every 7 days</option>
-    <option value="14">Every 14 days</option>
-    <option value="28">Every 28 days</option>
-   </Form.Select>
 
-   <div className="mt-5">
-    <p className="fw-bold">Reasons for sending a notification</p>
-    <Form.Group className="mb-3" controlId="acceptedPubs">
-     <Form.Check type="checkbox" label="A new publication has been accepted on your behalf" onChange={()=>handleAccept()}/>
-    </Form.Group>
-    <Form.Group className="mb-3" controlId="suggestedPubs">
-     <Form.Check type="checkbox" label="A new publication has been suggested" />
-    </Form.Group>
-    <div className={styles.nestedMenu}>
-     <Form.Group className="mb-3" controlId="minEvidenceScore">
-      <Form.Check type="checkbox" label="Minimum evidence score for triggering a notification(higher scores indicate greater confidence)" onChange={()=>handleEvidence()}/>
-     </Form.Group>
-     <Form.Select aria-label="Minimum evidence score threshold" value={minimumThreshold} disabled={evidence} onChange={(e)=>handleValueChange("minimumThreshold",e.target.value)} className={styles.selectCount}>
-      {/* <option>7</option> */}
-      <option value="10">10</option>
-      <option value="9">9</option>
-      <option value="8">8</option>
-      <option value="7">7</option>
-      <option value="6">6</option>
-      <option value="5">5</option>
-      <option value="4">4</option>
-     </Form.Select>
+  useEffect(() => {
+    let userPermissions = JSON.parse(session.data.userRoles);
+    let curatorSelfRole = userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self);
+    let curatorAllfRole = userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_All);
+    let superUserRole = userPermissions.some(role => role.roleLabel === allowedPermissions.Superuser);
+
+    if(router.query.userId === session.data.username ){
+      if (!curatorSelfRole) {
+        if (superUserRole || curatorAllfRole) {
+          SetIsSuperUserORCuratorAll(true)
+        } else {
+          setIsReporterAll(true)
+        }
+      } else {
+        setIsCuratorSelf(true)
+      }
+    }else{
+      setIsCuratorSelf(true)
+    }
+    let userId = null;
+    if(!router.query.userId && session.data.username)
+         userId = window.location.pathname.substring(window.location.pathname.lastIndexOf('/')+1)
+    else
+       userId = router.query.userId ? router.query.userId : session.data.username
+    getNotification(userId);
+  }, [router.query.userId])
+
+  const handleAccept = () => {
+    setAccepted(!accepted)
+  }
+
+  const getNotification = (personIdentifier) => {
+    let url = `/api/db/admin/notifications/getNotificationsByID?personIdentifier=${personIdentifier || ""}`
+    fetch(url, {
+      credentials: "same-origin",
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        "Content-Type": "application/json",
+        'Authorization': reciterConfig.backendApiKey
+      },
+    }).then(response => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.json();
+      })
+      .then(data => {
+        if (data.message === "User does not exist") {
+          setDisableSaveBtn(true);
+          setIsExistingUser(false);
+          setEmail(data.email);
+          toast.error("User does not exist", {
+            position: "top-right",
+            autoClose: 2000,
+            theme: 'colored'
+          });
+        } else if(data.message === "No data found"){
+          setEmail(data.email);
+          setUserId(data.userID)
+          setDisableSaveBtn(true);
+        }else{
+          const { minimumThreshold, suggested, accepted, frequency, email,userID} = data;
+          setState(state => ({ ...state, ["minimumThreshold"]: minimumThreshold == 0 ? 80 : minimumThreshold, ["frequency"]: frequency }))
+          setSuggested(suggested == 1 ? true : false);
+          setEvidance(minimumThreshold == 0 ? false : true);
+          setAccepted(accepted == 1 ? true : false);
+          setEmail(email);
+          setUserId(userID)
+          setDisableSaveBtn(false);
+        }
+      })
+      .catch(error => {
+        console.error("[ERR-6010]", error);
+        reportError("ERR-6010", "Unable to load notification preferences", error);
+        toast.error("Unable to load notification preferences. Please try again. (ERR-6010)", {
+          position: "top-right",
+          autoClose: 2000,
+          theme: 'colored'
+        });
+      });
+  }
+
+  const handleSuggested = () => {
+    setSuggested(!suggested)
+  }
+
+  const onSave = () => {
+    let payload = { frequency, suggested: suggested ? 1 : 0, accepted: accepted === true ? 1 : 0, status: status === true ? 1 : 0, minimumThreshold: suggested ? minimumThreshold : 0, personIdentifier :router.query.userId ? router.query.userId : session.data.username ,userID :userId ? userId:'' ,recipient : email,isReqFrom :"notificationPref", recipientName :userName   }
+    dispatch(saveNotification(payload))
+  }
+
+  const handleValueChange = (field, e) => {
+    let value = field === "minimumThreshold" ? parseInt(e.target.value) : e;
+    if (field === "minimumThreshold") {
+      setState(state => ({ ...state, [field]: value }))
+    } else {
+      setState(state => ({ ...state, [field]: value }))
+    }
+  }
+
+  const sliderPct = ((minimumThreshold) / 100) * 100;
+  const sliderBg = `linear-gradient(to right, #1a2133 0%, #1a2133 ${sliderPct}%, #ddd7ce ${sliderPct}%, #ddd7ce 100%)`;
+
+  return (
+    <div className={appStyles.mainContainer}>
+      <h1 className={styles.header}>Manage Notifications</h1>
+      <p className={styles.subtitle}>Control when and how often ReCiter sends you email alerts.</p>
+
+      {(isCuratorSelf || isSuperUserORCuratorAll) ? (
+        <>
+          {getNotificationsByIdLoading ? (
+            <Loader />
+          ) : (
+            <>
+              {/* ── SECTION: Notification triggers ── */}
+              <div className={styles.section}>
+                <div className={styles.sectionLabel}>Notification triggers</div>
+                <div className={styles.card}>
+                  <div className={styles.cardHead}>
+                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M8 2a5 5 0 015 5c0 2.5-.8 4-1.5 5H4.5C3.8 11 3 9.5 3 7a5 5 0 015-5zM6 13h4M8 2v-.5"/></svg>
+                    Send me an email when…
+                  </div>
+                  <div className={styles.cardBody}>
+                    <div className={styles.toggleRow}>
+                      <div className={styles.toggleInfo}>
+                        <div className={styles.toggleTitle}>A publication has been accepted on my behalf</div>
+                        <div className={styles.toggleDesc}>Notifies you when an admin or curator accepts a publication and attributes it to your profile.</div>
+                      </div>
+                      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- toggle label wraps checkbox; visible text is in sibling div */}
+                      <label className={styles.toggle} aria-label="Toggle accepted publication notifications">
+                        <input type="checkbox" checked={accepted} onChange={handleAccept} />
+                        <span className={styles.toggleSlider}></span>
+                      </label>
+                    </div>
+                    <div className={styles.toggleRow}>
+                      <div className={styles.toggleInfo}>
+                        <div className={styles.toggleTitle}>A new publication has been suggested</div>
+                        <div className={styles.toggleDesc}>Notifies you when ReCiter identifies a new publication that may belong to you and is pending your review.</div>
+                      </div>
+                      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- toggle label wraps checkbox; visible text is in sibling div */}
+                      <label className={styles.toggle} aria-label="Toggle suggested publication notifications">
+                        <input type="checkbox" checked={suggested} onChange={handleSuggested} />
+                        <span className={styles.toggleSlider}></span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* ── SECTION: Confidence threshold ── */}
+              <div className={styles.section}>
+                <div className={styles.sectionLabel}>Confidence threshold</div>
+                <div className={styles.card}>
+                  <div className={styles.cardHead}>
+                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M2 12l4-4 3 3 5-7"/></svg>
+                    Minimum evidence score
+                  </div>
+                  <div className={styles.cardBody}>
+                    <div className={styles.sliderSection}>
+                      <div className={styles.sliderHeader}>
+                        <div>
+                          <div className={styles.sliderTitle}>Only notify me for high-confidence suggestions</div>
+                          <div className={styles.sliderDesc}>Higher values reduce noise by filtering out low-confidence matches. A score of 0 notifies you about all suggestions regardless of confidence.</div>
+                        </div>
+                        <div className={styles.sliderValueBadge}>
+                          <div className={styles.sliderValueNum}>{minimumThreshold}</div>
+                          <div className={styles.sliderValueLabel}>score</div>
+                        </div>
+                      </div>
+                      <div className={styles.sliderWrap}>
+                        <input
+                          type="range"
+                          min="0"
+                          max="100"
+                          value={minimumThreshold}
+                          step="1"
+                          disabled={!suggested}
+                          onChange={(e) => handleValueChange("minimumThreshold", e)}
+                          style={{ background: sliderBg }}
+                        />
+                      </div>
+                      <div className={styles.sliderScale}>
+                        <span>0</span><span>25</span><span>50</span><span>75</span><span>100</span>
+                      </div>
+                      <div className={styles.sliderHintRow}>
+                        <span className={styles.sliderHint}>Notify for all suggestions</span>
+                        <span className={styles.sliderHint}>Only very high confidence</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* ── SECTION: Delivery ── */}
+              <div className={styles.section}>
+                <div className={styles.sectionLabel}>Delivery</div>
+                <div className={styles.card}>
+                  <div className={styles.cardHead}>
+                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="2" y="4" width="12" height="9" rx="1"/><path d="M2 5l6 5 6-5"/></svg>
+                    Email frequency and address
+                  </div>
+                  <div className={styles.cardBody}>
+                    <div className={styles.toggleRow} style={{ borderBottom: 'none', paddingBottom: 0 }}>
+                      <div className={styles.toggleInfo}>
+                        <div className={styles.toggleTitle}>Notification frequency</div>
+                        <div className={styles.toggleDesc}>How often qualifying notifications are batched and sent.</div>
+                      </div>
+                    </div>
+                    <div style={{ marginTop: 10 }}>
+                      <select
+                        className={styles.fieldSelect}
+                        value={frequency}
+                        onChange={(e) => handleValueChange("frequency", e.target.value)}
+                      >
+                        <option value="1">Every day</option>
+                        <option value="7">Every 7 days</option>
+                        <option value="14">Every 14 days</option>
+                        <option value="28">Every 30 days</option>
+                      </select>
+                    </div>
+                    {email && (
+                      <div className={styles.emailNote}>
+                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5"><rect x="2" y="4" width="12" height="9" rx="1"/><path d="M2 5l6 5 6-5"/></svg>
+                        Emails will be sent to <strong>{email}</strong>
+                        <span className={styles.emailNoteHint}>· Change in profile settings</span>
+                      </div>
+                    )}
+                  </div>
+                  <div className={styles.formFooter}>
+                    <button
+                      className={styles.btnSave}
+                      onClick={onSave}
+                      disabled={(disableSaveBtn && !accepted && !suggested) || !isExistingUser}
+                    >
+                      {saveNotificationsLoading ? (
+                        <Spinner animation="border" size="sm" />
+                      ) : (
+                        <>
+                          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M2 8l4 4 8-8"/></svg>
+                          Save preferences
+                        </>
+                      )}
+                    </button>
+                    <button className={styles.btnCancel} onClick={() => router.back()}>Cancel</button>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+          <ToastContainerWrapper />
+        </>
+      ) : (!isCuratorSelf || !isReporterAll) ? (
+        <div className={styles.noAccess}>
+          <p>Your user does not have the Curator Self role. To edit the Manage Notification preferences for another user, first click on the Manage Users tab.</p>
+        </div>
+      ) : null}
     </div>
-    <p className="mt-3">Emails will be sent to Email</p>
-   </div>
-  <Button variant="warning" className="m-2" onClick={()=>onSave()}>Save</Button>
-  </div>
- )
+  )
 }
-
-
-
 
 export default Notifications;


### PR DESCRIPTION
## Summary
The dev_v2 re-restore in `2a0a747` dropped substantial portions of these two pages:
- `ManageProfile.tsx`: -271 net lines
- `Notifications.tsx`: -176 net lines

Restored from `b7210e6` with the standard v3 patch:
- `next-auth/react` → `next-auth/client`
- `const { data: session, status } = useSession(); const loading = status === "loading"` → `const [session, loading] = useSession()`

Notifications used `status: sessionStatus` aliasing — same conversion applied.

## Test plan
- [ ] CodeBuild green
- [ ] /manageprofile shows the rich profile UI (ORCID, suggestions, etc.)
- [ ] /notifications shows the rich notifications config UI