### PR TITLE
fix: restore rich ManageUsers + UsersTable from b7210e6

### DIFF
--- a/src/components/elements/Manage/ManageUsers.tsx
+++ b/src/components/elements/Manage/ManageUsers.tsx
@@ -1,48 +1,96 @@
 import React, { useState, useEffect } from "react";
-import { useSelector, useDispatch, RootStateOrAny } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
+import { RootStateOrAny } from "../../../types/redux";
 import appStyles from '../App/App.module.css';
 import styles from "./ManageUsers.module.css";
-import { PageHeader } from '../Common/PageHeader';
-import SkeletonTable from '../Common/SkeletonTable';
+import Loader from '../Common/Loader';
 import { reciterConfig } from '../../../../config/local';
 import UsersTable from "./UsersTable";
 import { useRouter } from 'next/router'
-import { Button, Card, Row, Col,InputGroup,Form } from 'react-bootstrap';
-import { adminUsersListAction, createORupdateUserIDAction, getAdminDepartments, getAdminRoles } from "../../../redux/actions/actions";
+import { adminUsersListAction, createORupdateUserIDAction, getAdminDepartments, getAdminRoles, sendNotification } from "../../../redux/actions/actions";
 import ToastContainerWrapper from '../ToastContainerWrapper/ToastContainerWrapper';
 import { toast } from "react-toastify"
-import Pagination from '../Pagination/Pagination';
-import Filter from "../Filter/Filter";
+import { reportError } from "../../../utils/reportError";
+import { useSession } from 'next-auth/client';
+
 
 
 const ManageUsers = () => {
 
   const createORupdateUserID = useSelector((state: RootStateOrAny) => state.createORupdateUserID);
+  const updatedAdminSettings = useSelector((state: RootStateOrAny) => state.updatedAdminSettings)
+
+  const [session, loading] = useSession();
 
   const [users, setUsers] = useState([]);
   const [allUsers, setAllUsers] = useState([]);
   const [searchText, setSearchText] = useState("")
-  const [loading, setLoading] = useState(false);
+  const [filterText, setFilterText] = useState("")
+  const [pageLoading, setpageLoading] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
+  const [nameOrcwidLabel, setNameOrcwidLabel] = useState()
+  const [isVisibleNotification, setVisibleNotification] = useState(true)
 
   const router = useRouter()
   const dispatch = useDispatch();
 
   const [page, setPage] = useState(1)
-  const [count, setCount] = useState(50)
-  const [roleFilter, setRoleFilter] = useState('')
+  const [count, setCount] = useState(100)
 
- 
+
   useEffect(() => {
         dispatch(getAdminDepartments());
         dispatch(getAdminRoles());
         fetchAllAdminUsers(page, count)
+        adminConfigurations();
   }, [])
 
-  const fetchAllAdminUsers=(page ?: number, limit?:number, searchTextInput? :string, roleFilterParam? :string)=>{
-    setLoading(true);
+  const adminConfigurations = () => {
+    var viewAttributes = [];
+    var emailNotifications = [];
+
+    if (updatedAdminSettings.length > 0) {
+      let updatedData = updatedAdminSettings.find(obj => obj.viewName === "findPeople")
+      let notificationsData = updatedAdminSettings.find(obj => obj.viewName === "EmailNotifications")
+      viewAttributes = updatedData.viewAttributes;
+      emailNotifications = notificationsData.viewAttributes;
+      let cwidLabel = viewAttributes.find(data => data.labelUserKey === "personIdentifier")
+      setNameOrcwidLabel(cwidLabel.labelUserView)
+    } else if (session?.adminSettings) {
+      let adminSettings = JSON.parse(session.adminSettings);
+      let data = adminSettings.find(obj => obj.viewName === "findPeople")
+      viewAttributes = JSON.parse(data.viewAttributes)
+      let cwidLabel = viewAttributes.find(data => data.labelUserKey === "personIdentifier")
+      let notificationsData = adminSettings.find(obj => obj.viewName === "EmailNotifications")
+      emailNotifications = JSON.parse(notificationsData.viewAttributes);
+      cwidLabel && setNameOrcwidLabel(cwidLabel.labelUserView)
+    }
+    let settingsObj = emailNotifications && emailNotifications.find(data => data.isVisible)
+    setVisibleNotification(settingsObj && settingsObj.isVisible || false)
+  }
+
+  // Re-derive findPeople and notification settings when admin settings arrive in Redux (async)
+  useEffect(() => {
+    if (updatedAdminSettings && updatedAdminSettings.length > 0) {
+      let updatedData = updatedAdminSettings.find(obj => obj.viewName === "findPeople")
+      if (updatedData) {
+        let viewAttributes = updatedData.viewAttributes;
+        let cwidLabel = viewAttributes.find(data => data.labelUserKey === "personIdentifier")
+        if (cwidLabel) setNameOrcwidLabel(cwidLabel.labelUserView)
+      }
+      let notificationsData = updatedAdminSettings.find(obj => obj.viewName === "EmailNotifications")
+      if (notificationsData) {
+        let emailNotifications = notificationsData.viewAttributes;
+        let settingsObj = emailNotifications && emailNotifications.find(data => data.isVisible)
+        setVisibleNotification(settingsObj && settingsObj.isVisible || false)
+      }
+    }
+  }, [updatedAdminSettings])
+
+  const fetchAllAdminUsers = (page?: number, limit?: number, searchTextInput?: string) => {
+    setpageLoading(true);
     const offset = (page - 1) * limit;
-    const request = { limit, offset , searchTextInput, roleFilter: roleFilterParam !== undefined ? roleFilterParam : roleFilter };
+    const request = { limit, offset, searchTextInput };
     fetch(`/api/db/admin/users`, {
       credentials: "same-origin",
       method: 'POST',
@@ -54,11 +102,10 @@ const ManageUsers = () => {
       body: JSON.stringify(request),
     }).then(response => response.json())
       .then(data => {
-        setUsers(data.usersData);
-        setAllUsers(data.usersData)
-        setTotalCount( data.totalUsersCount)
+        prepareTabelData(data.usersData)
+        setTotalCount(data.totalUsersCount)
         dispatch(adminUsersListAction(data))
-        setLoading(false);
+        setpageLoading(false);
         if (createORupdateUserID) toast.success(createORupdateUserID + " successfully", {
           position: "top-right",
           autoClose: 2000,
@@ -67,151 +114,198 @@ const ManageUsers = () => {
         dispatch(createORupdateUserIDAction(""))
       })
       .catch(error => {
-        console.log(error)
-        setLoading(false);
+        console.error("[ERR-5010]", error);
+        reportError("ERR-5010", "Unable to load user list", error);
+        setpageLoading(false);
+        toast.error("Unable to load user list. Please try again. (ERR-5010)", {
+          position: "top-right",
+          autoClose: 2000,
+          theme: 'colored'
+        });
       });
   }
 
-  const onReset = ()=>{
-    setPage(1);
-    setCount(50);
-    setSearchText("");
-    setRoleFilter("");
-    fetchAllAdminUsers(1,50,'','');
-  }
-
-  const fetchPaginatedData = (newCount) => {
-    // dispatch(identityFetchPaginatedData(page, newCount ? newCount : count))
-    fetchAllAdminUsers(page, newCount ? newCount : count)
-  }
-
-
-  const handlePaginationUpdate = (page) => {
-    setPage(page)
-    // if(searchText.trim().length >= 3) fetchAllAdminUsers(page, count, searchText)
-    // else 
-     fetchAllAdminUsers(page, count)
-  }
-
-  const handleFilterUpdate= (searchText)=>{
-    filter(searchText ? searchText : "");
-  }
-
-  const filter = (search) => { 
-    let filteredUsers = []
-    if (users  && users.length > 0) {
-      users.forEach((user) => {
-    if (search ) {
-      if (/^[0-9 ]*$/.test(search)) {
-        var userIds = search.split(" ");
-        if (userIds.some(userId => Number(userId) === user.userID)) {
-            filteredUsers.push(user);
-        }
-      }else{
-        var addUser = true;
-        if (search) {
-          addUser = false;
-          //nameFirst
-          if (user.nameFirst && user.nameFirst.toLowerCase().includes(search.toLowerCase())) {
-            addUser = true
+  const prepareTabelData = (usersData) => {
+    let tableData = [];
+    usersData.map((data) => {
+      const { nameFirst, nameLast, userID, personIdentifier, email, department, person, listRoles, scope_person_types, scope_org_units, proxy_person_ids } = data;
+      if (data.AdminUserDept?.length > 0) {
+        data.AdminUserDept && data.AdminUserDept.map((deptData => {
+          let obj = {
+            email: email,
+            personIdentifier: personIdentifier,
+            userID: userID,
+            nameFirst: nameFirst,
+            nameLast: nameLast,
+            department: deptData.departmentLabel,
+            primaryOrganizationalUnit: person && Object.keys(person).length > 0 && person.primaryOrganizationalUnit || "",
+            listRoles: listRoles || [],
+            scope_person_types: scope_person_types || null,
+            scope_org_units: scope_org_units || null,
+            proxy_person_ids: proxy_person_ids || null,
           }
-          //nameLast
-          if (user.nameLast && user.nameLast.toLowerCase().includes(search.toLowerCase())) {
-              addUser = true
-          }
+          tableData.push(obj);
+        }))
+      } else {
+        let obj = {
+          email: email,
+          personIdentifier: personIdentifier,
+          userID: userID,
+          nameFirst: nameFirst,
+          nameLast: nameLast,
+          department: "",
+          primaryOrganizationalUnit: person && Object.keys(person).length > 0 && person.primaryOrganizationalUnit || "",
+          listRoles: listRoles || [],
+          scope_person_types: scope_person_types || null,
+          scope_org_units: scope_org_units || null,
+          proxy_person_ids: proxy_person_ids || null,
         }
-        if (addUser) {
-          filteredUsers.push(user);
-        }
+        tableData.push(obj);
       }
-    }
-  })
-  }
-  if(filteredUsers && filteredUsers.length > 0 ) setUsers( filteredUsers)
-  else setUsers( allUsers)
- 
-}
-
-  
-  const handleCountUpdate = (count) => {
-    if (count) {
-      setPage(page);
-      setCount(parseInt(count));
-      fetchPaginatedData(parseInt(count))
-    }
+    })
+    setUsers(tableData);
+    setAllUsers(tableData)
   }
 
-  const handleSearchUpdate = async (e) => {
-    let inputBySearch = e.target.value;
-    await setSearchText(inputBySearch);
+  const onReset = () => {
+    setPage(1);
+    setCount(100);
+    setSearchText("");
+    setFilterText("");
+    fetchAllAdminUsers(1, 100);
+  }
+
+  const handlePaginationUpdate = (newPage) => {
+    setPage(newPage)
+    fetchAllAdminUsers(newPage, count)
+  }
+
+  const handleCountUpdate = (newCount) => {
+    if (newCount) {
+      setPage(1);
+      setCount(parseInt(newCount));
+      fetchAllAdminUsers(1, parseInt(newCount))
     }
-    const onSearch = ()=>{
-     if(searchText.trim().length >= 3) {
+  }
+
+  const handleSearchUpdate = (e) => {
+    setSearchText(e.target.value);
+  }
+
+  const onSearch = () => {
+    if (searchText.trim().length >= 3) {
       fetchAllAdminUsers(page, count, searchText)
-     }}
+    }
+  }
+
+  const handleFilterUpdate = (e) => {
+    const text = e.target.value;
+    setFilterText(text);
+    if (!text) {
+      setUsers(allUsers);
+      return;
+    }
+    const term = text.toLowerCase();
+    const filtered = allUsers.filter((user) => {
+      return (
+        (user.nameFirst && user.nameFirst.toLowerCase().includes(term)) ||
+        (user.nameLast && user.nameLast.toLowerCase().includes(term)) ||
+        (user.personIdentifier && user.personIdentifier.toLowerCase().includes(term)) ||
+        (user.department && user.department.toLowerCase().includes(term)) ||
+        (user.email && user.email.toLowerCase().includes(term)) ||
+        (user.primaryOrganizationalUnit && user.primaryOrganizationalUnit.toLowerCase().includes(term))
+      );
+    });
+    setUsers(filtered);
+  }
+
+  const onSendNotifications = () => {
+    sendNotification()
+  }
+
+  const totalPages = Math.ceil(totalCount / count);
 
   return (
     <div className={appStyles.mainContainer}>
-      <PageHeader label="Manage Users" />
-      <Row className={styles.globalfilter}>
-        <Col md={4} className={styles.pt5}>
-          <InputGroup className="mb-3">
-            <Form.Control
-              type="text"
-              className={`form-control ${styles.searchInput}`}
-              placeholder="Search users"
-              aria-label="Search users"
-              value={searchText}
-              onChange={handleSearchUpdate}
-              onKeyDown={(e) => { if (e.key === 'Enter') onSearch(); }}
-            />
-            <Button variant="outline-secondary" onClick={onSearch}>Search</Button>
-          </InputGroup>
-        </Col>
-        <Col md={3} className={styles.pt5}>
-          <Form.Group controlId="roleFilter">
-            <Form.Label htmlFor="roleFilter">Filter by role</Form.Label>
-            <Form.Select
-              id="roleFilter"
-              value={roleFilter}
-              onChange={(e) => {
-                setRoleFilter(e.target.value);
-                fetchAllAdminUsers(1, count, searchText, e.target.value);
-              }}
-            >
-              <option value="">All Roles</option>
-              <option value="Superuser">Superuser</option>
-              <option value="Curator_All">Curator_All</option>
-              <option value="Curator_Scoped">Curator_Scoped</option>
-              <option value="Curator_Self">Curator_Self</option>
-              <option value="Reporter_All">Reporter_All</option>
-            </Form.Select>
-          </Form.Group>
-        </Col>
-        <Col md={1}>
-        <Button variant="link" className={`mt-1 pt-2 ${styles.textButton}`} onClick={onReset}>Reset</Button>
-        </Col>
-        <Col md={4}>
-          <Button className="my-1 floatRight" onClick={() => router.push("/manageusers/add")}>Add User</Button>
-        </Col>
-      </Row>
-      {/* <Button className="my-2" onClick={() => router.push("/admin/users/add")}>Add User</Button> */}
-      {loading ?
-        <SkeletonTable />
-        :
-        <>
-          <Pagination total={totalCount} page={page} count={count} onCountChange={handleCountUpdate} onChange={handlePaginationUpdate} />
-          <div className={`row ${styles.filterSecbgColor}`}>
-          <div className="col-md-5"></div>
-            <div className="col-md-7">
-              <Filter onSearch={handleFilterUpdate} showSort={false} isFrom="pubMed"/>
-            </div>
-          </div>
-            <UsersTable data={users} />
-          <Pagination total={totalCount} page={page} count={count}  onCountChange={handleCountUpdate} onChange={handlePaginationUpdate} />
-        </>}
-      <ToastContainerWrapper />
+      {/* Page header */}
+      <div className={styles.pageHeader}>
+        <div>
+          <h1 className={styles.pageTitle}>Manage Users</h1>
+          <p className={styles.pageSubtitle}>Administer user access and notification settings</p>
+        </div>
+        <button className={styles.btnAdd} onClick={() => router.push("/manageusers/add")}>
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M8 3v10M3 8h10"/></svg>
+          Add User
+        </button>
+      </div>
 
+      {/* Search row */}
+      <div className={styles.searchRow}>
+        <div className={styles.searchInputWrap}>
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8"><circle cx="6.5" cy="6.5" r="4"/><path d="M11 11l2.5 2.5"/></svg>
+          <input
+            className={styles.searchInput}
+            type="text"
+            placeholder="Search by name, CWID, or email..."
+            value={searchText}
+            onChange={handleSearchUpdate}
+            onKeyDown={(e) => e.key === 'Enter' && onSearch()}
+          />
+        </div>
+        <button className={styles.btnSearch} onClick={onSearch}>Search</button>
+        <button className={styles.btnReset} onClick={onReset}>Reset</button>
+      </div>
+
+      {pageLoading ? (
+        <div className="d-flex justify-content-center align-items"><Loader /></div>
+      ) : (
+        <div className={styles.tableCard}>
+          {/* Controls bar */}
+          <div className={styles.tableControls}>
+            <div className={styles.controlsLeft}>
+              <span className={styles.ctrlLabel}>Show</span>
+              <select className={styles.ctrlSelect} value={count} onChange={(e) => handleCountUpdate(e.target.value)}>
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+                <option value={100}>100</option>
+                <option value={200}>200</option>
+              </select>
+              <span className={styles.ctrlLabel}>per page</span>
+            </div>
+
+            <div className={styles.filterWrap}>
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8"><circle cx="6.5" cy="6.5" r="4"/><path d="M11 11l2.5 2.5"/></svg>
+              <input
+                className={styles.filterInput}
+                type="text"
+                placeholder="Filter this page..."
+                value={filterText}
+                onChange={handleFilterUpdate}
+              />
+            </div>
+
+            {totalCount > 0 && (
+              <div className={styles.pageNav}>
+                <button className={styles.pageBtn} onClick={() => handlePaginationUpdate(page - 1)} disabled={page === 1}>&#8249;</button>
+                <span className={styles.pageInfo}>
+                  Page <strong>{page.toLocaleString()}</strong> of {totalPages.toLocaleString()}
+                </span>
+                <button className={styles.pageBtn} onClick={() => handlePaginationUpdate(page + 1)} disabled={page >= totalPages}>&#8250;</button>
+              </div>
+            )}
+          </div>
+
+          {/* Table */}
+          <UsersTable
+            isVisibleNotification={isVisibleNotification}
+            data={users}
+            onSendNotifications={onSendNotifications}
+            nameOrcwidLabel={nameOrcwidLabel}
+          />
+        </div>
+      )}
+      <ToastContainerWrapper />
     </div>
   )
 }

--- a/src/components/elements/Manage/UsersTable.tsx
+++ b/src/components/elements/Manage/UsersTable.tsx
@@ -1,81 +1,129 @@
 import React from 'react';
-import Table from 'react-bootstrap/Table';
 import styles from "./UsersTable.module.css";
-import Image from 'next/image'
-import Link from "next/link";
 import { useRouter } from 'next/router'
-import { Button } from 'react-bootstrap';
+import { notificationEmail } from '../../../redux/actions/actions';
+import { useDispatch } from 'react-redux';
+import SplitDropdown from '../Dropdown/SplitDropdown';
 
-interface UsersTableProps {
-  data: any
+const ROLE_LABELS: Record<string, string> = {
+  'Superuser': 'Superuser',
+  'Curator_All': 'Curator \u2014 All',
+  'Curator_Self': 'Curator \u2014 Self',
+  'Curator_Scoped': 'Curator \u2014 Scoped',
+  'Curator_Department': 'Curator \u2014 Department',
+  'Curator_Department_Delegate': 'Curator \u2014 Department Delegate',
+  'Reporter_All': 'Reporter \u2014 All',
+};
+
+function parseJsonColumn(val: any): any[] {
+  if (!val) return [];
+  if (Array.isArray(val)) return val;
+  if (typeof val === 'string') {
+    try { return JSON.parse(val); } catch { return []; }
+  }
+  return [];
 }
 
-const UsersTable:React.FC<UsersTableProps> = ({ data }) => {
+interface UsersTableProps {
+  data: any,
+  onSendNotifications: () => void,
+  nameOrcwidLabel?:string,
+  isVisibleNotification?:boolean
+}
+
+const UsersTable:React.FC<UsersTableProps> = ({ data, onSendNotifications, nameOrcwidLabel, isVisibleNotification }) => {
   const router = useRouter();
+  const dispatch = useDispatch();
+
+  const redirectToManageUsers = (userID) => {
+    router.push(`/manageusers/${userID}`)
+  }
+
+  const handleDropdownClick = (title: string, user: any) => {
+    if (title === 'Manage Profile') {
+      router.push(`/manageprofile/${user.personIdentifier}`)
+    } else if (title === 'Manage Notifications') {
+      dispatch(notificationEmail({ email: user.email, userName: user.nameFirst }));
+      router.push(`/notifications/${user.personIdentifier}`)
+    }
+  }
+
+  const listItems = isVisibleNotification
+    ? [{ title: 'Manage Profile', to: '' }, { title: 'Manage Notifications', to: '' }]
+    : [{ title: 'Manage Profile', to: '' }];
+
+  const renderRoleCell = (user: any) => {
+    const roles = user.listRoles || [];
+    const personTypes = parseJsonColumn(user.scope_person_types);
+    const orgUnits = parseJsonColumn(user.scope_org_units);
+    const proxyIds = parseJsonColumn(user.proxy_person_ids);
+
+    return (
+      <div>
+        {roles.length > 0 ? roles.map((roleObj: any, idx: number) => {
+          const label = roleObj.AdminRole?.roleLabel || roleObj.listRole?.roleLabel || '';
+          if (label === 'Curator_Scoped') {
+            const scopeItems = [...personTypes, ...orgUnits];
+            const scopeSummary = scopeItems.length > 0 ? ` (${scopeItems.join(', ')})` : '';
+            return <div key={label + idx} className={styles.roleLabel}>Curator &mdash; Scoped{scopeSummary}</div>;
+          }
+          return <div key={label + idx} className={styles.roleLabel}>{ROLE_LABELS[label] || label}</div>;
+        }) : <span className={styles.roleMuted}>&mdash;</span>}
+        {proxyIds.length > 0 && (
+          <div className={styles.proxyCount}>
+            {proxyIds.length === 1 ? '1 proxy' : `${proxyIds.length} proxies`}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   return (
-    <Table striped bordered hover>
-      <thead className={styles.tableHead}>
-        <tr className={styles.tableHeadRow}>
-          <th scope="col" className={styles.tableHeadCell}>Name</th>
-          <th scope="col" className={styles.tableHeadCell}>Department</th>
-          <th scope="col" className={styles.tableHeadCell}>Roles</th>
-          <th scope="col" className={styles.tableHeadCell}>Email</th>
-          <th scope="col" className={styles.tableHeadCell} style={{ minWidth: '80px' }}>Proxies</th>
-          <th scope="col" className={styles.tableHeadCell}>Actions</th>
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Role</th>
+          <th>Email</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-        {
-         data && data.length > 0 ? data.map((user, index) => {
-            const {nameFirst, nameLast, userID,personIdentifier,email} = user;
-            const roles = user.adminUsersRoles?.map(ur => ur.role?.roleLabel).filter(Boolean) || [];
-            const personTypes = user.adminUsersPersonTypes?.map(pt => pt.personType).filter(Boolean) || [];
-            const departments = user.adminUsersDepartments?.map(ud => ud.department?.departmentLabel).filter(Boolean) || [];
-            return (
-              <tr key={index}>
-                <td><div>
-                  <p className="text-primary mb-0">{`${nameFirst && nameFirst != "null" ? nameFirst : "" } ${nameLast && nameLast != "null" ? nameLast : ""}`}</p>
-                  <p>person ID: {personIdentifier}</p>
-                  </div>
-                  </td>
-                <td>{departments.join(', ')}</td>
-                <td>
-                  <span style={{ fontSize: '14px', fontWeight: 400 }}>
-                    {roles.map((role, i) => {
-                      if (role === 'Curator_Scoped') {
-                        const scopeParts = [...personTypes, ...departments];
-                        return (
-                          <span key={i}>
-                            {i > 0 ? ', ' : ''}Curator_Scoped
-                            {scopeParts.length > 0 && (
-                              <span style={{ fontSize: '12px', fontWeight: 600, color: '#777777' }}>
-                                {' '}({scopeParts.join(', ')})
-                              </span>
-                            )}
-                          </span>
-                        );
-                      }
-                      return <span key={i}>{i > 0 ? ', ' : ''}{role}</span>;
-                    })}
+        {data && data.length > 0 ? data.map((user, index) => {
+          const { nameFirst, nameLast, userID, personIdentifier, email, department, primaryOrganizationalUnit } = user;
+          return (
+            <tr key={index}>
+              <td>
+                <div className={styles.personName}>{`${nameFirst || ''} ${nameLast || ''}`}</div>
+                {(primaryOrganizationalUnit || department) && (
+                  <div className={styles.personDept}>{primaryOrganizationalUnit || department}</div>
+                )}
+                <div className={styles.personId}>
+                  <span className={styles.idLabel}>{nameOrcwidLabel || 'CWID'}:</span> {personIdentifier || ''}
+                </div>
+              </td>
+              <td>{renderRoleCell(user)}</td>
+              <td><span className={styles.email}>{email || ''}</span></td>
+              <td>
+                <button type="button" className={styles.actionLink} onClick={() => redirectToManageUsers(userID)}>Edit</button>
+                {listItems && listItems.map((item, i) => (
+                  <span key={i}>
+                    <span className={styles.actionDot}>·</span>
+                    <button type="button" className={styles.actionLink} onClick={() => handleDropdownClick(item.title, user)}>{item.title}</button>
                   </span>
-                </td>
-                <td>{email}</td>
-                <td>
-                  {(() => {
-                    const count = user.adminUsersProxies?.length || 0;
-                    if (count === 0) return '\u2014';
-                    if (count === 1) return '1 person';
-                    return `${count} people`;
-                  })()}
-                </td>
-                <td> <div> <Button   variant="outline-dark" className='fw-bold' href={`/manageusers/${userID}`} size="sm">Manage User</Button> <Button size="sm" variant="outline-dark"  className='d-none text-light'>Manage Notifications</Button></div>
-                </td>
-              </tr>
-            )
-          }) : <tr><td colSpan={6}><p className={styles.noRecordsFound}>No Records Found</p></td></tr>
-        }
+                ))}
+              </td>
+            </tr>
+          )
+        }) : (
+          <tr>
+            <td colSpan={4}>
+              <p className={styles.noRecordsFound}>No Records Found</p>
+            </td>
+          </tr>
+        )}
       </tbody>
-    </Table>
+    </table>
   )
 }
 


### PR DESCRIPTION
## Summary
The dev_v2 re-restore in `2a0a747` dropped the rich ManageUsers page UI:
- ManageUsers.tsx: -228 net lines
- UsersTable.tsx: -88 net lines

Restored from `b7210e6`. v3 patch on ManageUsers (UsersTable has no auth import).

## Test plan
- [ ] CodeBuild green
- [ ] /manageusers shows the rich list UI (search, filter, role badges, action buttons, etc.)
- [ ] /manageusers/[userId] edit page still functions (uses these as parent context)