### PR TITLE
fix(ui): restore Login.js + AddUser autocomplete font consistency

### DIFF
--- a/src/components/elements/AddUser/AddUser.tsx
+++ b/src/components/elements/AddUser/AddUser.tsx
@@ -253,10 +253,14 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
     }, [router.query.userId, allAdminRoles])
 
     const CssTextField = styled(TextField)({
+        // Match the .fieldInput CSS in AddUser.module.css so the Autocomplete
+        // text fields in the Curation Scope and Proxy Assignment sections are
+        // visually consistent with the plain inputs above them on this form.
         '& .MuiOutlinedInput-root': {
             background: 'rgba(255, 255, 255, 0.9)',
             borderColor: '#ced4da',
             padding: '.375rem .75rem',
+            fontSize: '13px',
             '& fieldset': {
                 top: '0px',
                 '& legend': {
@@ -266,6 +270,15 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
             '&:hover fieldset': {
                 borderColor: '#ced4da',
             },
+        },
+        '& .MuiOutlinedInput-input': {
+            fontSize: '13px',
+        },
+        '& .MuiAutocomplete-tag': {
+            fontSize: '13px',
+        },
+        '& input::placeholder': {
+            fontSize: '13px',
         },
     });
 

--- a/src/components/elements/Login/Login.js
+++ b/src/components/elements/Login/Login.js
@@ -7,7 +7,7 @@ import Router from "next/router"
 import Header from "../Header/Header"
 import { signIn,getSession } from "next-auth/client"
 import { toast } from "react-toastify"
-import { allowedPermissions } from "../../../utils/constants";
+import { getPermissionsFromRaw, getLandingPageFromPermissions } from '../../../utils/permissionUtils';
 import { useRouter } from 'next/router'
 
 const Login = () => {
@@ -19,19 +19,12 @@ const Login = () => {
     const session = getSession();
     const router = useRouter()
 
-    const validateForm = () => {
-        if(username === ''){
-            setIsShowButton(true)
-        } else if(password === '') {
-            setIsShowButton(true)
-        } else {
-            setIsShowButton(false)
-        }
-    }
+    useEffect(() => {
+        setIsShowButton(username === '' || password === '')
+    }, [username, password])
 
     const handleUserNameInput = e => {
         setUsername(e.target.value)
-        validateForm()
     }
 
     const handleSubmit = async(e) => {
@@ -48,17 +41,20 @@ const Login = () => {
                 autoClose: 2000,
                 theme: "colored"
             });
-            //if(session && session.data && session.data.userRoles)
-             getSession().then((session) => {
+            getSession().then((session) => {
                 if (session) {
-                    let userPermissions = JSON.parse(session.data.userRoles);
-                    let userName = session.data.username;
-                    let personIdentifier = userPermissions && userPermissions.length > 0 ? userPermissions[0].personIdentifier : ""
-                    if((userPermissions.some(role => role.roleLabel === allowedPermissions.Curator_Self)) && userName)  
-                        router.push(`/curate/${personIdentifier}`);
-                    else 
-                        router.push('/search');
-                } 
+                    const permissions = getPermissionsFromRaw(session?.data?.permissions)
+                    const userRoles = session.data.userRoles ? JSON.parse(session.data.userRoles) : []
+
+                    if (!session.data.databaseUser || session.data.databaseUser.status == 0) {
+                        router.push('/noaccess')
+                    } else if (permissions.length === 0 && (!userRoles || userRoles.length === 0)) {
+                        router.push('/noaccess')
+                    } else {
+                        const landingPage = getLandingPageFromPermissions(permissions, userRoles)
+                        router.push(landingPage)
+                    }
+                }
             });
             
         } else {
@@ -73,26 +69,22 @@ const Login = () => {
 
     const handlePasswordInput = e => {
         setPassword(e.target.value)
-        validateForm()
     }
 
     return (
         <div className={styles.loginMainContainer}>
-        <Header/>
+        {/* <Header/> */}
         <div className={styles.formContainer}>
             <Form className={styles.loginForm} onSubmit={handleSubmit}>
             <h3>Sign in to your account</h3>
             <p>Please enter your CWID and password to log in.</p>
             <FormGroup controlId="username" style={{marginBottom: '10px'}}>
-                <Form.Label className="visually-hidden">CWID</Form.Label>
                 <FormControl
-                type="text"
-                autoComplete="username"
+                type="username"
                 value={username}
                 onChange={handleUserNameInput}
                 placeholder="Username"
-                aria-label="CWID"
-                style={{
+                style={{ 
                         background: `url("../../../images/icon-login-user.png")`,
                         backgroundSize: '15px 15px',
                         backgroundRepeat: 'no-repeat',
@@ -103,16 +95,14 @@ const Login = () => {
                 />
             </FormGroup>
             <FormGroup controlId="password" style={{marginBottom: '10px'}}>
-                <Form.Label className="visually-hidden">Password</Form.Label>
                 <FormControl
                 value={password}
                 onChange={handlePasswordInput}
                 type="password"
                 placeholder="Password"
-                aria-label="Password"
                 style={{
                         background: `url("../../../images/icon-login-pass.png")`,
-                        backgroundSize: '15px 15px',
+                        backgroundSize: '15px 15px', 
                         backgroundRepeat: 'no-repeat',
                         backgroundPosition: 'left 10px center',
                         paddingLeft: '32px'
@@ -138,7 +128,7 @@ const Login = () => {
             </Form>
         </div>
 
-        <Footer />
+        {/* <Footer /> */}
         </div>
     );
 };


### PR DESCRIPTION
## Summary
1. **Login.js**: restored from `b7210e6`. Patched `next-auth/react` → `next-auth/client`.
2. **AddUser.tsx**: the MUI styled `CssTextField` used by the Curation Scope and Proxy Assignments autocomplete inputs defaulted to MUI's 16px while the plain `.fieldInput` rule in `AddUser.module.css` is 13px. Same Edit User form was visually mixing two input sizes. Added `fontSize: 13px` on the OutlinedInput, the input element, the autocomplete chip tags, and the placeholder.

## Test plan
- [ ] CodeBuild green
- [ ] /login renders the v1 form correctly
- [ ] /manageusers/[userId] (Edit User) — all input fields appear at the same size, including Person Types / Org Units / Proxy users autocompletes