### PR TITLE
fix(rbac): persist + enforce Curator_Scoped scope; fix AddUser redirect

### DIFF
--- a/controllers/db/manage-users/user.controller.ts
+++ b/controllers/db/manage-users/user.controller.ts
@@ -239,9 +239,9 @@ export const createOrUpdateAdminUser = async (
         'nameMiddle': middleName,
         'nameLast': lastName,
         'modifyTimestamp': new Date(),
-        // Phase 9: Scope fields for Curator_Scoped role
-        'scope_person_types': req.body.scopePersonTypes || null,
-        'scope_org_units': req.body.scopeOrgUnits || null,
+        // Phase 9: Scope fields for Curator_Scoped role (stored as JSON text)
+        'scope_person_types': Array.isArray(req.body.scopePersonTypes) && req.body.scopePersonTypes.length ? JSON.stringify(req.body.scopePersonTypes) : null,
+        'scope_org_units': Array.isArray(req.body.scopeOrgUnits) && req.body.scopeOrgUnits.length ? JSON.stringify(req.body.scopeOrgUnits) : null,
       }
       
 
@@ -316,9 +316,9 @@ export const createOrUpdateAdminUser = async (
         'email': email,
         'status': 1,  // Hardcoded 1 to make user active bydefault
         'createTimestamp': new Date(),
-        // Phase 9: Scope fields for Curator_Scoped role
-        'scope_person_types': req.body.scopePersonTypes || null,
-        'scope_org_units': req.body.scopeOrgUnits || null,
+        // Phase 9: Scope fields for Curator_Scoped role (stored as JSON text)
+        'scope_person_types': Array.isArray(req.body.scopePersonTypes) && req.body.scopePersonTypes.length ? JSON.stringify(req.body.scopePersonTypes) : null,
+        'scope_org_units': Array.isArray(req.body.scopeOrgUnits) && req.body.scopeOrgUnits.length ? JSON.stringify(req.body.scopeOrgUnits) : null,
       }
 
       

--- a/controllers/db/userroles.controller.ts
+++ b/controllers/db/userroles.controller.ts
@@ -154,6 +154,67 @@ export const findUserPermissionsEnriched = async (
     return { permissions, permissionResources };
 };
 
+/**
+ * Resolve a user's curation scope (Curator_Scoped) from the stored JSON columns.
+ * Returns { personTypes, orgUnits } where each is a non-empty string[] or null
+ * (null = no restriction on that axis). Used to enrich the JWT at login.
+ */
+export const findUserScope = async (
+  attrTypes: string[],
+  attrValues: string[]
+): Promise<{ personTypes: string[] | null; orgUnits: string[] | null }> => {
+
+    if (!Array.isArray(attrTypes) || !Array.isArray(attrValues) || attrTypes.length !== attrValues.length) {
+        return { personTypes: null, orgUnits: null };
+    }
+
+    const allowedFields = ['email', 'personIdentifier'];
+    const replacements: Record<string, any> = { personIdentifier: '', email: '' };
+
+    attrTypes.forEach((field, index) => {
+        const value = attrValues[index] ?? '';
+        if (!allowedFields.includes(field)) return;
+        if (field === 'personIdentifier') replacements.personIdentifier = value;
+        if (field === 'email') replacements.email = value;
+    });
+
+    const whereClause = `
+        (au.personIdentifier = :personIdentifier AND au.email = :email)
+        OR
+        (
+        au.email = :email
+        AND au.email IS NOT NULL AND au.email <> ''
+        AND au.email IN (
+            SELECT email
+            FROM admin_users
+            WHERE email IS NOT NULL AND email <> ''
+            GROUP BY email
+            HAVING COUNT(*) = 1
+        )
+        )
+    `;
+
+    const rows: any[] = await sequelize.query(
+        `SELECT au.scope_person_types, au.scope_org_units FROM admin_users au WHERE ${whereClause}`,
+        { replacements, raw: true, nest: true }
+    );
+
+    // Prefer the row that actually has scope set (handles duplicate-email rows)
+    const chosen: any = rows.find((r: any) => r.scope_person_types || r.scope_org_units) || rows[0] || {};
+
+    const parse = (v: any): string[] | null => {
+        if (!v) return null;
+        try {
+            const arr = JSON.parse(v);
+            return Array.isArray(arr) && arr.length ? arr : null;
+        } catch {
+            return null;
+        }
+    };
+
+    return { personTypes: parse(chosen.scope_person_types), orgUnits: parse(chosen.scope_org_units) };
+};
+
 
 
 

--- a/src/components/elements/AddUser/AddUser.tsx
+++ b/src/components/elements/AddUser/AddUser.tsx
@@ -129,8 +129,9 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
             let selectedRoleIds = roleIds || [];
             let departmentIds = departMentIds || [];
             let isEditUserId = router.query.userId;
-            let personTypeLabels = hasScopedRole ? selectedPersonTypes : [];
-            let createOrUpdatePayload = { cwid, email, firstName, lastName, middleName, division, title, selectedRoleIds, departmentIds, isEditUserId, personTypeLabels }
+            let scopePersonTypes = hasScopedRole ? selectedPersonTypes : [];
+            let scopeOrgUnits = hasScopedRole ? selectedDepartments : [];
+            let createOrUpdatePayload = { cwid, email, firstName, lastName, middleName, division, title, selectedRoleIds, departmentIds, isEditUserId, scopePersonTypes, scopeOrgUnits }
 
             if (isEditUserId) {
                 let resp = await createAdminUser(createOrUpdatePayload)
@@ -202,9 +203,9 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
         if (isEditUserId && allAdminRoles.length > 0) {
             setLoading(true)
             let userDetails = fetchUserInfoByID(isEditUserId).then(result => {
-                const { adminUsersDepartments, adminUsersRoles, email, nameFirst, nameLast, nameMiddle, personIdentifier } = result && result[0];
+                const { adminUsersDepartments, adminUsersRoles, email, nameFirst, nameLast, nameMiddle, personIdentifier, scope_person_types, scope_org_units } = result && result[0];
+                let roleNames = [];
                 if (adminUsersRoles) {
-                    let roleNames = [];
                     allAdminRoles.map(role => {
                         adminUsersRoles.map((editRole) => {
                             if (editRole.roleID === role.roleID) roleNames.push(role.roleLabel)
@@ -212,20 +213,27 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
                     })
                     setSelectedRoles(roleNames ? roleNames : [])
 
-                    // Load person type scope data for edit
+                    // Load saved person-type scope for edit (stored as JSON on the user record)
                     if (roleNames.includes('Curator_Scoped')) {
-                        fetch(`/api/db/admin/users/persontypes?userId=${isEditUserId}`, {
-                            headers: { 'Authorization': reciterConfig?.backendApiKey || '' },
-                        })
-                            .then(r => r.json())
-                            .then(data => {
-                                if (Array.isArray(data)) setSelectedPersonTypes(data.map(d => d.personType));
-                            })
-                            .catch(err => console.log('Error fetching user person types:', err));
+                        try {
+                            const savedPersonTypes = scope_person_types ? JSON.parse(scope_person_types) : [];
+                            if (Array.isArray(savedPersonTypes)) setSelectedPersonTypes(savedPersonTypes);
+                        } catch (err) {
+                            console.log('Error parsing scope_person_types:', err);
+                        }
                     }
                 }
 
-                if (adminUsersDepartments) {
+                if (roleNames.includes('Curator_Scoped')) {
+                    // Scoped curators: org-unit scope lives in scope_org_units, not the department join
+                    try {
+                        const savedOrgUnits = scope_org_units ? JSON.parse(scope_org_units) : [];
+                        setSelectedDepartments(Array.isArray(savedOrgUnits) ? savedOrgUnits : [])
+                    } catch (err) {
+                        console.log('Error parsing scope_org_units:', err);
+                        setSelectedDepartments([])
+                    }
+                } else if (adminUsersDepartments) {
                     let departmentNames = [];
                     adminDepartments.map((department) => {
                         adminUsersDepartments.map((editIds) => {

--- a/src/components/elements/AddUser/AddUser.tsx
+++ b/src/components/elements/AddUser/AddUser.tsx
@@ -153,7 +153,7 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
                         console.log('Error saving proxy assignments:', err);
                     }
                     dispatch(createORupdateUserIDAction("UserID " + isEditUserId + " has been Updated"))
-                    router.push("/admin/manage/users")
+                    router.push("/manageusers")
                 }
             }
             else {
@@ -177,7 +177,7 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
                         console.log('Error saving proxy assignments:', err);
                     }
                     dispatch(createORupdateUserIDAction("UserID " + resp[0].userID + " has been Created"))
-                    router.push("/admin/manage/users")
+                    router.push("/manageusers")
                 }
             }
         }

--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -4,7 +4,7 @@ import saml2 from "saml2-js";
 import { reciterSamlConfig }  from "../../../../config/saml"
 import { authenticate } from "../../../../controllers/authentication.controller";
 import { findOrCreateAdminUsers,findOrCreateAdminUserRole } from '../../../../controllers/db/admin.users.controller';
-import { findUserPermissions, findUserPermissionsEnriched } from '../../../../controllers/db/userroles.controller';
+import { findUserPermissions, findUserPermissionsEnriched, findUserScope } from '../../../../controllers/db/userroles.controller';
 import {fetchUpdatedAdminSettings, findOneAdminSettings} from '../../../../controllers/db/admin.settings.controller';
 import { createAdminUser } from "../../../redux/actions/actions";
 import { reciterConfig } from "../../../../config/local";
@@ -48,6 +48,15 @@ const findOrcreateAdminUser = async(cwid,samlEmail,samlFirstName,samlLastName) =
                 console.error('Permission enrichment failed:', err);
                 createdAdminUser.permissions = [];
                 createdAdminUser.permissionResources = [];
+            }
+        }
+        // Phase 9: Resolve curation scope (Curator_Scoped) into the JWT
+        if(samlEmail || cwid) {
+            try {
+                createdAdminUser.scopeData = await findUserScope([EMAIL, PERSONIDENTIFIER], [samlEmail, cwid]);
+            } catch(err) {
+                console.error('Scope enrichment failed:', err);
+                createdAdminUser.scopeData = { personTypes: null, orgUnits: null };
             }
         }
           let databaseUser = {
@@ -315,6 +324,10 @@ const options = {
               }
               if(apiResponse.permissionResources) {
                   token.permissionResources = JSON.stringify(apiResponse.permissionResources)
+              }
+              // Phase 9: Carry curation scope in JWT (read by checkCurationScope / Search / SideNavbar)
+              if(apiResponse.scopeData) {
+                  token.scopeData = JSON.stringify(apiResponse.scopeData)
               }
             }
             return token

--- a/src/utils/checkCurationScope.ts
+++ b/src/utils/checkCurationScope.ts
@@ -59,23 +59,33 @@ export async function checkCurationScope(
       ? JSON.parse(token.scopeData as string)
       : null
 
-    const person = await models.Person.findOne({
-      where: { personIdentifier: targetUid },
-      attributes: ['primaryOrganizationalUnit'],
-      raw: true,
-    })
+    // Fail closed: a scoped curator with no configured scope can curate no one.
+    // isPersonInScope treats a null/empty scope as "no restriction" (allow-all) —
+    // correct for the search filter, but wrong for the curate gate, so guard here.
+    const hasScope =
+      !!scopeData &&
+      ((Array.isArray(scopeData.personTypes) && scopeData.personTypes.length > 0) ||
+        (Array.isArray(scopeData.orgUnits) && scopeData.orgUnits.length > 0))
 
-    const personTypes = await models.PersonPersonType.findAll({
-      where: { personIdentifier: targetUid },
-      attributes: ['personType'],
-      raw: true,
-    })
+    if (hasScope) {
+      const person = await models.Person.findOne({
+        where: { personIdentifier: targetUid },
+        attributes: ['primaryOrganizationalUnit'],
+        raw: true,
+      })
 
-    const orgUnit = person?.primaryOrganizationalUnit || null
-    const types = personTypes.map((pt: any) => pt.personType).filter(Boolean)
+      const personTypes = await models.PersonPersonType.findAll({
+        where: { personIdentifier: targetUid },
+        attributes: ['personType'],
+        raw: true,
+      })
 
-    if (isPersonInScope(scopeData, orgUnit, types)) {
-      return { allowed: true }
+      const orgUnit = person?.primaryOrganizationalUnit || null
+      const types = personTypes.map((pt: any) => pt.personType).filter(Boolean)
+
+      if (isPersonInScope(scopeData, orgUnit, types)) {
+        return { allowed: true }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Completes the `Curator_Scoped` (role-factoring) feature, which was collected in the admin UI but never took effect, plus a redirect fix. Targets the canonical dev branch `dev_Upd_NextJS14SNode18`.

### Commits
1. **AddUser post-save redirect → `/manageusers`** — previously pushed admins to the legacy `/admin/manage/users` page, dropping them out of the new Roles/Permissions tabbed UI.
2. **Make `Curator_Scoped` scope persist and enforce end-to-end** — four coordinated parts:
   - **Persist:** AddUser sent `personTypeLabels` (and nothing for org units) while the controller read `scopePersonTypes`/`scopeOrgUnits` and stored them raw. Now sends both and `JSON.stringify`s into `scope_person_types` / `scope_org_units`.
   - **Rehydrate on edit:** the edit form fetched a non-existent `/api/db/admin/users/persontypes` route (404). Now parses the saved scope columns from the user record; scoped curators load org units from `scope_org_units` rather than the department join.
   - **Enrich the JWT:** `token.scopeData` was never built, so enforcement always saw `null`. Added `findUserScope()` and set `token.scopeData` at login (surfaces to `session.data.scopeData` via the existing session callback).
   - **Fail-closed guard:** `isPersonInScope` treats a null/empty scope as allow-all, so a scoped curator with no scope could curate **anyone**. The curate gate now denies an unscoped scoped-curator.

## Why it matters
Before this, `Curator_Scoped` was effectively **fail-open** for the curate gate and the search scope filter never engaged. (Prod exposure is nil today: no `scope_person_types` column on prod and zero `Curator_Scoped` users.)

## Verification needed on reciter-dev (can't be tested locally — SAML/JWT path)
- [ ] Log in as a `Curator_Scoped` test user.
- [ ] In Manage Users → edit that user: confirm Person Types + Organizational Units **save and reload** correctly.
- [ ] Confirm the curate gate + search scope filter actually **restrict** to the configured scope.
- [ ] **Vocabulary check:** `scope_org_units` stores `AdminDepartment.departmentLabel`, matched against `Person.primaryOrganizationalUnit`. Confirm those values align in dev (person-type scope is unaffected — uses `PersonPersonType`).

## Notes
- `tsc --noEmit` clean for all changed files (only pre-existing `__tests__` jest-globals errors remain, which `next build` does not type-check).
- Back-port caveat: prod reciterDB lacks the `scope_*` columns — the migration must run before this code reaches prod.
