### PR TITLE
feat(audit): Audit History panel on curate page (FeedbackLog + provenance)

### DIFF
--- a/config/local.js
+++ b/config/local.js
@@ -100,6 +100,11 @@ export const reciterConfig = {
         reciterUpdateGoldStandardEndpoint:
                 process.env.RECITER_API_BASE_URL + '/reciter/goldstandard',
         /**
+         * Read-only curation audit history (FeedbackLog + ArticleProvenance) by uid.
+         */
+        reciterFeedbackLogEndpoint:
+                process.env.RECITER_API_BASE_URL + '/reciter/feedback-log/',
+        /**
          * This endpoints serves to do CRUD on user feedback. This is used to track the publication feedback in the application. When refreshed
          * the feedback is erased from the database.
          */

--- a/controllers/db/manage-users/user.controller.ts
+++ b/controllers/db/manage-users/user.controller.ts
@@ -11,6 +11,33 @@ models.AdminUser.hasMany(models.AdminDepartment, {as:'AdminDepartment', constrai
 models.AdminUser.hasMany(models.AdminUsersRole, { as: 'listRoles', constraints: false, foreignKey: 'userID' });
 models.AdminUsersRole.belongsTo(models.AdminRole, { as: 'listRole', constraints: false, foreignKey: 'roleID' });
 
+/**
+ * Phase 34: resolve a set of admin_users.userID values to display names, for the
+ * curation Audit History (FeedbackLog.curatedBy). Returns a { userID: name } map;
+ * ids that are missing/invalid (e.g. 0 = unknown) are simply absent from the map.
+ */
+export const findAdminUserNamesByIds = async (ids: number[]): Promise<{ [id: number]: string }> => {
+  const map: { [id: number]: string } = {};
+  const valid = (ids || []).filter((id) => Number.isInteger(id) && id > 0);
+  if (valid.length === 0) {
+    return map;
+  }
+  try {
+    const users: any[] = await models.AdminUser.findAll({
+      where: { userID: { [Op.in]: valid } },
+      attributes: ['userID', 'nameFirst', 'nameLast'],
+      raw: true,
+    });
+    users.forEach((u) => {
+      const name = [u.nameFirst, u.nameLast].filter(Boolean).join(' ').trim();
+      map[u.userID] = name || String(u.userID);
+    });
+  } catch (e) {
+    console.log('findAdminUserNamesByIds error', e);
+  }
+  return map;
+};
+
 export const listAllUsers = async (
   req: NextApiRequest,
   res: NextApiResponse

--- a/controllers/feedbacklog.controller.ts
+++ b/controllers/feedbacklog.controller.ts
@@ -1,0 +1,28 @@
+import { reciterConfig } from '../config/local'
+
+/**
+ * Phase 34: fetch curation audit history (FeedbackLog + ArticleProvenance) for a uid
+ * from the ReCiter engine. Returns { statusCode, data } on success or
+ * { statusCode, statusText } on error. Never throws.
+ */
+export async function getFeedbackLog(uid: string): Promise<{ statusCode: number; data?: any; statusText?: string }> {
+    return fetch(`${reciterConfig.reciter.reciterFeedbackLogEndpoint}${encodeURIComponent(uid)}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            'api-key': reciterConfig.reciter.adminApiKey,
+            'User-Agent': 'reciter-pub-manager-server'
+        }
+    })
+        .then(async (res) => {
+            if (res.status !== 200) {
+                return { statusCode: res.status, statusText: await res.text() }
+            }
+            const data: any = await res.json()
+            return { statusCode: 200, data }
+        })
+        .catch((error) => {
+            console.log('ReCiter feedback-log api is not reachable: ' + error)
+            return { statusCode: error.status || 500, statusText: String(error) }
+        })
+}

--- a/controllers/goldstandard.controller.ts
+++ b/controllers/goldstandard.controller.ts
@@ -3,14 +3,17 @@ import { NextApiRequest } from 'next'
 import url from 'url'
 import { saveUserFeedback } from './userfeedback.controller'
 
-export async function updateGoldStandard(req: NextApiRequest)  {
+export async function updateGoldStandard(req: NextApiRequest, curatedBy?: number)  {
 
     const {
         query: { goldStandardUpdateFlag }
       } = req;
 
-    
-   return fetch(`${reciterConfig.reciter.reciterUpdateGoldStandardEndpoint}?goldStandardUpdateFlag=${goldStandardUpdateFlag}&source=publication-manager`, {
+    // Phase 34: forward the curating user's id so ReCiter records who performed the action
+    const curatedByParam = (curatedBy !== undefined && curatedBy !== null && !Number.isNaN(curatedBy))
+        ? `&curatedBy=${curatedBy}` : '';
+
+   return fetch(`${reciterConfig.reciter.reciterUpdateGoldStandardEndpoint}?goldStandardUpdateFlag=${goldStandardUpdateFlag}&source=publication-manager${curatedByParam}`, {
         method: "POST",
         headers: {
             'Content-Type': 'application/json',

--- a/src/components/elements/CurateIndividual/AuditHistoryPanel.module.css
+++ b/src/components/elements/CurateIndividual/AuditHistoryPanel.module.css
@@ -1,0 +1,77 @@
+.panel {
+  margin: 1.5rem 0;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .75rem 1rem;
+  background: #f7f8fa;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  cursor: pointer;
+  text-align: left;
+}
+
+.caret {
+  font-size: 10px;
+  color: #888;
+}
+
+.count {
+  margin-left: .5rem;
+  background: #e2e6ea;
+  color: #555;
+  border-radius: 10px;
+  padding: 0 .5rem;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.body {
+  padding: .5rem 1rem 1rem;
+}
+
+.muted { color: #888; font-size: 13px; margin: .5rem 0; }
+.error { color: #c0392b; font-size: 13px; margin: .5rem 0; }
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: .4rem .6rem;
+  border-bottom: 1px solid #eee;
+  vertical-align: top;
+}
+
+.table th {
+  color: #666;
+  font-weight: 600;
+  border-bottom: 2px solid #e0e0e0;
+}
+
+.badge {
+  display: inline-block;
+  padding: .1rem .5rem;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .02em;
+}
+
+.accepted { background: #e6f4ea; color: #1e7e34; }
+.rejected { background: #fdecea; color: #c0392b; }
+.pending  { background: #fef7e0; color: #8a6d00; }

--- a/src/components/elements/CurateIndividual/AuditHistoryPanel.tsx
+++ b/src/components/elements/CurateIndividual/AuditHistoryPanel.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useCallback } from 'react';
+import { reciterConfig } from '../../../../config/local';
+import styles from './AuditHistoryPanel.module.css';
+
+interface AuditEntry {
+  articleId?: string;
+  feedback?: string;
+  curatedBy?: number;
+  curatorName?: string | null;
+  createTimestamp?: number;
+  sk?: string;
+}
+
+interface Props {
+  uid: string;
+}
+
+const ACTION_CLASS: { [key: string]: string } = {
+  ACCEPTED: styles.accepted,
+  REJECTED: styles.rejected,
+  PENDING: styles.pending,
+};
+
+/**
+ * Collapsible "Audit History" panel on the curate page. Lazily loads the
+ * person's curation action history (accept/reject/pending) from
+ * /api/reciter/feedback-log/[uid] on first expand. Newest first.
+ */
+const AuditHistoryPanel: React.FC<Props> = ({ uid }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [entries, setEntries] = useState<AuditEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!uid) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/reciter/feedback-log/${encodeURIComponent(uid)}`, {
+        credentials: 'same-origin',
+        headers: {
+          Accept: 'application/json',
+          'Authorization': reciterConfig.backendApiKey,
+        },
+      });
+      if (!res.ok) {
+        throw new Error(`Request failed (${res.status})`);
+      }
+      const data = await res.json();
+      setEntries(Array.isArray(data) ? data : []);
+      setLoaded(true);
+    } catch (e) {
+      setError('Unable to load audit history.');
+    } finally {
+      setLoading(false);
+    }
+  }, [uid]);
+
+  const toggle = () => {
+    const next = !expanded;
+    setExpanded(next);
+    if (next && !loaded && !loading) {
+      load();
+    }
+  };
+
+  const formatDate = (epochSeconds?: number) => {
+    if (!epochSeconds) return '—';
+    try {
+      return new Date(epochSeconds * 1000).toLocaleString();
+    } catch (e) {
+      return '—';
+    }
+  };
+
+  return (
+    <div className={styles.panel}>
+      <button type="button" className={styles.header} onClick={toggle} aria-expanded={expanded}>
+        <span className={styles.caret}>{expanded ? '▼' : '▶'}</span>
+        Audit History
+        {loaded && <span className={styles.count}>{entries.length}</span>}
+      </button>
+
+      {expanded && (
+        <div className={styles.body}>
+          {loading && <p className={styles.muted}>Loading…</p>}
+          {!loading && error && <p className={styles.error}>{error}</p>}
+          {!loading && !error && loaded && entries.length === 0 && (
+            <p className={styles.muted}>No curation actions recorded for this person yet.</p>
+          )}
+          {!loading && !error && entries.length > 0 && (
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Action</th>
+                  <th>PMID</th>
+                  <th>Curator</th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((e, i) => (
+                  <tr key={(e.sk || '') + i}>
+                    <td>{formatDate(e.createTimestamp)}</td>
+                    <td>
+                      <span className={`${styles.badge} ${ACTION_CLASS[e.feedback || ''] || ''}`}>
+                        {e.feedback || '—'}
+                      </span>
+                    </td>
+                    <td>
+                      {e.articleId ? (
+                        <a
+                          href={`https://pubmed.ncbi.nlm.nih.gov/${e.articleId}/`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {e.articleId}
+                        </a>
+                      ) : '—'}
+                    </td>
+                    <td>{e.curatorName || (e.curatedBy ? `#${e.curatedBy}` : '—')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AuditHistoryPanel;

--- a/src/components/elements/CurateIndividual/CurateIndividual.tsx
+++ b/src/components/elements/CurateIndividual/CurateIndividual.tsx
@@ -20,6 +20,7 @@ import { reciterConfig } from "../../../../config/local";
 import { toast } from "react-toastify";
 import { reportError } from "../../../utils/reportError";
 import GrantProxyModal from './GrantProxyModal';
+import AuditHistoryPanel from './AuditHistoryPanel';
 
 
 
@@ -238,6 +239,7 @@ const CurateIndividual = () => {
             fullName={personFullName}
             fetchOriginalData={fetchData}
           />
+          {identityData.uid && <AuditHistoryPanel uid={identityData.uid} />}
           <Profile
             uid={identityData.uid}
             modalShow={modalShow}

--- a/src/pages/api/reciter/feedback-log/[uid].ts
+++ b/src/pages/api/reciter/feedback-log/[uid].ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getFeedbackLog } from "../../../../../controllers/feedbacklog.controller"
+import { reciterConfig } from '../../../../../config/local'
+import { checkCurationScope } from '../../../../utils/checkCurationScope'
+
+/**
+ * GET /api/reciter/feedback-log/[uid]
+ *
+ * Returns the curation audit history for a person, proxied from ReCiter's
+ * /reciter/feedback-log/{uid}. Requires the backend api-key header and gates
+ * visibility by curate access (a user can only see history for people they may
+ * curate — same rule as the goldstandard save route).
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== "GET") {
+        return res.status(400).send({ statusCode: 400, message: "HTTP Method supported is GET" })
+    }
+    if (req.headers.authorization === undefined) {
+        return res.status(400).send({ statusCode: 400, message: "Authorization header is needed" })
+    }
+    if (req.headers.authorization !== reciterConfig.backendApiKey) {
+        return res.status(401).send({ statusCode: 401, message: "Authorization header is incorrect" })
+    }
+
+    const { uid } = req.query
+    const targetUid = Array.isArray(uid) ? uid[0] : uid
+    if (!targetUid) {
+        return res.status(400).send({ statusCode: 400, message: "uid is required" })
+    }
+
+    try {
+        const scopeCheck = await checkCurationScope(req, targetUid)
+        if (!scopeCheck.allowed) {
+            return res.status(scopeCheck.status!).send({ statusCode: scopeCheck.status!, message: scopeCheck.message })
+        }
+
+        const apiResponse = await getFeedbackLog(targetUid)
+        if (apiResponse.statusCode === 200) {
+            return res.status(200).send(apiResponse.data)
+        }
+        return res.status(apiResponse.statusCode || 500).send({
+            statusCode: apiResponse.statusCode || 500,
+            message: apiResponse.statusText
+        })
+    } catch (err) {
+        console.error('[feedback-log] Unhandled error:', err)
+        return res.status(500).send({ statusCode: 500, message: 'Internal server error' })
+    }
+}

--- a/src/pages/api/reciter/feedback-log/[uid].ts
+++ b/src/pages/api/reciter/feedback-log/[uid].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { getFeedbackLog } from "../../../../../controllers/feedbacklog.controller"
+import { findAdminUserNamesByIds } from "../../../../../controllers/db/manage-users/user.controller"
 import { reciterConfig } from '../../../../../config/local'
 import { checkCurationScope } from '../../../../utils/checkCurationScope'
 
@@ -36,7 +37,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         const apiResponse = await getFeedbackLog(targetUid)
         if (apiResponse.statusCode === 200) {
-            return res.status(200).send(apiResponse.data)
+            const data = apiResponse.data
+            // Resolve curatedBy (admin_users.userID) -> display name for the UI.
+            if (Array.isArray(data)) {
+                const ids: number[] = Array.from(
+                    new Set(data.map((e: any) => e.curatedBy).filter((n: any) => Number.isInteger(n) && n > 0))
+                )
+                const nameMap = await findAdminUserNamesByIds(ids)
+                data.forEach((e: any) => {
+                    e.curatorName = (e.curatedBy && nameMap[e.curatedBy]) ? nameMap[e.curatedBy] : null
+                })
+            }
+            return res.status(200).send(data)
         }
         return res.status(apiResponse.statusCode || 500).send({
             statusCode: apiResponse.statusCode || 500,

--- a/src/pages/api/reciter/update/goldstandard.ts
+++ b/src/pages/api/reciter/update/goldstandard.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { getToken } from 'next-auth/jwt'
 import { updateGoldStandard } from "../../../../../controllers/goldstandard.controller"
 import { reciterConfig } from '../../../../../config/local'
 import { checkCurationScope } from '../../../../utils/checkCurationScope'
@@ -28,7 +29,20 @@ export default async function handler(
             }
         }
 
-        const apiResponse = await updateGoldStandard(req);
+        // Phase 34: resolve the curating user's admin_users.userID from the JWT so
+        // ReCiter can record who performed the action (FeedbackLog.curatedBy).
+        let curatedBy: number | undefined = undefined;
+        try {
+            const token: any = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+            const userID = token?.databaseUser?.userID;
+            if (userID !== undefined && userID !== null && !Number.isNaN(Number(userID))) {
+                curatedBy = Number(userID);
+            }
+        } catch (e) {
+            // Leave curatedBy undefined -> ReCiter defaults to 0 (unknown).
+        }
+
+        const apiResponse = await updateGoldStandard(req, curatedBy);
         if(apiResponse.statusCode === 200) {
             res.status(apiResponse.statusCode).send({
                 statusCode: apiResponse.statusCode,


### PR DESCRIPTION
## Summary
Adds the **Audit History** feature to the curate page, showing each person's curation actions. Pairs with the ReCiter PR (`feat(audit): capture curatedBy + add curation audit-history read endpoint`).

### Backend wiring
- New `GET /api/reciter/feedback-log/[uid]` proxies ReCiter's `feedback-log/{uid}`. Requires the backend api-key header and gates visibility by **curate access** (`checkCurationScope`) — a user only sees history for people they may curate.
- The goldstandard **save** proxy now resolves the curating user's `admin_users.userID` from the JWT and forwards it to ReCiter as `curatedBy`, so future actions record who performed them.
- `findAdminUserNamesByIds` resolves `curatedBy` → display name server-side; rows are enriched with `curatorName`.

### UI
- `AuditHistoryPanel`: a collapsible panel below the publication list on the curate page. Lazily loads on first expand; shows **Date · Action (badge) · PMID (linked) · Curator**, newest first.

## Verification
- `tsc --noEmit` clean for changed files (only pre-existing `__tests__` jest-globals errors remain).
- **Needs visual verification on dev after deploy** (per UI convention): confirm the panel renders/expands on a curate page, the table populates, badges/links look right, and curator names resolve. Historical rows (pre-`curatedBy` capture) will show a blank curator — expected.

## Depends on / deploy order
Requires the ReCiter PR deployed first (provides the `feedback-log` endpoint and accepts `curatedBy`). Independent of PR #713 (the RBAC scope fix).
