### PR TITLE
debug(saml): temporary logging to diagnose reciter-dev sign-in failure

### DIFF
--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -212,6 +212,8 @@ const options = {
                         reciterSamlConfig.saml_idp_options
                     );
                     const { user } = await postAssert(idp, samlBody);
+                    // TEMP DIAGNOSTIC (remove after SAML debug): confirm the assertion validated + show what attributes arrived
+                    console.log('[saml-authorize] post_assert OK; attribute keys:', user && user.attributes ? Object.keys(user.attributes) : 'none');
                     let cwid = null;
                     let email = null;
                     let usrAttr = null;
@@ -278,8 +280,13 @@ const options = {
                            if(adminUser)
                                     return adminUser;
                     }
+                    // TEMP DIAGNOSTIC (remove after SAML debug): assertion validated but no usable identity extracted
+                    console.warn('[saml-authorize] has_access:false — no cwid/email/upn extracted. cwid=', cwid, 'email=', smalUserEmail, 'upn=', userPrincipalName);
                     return { cwid, has_access: false };
                 } catch (error) {
+                    // TEMP DIAGNOSTIC (remove after SAML debug): surface the swallowed SAML/login error
+                    console.error('[saml-authorize] FAILED:', error && error.message ? error.message : error);
+                    console.error('[saml-authorize] stack:', error && error.stack ? error.stack : '(no stack)');
                     return null;
                 }
             },


### PR DESCRIPTION
Temporary diagnostics — surfaces the SAML error that authorize() currently swallows (catch → return null, no log). Adds a post_assert attribute-keys log, a has_access:false warn, and console.error of the caught error+stack. **Revert after root cause is found.** Deploy via Dev-V2 pipeline to reciter-dev.