### PR TITLE
revert: remove temporary SAML authorize diagnostic logging (#715)

### DIFF
--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -212,8 +212,6 @@ const options = {
                         reciterSamlConfig.saml_idp_options
                     );
                     const { user } = await postAssert(idp, samlBody);
-                    // TEMP DIAGNOSTIC (remove after SAML debug): confirm the assertion validated + show what attributes arrived
-                    console.log('[saml-authorize] post_assert OK; attribute keys:', user && user.attributes ? Object.keys(user.attributes) : 'none');
                     let cwid = null;
                     let email = null;
                     let usrAttr = null;
@@ -280,13 +278,8 @@ const options = {
                            if(adminUser)
                                     return adminUser;
                     }
-                    // TEMP DIAGNOSTIC (remove after SAML debug): assertion validated but no usable identity extracted
-                    console.warn('[saml-authorize] has_access:false — no cwid/email/upn extracted. cwid=', cwid, 'email=', smalUserEmail, 'upn=', userPrincipalName);
                     return { cwid, has_access: false };
                 } catch (error) {
-                    // TEMP DIAGNOSTIC (remove after SAML debug): surface the swallowed SAML/login error
-                    console.error('[saml-authorize] FAILED:', error && error.message ? error.message : error);
-                    console.error('[saml-authorize] stack:', error && error.stack ? error.stack : '(no stack)');
                     return null;
                 }
             },


### PR DESCRIPTION
Removes the temporary diagnostic logging added in #715. It did its job — confirmed the reciter-dev sign-in failure was 'SAML Assertion signature check failed' (stale IdP cert in S3, since replaced by Mahender; login verified working). Pure removal (7 lines), no behavior change.