### PR TITLE
fix(rbac): Curator_Scoped org-unit dropdown uses real org units (was admin departments)

### DIFF
--- a/src/components/elements/AddUser/AddUser.tsx
+++ b/src/components/elements/AddUser/AddUser.tsx
@@ -6,7 +6,7 @@ import { styled } from '@mui/material/styles';
 import styles from './AddUser.module.css';
 import Loader from '../Common/Loader';
 import TextField from '@mui/material/TextField';
-import { createAdminUser, createORupdateUserIDAction, fetchUserInfoByID, getAdminRoles, getAdminDepartments} from "../../../redux/actions/actions";
+import { createAdminUser, createORupdateUserIDAction, fetchUserInfoByID, getAdminRoles, getAdminDepartments, getOrgUnits} from "../../../redux/actions/actions";
 import { useRouter } from "next/router";
 import ToastContainerWrapper from '../ToastContainerWrapper/ToastContainerWrapper';
 import { PageHeader } from "../Common/PageHeader";
@@ -27,6 +27,9 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
 
     //Store Data
     const adminDepartments = useSelector((state: RootStateOrAny) => state.AllAdminDepatments);
+    // Curation-scope org units come from the real org-unit vocabulary (distinct
+    // Person.primaryOrganizationalUnit) — the same values scope enforcement compares against.
+    const orgUnitsData = useSelector((state: RootStateOrAny) => state.orgUnitsData);
     const allAdminRoles = useSelector((state: RootStateOrAny) => state.AllAdminRoles);
 
     const [state, setState] = useState({
@@ -60,6 +63,7 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
     useEffect(() => {
         if (!allAdminRoles || allAdminRoles.length === 0) dispatch(getAdminRoles());
         if (!adminDepartments || adminDepartments.length === 0) dispatch(getAdminDepartments());
+        if (!orgUnitsData || orgUnitsData.length === 0) dispatch(getOrgUnits());
     }, []);
 
     const hasScopedRole = selectedRoles.includes('Curator_Scoped');
@@ -432,7 +436,7 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
                                     selectedDepartments={selectedDepartments}
                                     onDepartmentsChange={setSelectedDepartments}
                                     personTypeOptions={personTypeOptions}
-                                    departmentOptions={adminDepartments.map(d => d.departmentLabel)}
+                                    departmentOptions={(orgUnitsData || []).map((o: any) => o.primaryOrganizationalUnit).filter(Boolean)}
                                     error={formErrorsInst.scopeRequired || null}
                                     CssTextField={CssTextField}
                                 />


### PR DESCRIPTION
The Curation Scope 'Organizational Units' picker pulled options from adminDepartments (admin-role departments), not the org-unit vocabulary scope enforcement actually checks (Person.primaryOrganizationalUnit). Result: empty/unusable dropdown on dev, and stored values that could never match enforcement. Now sourced from the existing getOrgUnits endpoint (/api/db/users/orgunits = distinct primaryOrganizationalUnit). Fixes the 'can't add an org unit' symptom and the vocabulary mismatch in one change. tsc clean; person-type scope and the role-department select unchanged.