### PR TITLE
feat(authorships): Authorships review tab on the NextJS14 (dev_Upd) line

### DIFF
--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -1,0 +1,104 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Op, fn, col } from "sequelize";
+import models from "../../src/db/sequelize";
+
+// Columns returned to the Authorships tab (one row per unassigned WCM authorship).
+const LIST_ATTRIBUTES = [
+  "id", "pmid", "author_key", "wcm_author", "author_position_label",
+  "entrez_date", "title", "journal", "doi", "classification",
+  "top_cwid", "top_name", "top_person_type", "top_dept",
+  "top_fg_score", "top_io_score", "top_confidence", "top_cohort_size",
+  "top_given_match", "top_affil_match", "n_candidates", "single_candidate",
+  "candidate_cwids_json", "status",
+];
+
+const SORTS: Record<string, any[]> = {
+  // default: single-candidate (high-precision) first, then identity-only score desc
+  precision: [["single_candidate", "DESC"], ["top_io_score", "DESC"]],
+  io: [["top_io_score", "DESC"]],
+  fg: [["top_fg_score", "DESC"]],
+  date: [["entrez_date", "DESC"]],
+};
+
+function buildWhere(body: any): any {
+  const and: any[] = [];
+
+  // feed: unassigned (open/snoozed) is the default; "all" drops the status filter
+  if (body.feed !== "all") {
+    and.push({ status: { [Op.in]: ["open", "snoozed"] } });
+  }
+  // classification lane: buried | suggested | absent
+  if (body.classification && body.classification !== "all") {
+    and.push({ classification: body.classification });
+  }
+  // precision lane: only single-candidate (near-certain) authorships
+  if (body.precision === "single") {
+    and.push({ single_candidate: true });
+  }
+  // free-text search across author name, proposed identity, and pmid
+  const search = (body.searchTextInput || "").trim();
+  if (search) {
+    const like = `%${search}%`;
+    const or: any[] = [
+      { wcm_author: { [Op.like]: like } },
+      { top_name: { [Op.like]: like } },
+      { top_cwid: { [Op.like]: like } },
+    ];
+    if (/^\d+$/.test(search)) or.push({ pmid: Number(search) });
+    and.push({ [Op.or]: or });
+  }
+
+  return and.length ? { [Op.and]: and } : {};
+}
+
+// POST /api/db/authorships — paginated, filtered list of unassigned WCM authorships.
+export const listAuthorships = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const body = req.body || {};
+    const limit = Number(body.limit) || 25;
+    const offset = Number(body.offset) || 0;
+    const order = SORTS[body.sort] || SORTS.precision;
+
+    const { count, rows } = await models.AuthorshipReview.findAndCountAll({
+      attributes: LIST_ATTRIBUTES,
+      where: buildWhere(body),
+      order,
+      offset,
+      limit,
+    });
+
+    res.send({ rows, count, limit, offset });
+  } catch (e) {
+    console.log(e);
+    res.status(500).send(e);
+  }
+};
+
+// POST /api/db/authorships/summary — counts per classification + precision lane, for the
+// tab headers. Honours the same feed/search filters but ignores classification/precision so
+// each lane shows its own total.
+export const authorshipSummary = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const body = { ...(req.body || {}), classification: "all", precision: "all" };
+    const where = buildWhere(body);
+    const [total, single, byClass] = await Promise.all([
+      models.AuthorshipReview.count({ where }),
+      models.AuthorshipReview.count({ where: { [Op.and]: [where, { single_candidate: true }] } }),
+      models.AuthorshipReview.findAll({
+        attributes: [
+          "classification",
+          [fn("COUNT", col("id")), "n"],
+        ],
+        where,
+        group: ["classification"],
+        raw: true,
+      }),
+    ]);
+    const classes: Record<string, number> = {};
+    (byClass as any[]).forEach((r) => { classes[r.classification] = Number(r.n); });
+    res.send({ total, single_candidate: single, classes });
+  } catch (e) {
+    console.log(e);
+    res.status(500).send(e);
+  }
+};

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -1,0 +1,258 @@
+import { useCallback, useEffect, useState } from "react";
+import { reciterConfig } from "../../../../config/local";
+
+// ---- types ---------------------------------------------------------------
+interface AuthorshipRow {
+  id: number;
+  pmid: number;
+  author_key: string;
+  wcm_author?: string;
+  author_position_label?: string;
+  entrez_date?: string;
+  title?: string;
+  journal?: string;
+  doi?: string;
+  classification?: "assigned" | "suggested" | "buried" | "absent";
+  top_cwid?: string;
+  top_name?: string;
+  top_person_type?: string;
+  top_dept?: string;
+  top_fg_score?: number;
+  top_io_score?: number;
+  top_confidence?: number;
+  top_cohort_size?: number;
+  top_given_match?: string;
+  top_affil_match?: boolean;
+  n_candidates?: number;
+  single_candidate?: boolean;
+  candidate_cwids_json?: string;
+  status?: string;
+}
+
+interface Summary { total: number; single_candidate: number; classes: Record<string, number>; }
+
+const PAGE_SIZE = 25;
+const apiHeaders = {
+  Accept: "application/json",
+  "Content-Type": "application/json",
+  Authorization: reciterConfig.backendApiKey,
+};
+
+const CLASS_META: Record<string, { label: string; color: string; hint: string }> = {
+  buried: { label: "Buried", color: "#b42318", hint: "Production buried it (final < 30)" },
+  absent: { label: "Never retrieved", color: "#8a5a00", hint: "Production never scored this person" },
+  suggested: { label: "Suggested", color: "#475467", hint: "Already in a curator's pending queue (final ≥ 30)" },
+  assigned: { label: "Assigned", color: "#067647", hint: "Accepted by a WCM person" },
+};
+
+// ---- small presentational bits -------------------------------------------
+const Badge = ({ text, color, title }: { text: string; color: string; title?: string }) => (
+  <span title={title} style={{
+    background: color, color: "#fff", borderRadius: 10, padding: "1px 8px",
+    fontSize: 11, fontWeight: 600, whiteSpace: "nowrap",
+  }}>{text}</span>
+);
+
+const Score = ({ value, kind }: { value?: number; kind: "fg" | "io" }) => {
+  if (value === null || value === undefined) return <span style={{ color: "#98a2b3" }}>—</span>;
+  // IO high = strong identity (green). FG low = buried (red), high = already suggested (grey).
+  let color = "#475467";
+  if (kind === "io") color = value >= 90 ? "#067647" : value >= 50 ? "#475467" : "#98a2b3";
+  if (kind === "fg") color = value < 30 ? "#b42318" : "#475467";
+  return <span style={{ color, fontWeight: 600 }}>{value.toFixed(1)}</span>;
+};
+
+// ---- main component ------------------------------------------------------
+const AuthorshipsTabs = () => {
+  const [rows, setRows] = useState<AuthorshipRow[]>([]);
+  const [count, setCount] = useState(0);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(0);
+  const [lane, setLane] = useState<"single" | "all">("single");
+  const [classification, setClassification] = useState<"all" | "buried" | "absent" | "suggested">("all");
+  const [search, setSearch] = useState("");
+  const [searchInput, setSearchInput] = useState("");
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const filterBody = useCallback(() => ({
+    feed: "unassigned",
+    precision: lane === "single" ? "single" : "all",
+    classification,
+    searchTextInput: search,
+    sort: "precision",
+  }), [lane, classification, search]);
+
+  const fetchData = useCallback(() => {
+    setLoading(true);
+    fetch("/api/db/authorships", {
+      credentials: "same-origin", method: "POST", headers: apiHeaders,
+      body: JSON.stringify({ ...filterBody(), limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+    })
+      .then((r) => r.json())
+      .then((d) => { setRows(d.rows || []); setCount(d.count || 0); })
+      .catch((e) => console.error("[authorships]", e))
+      .finally(() => setLoading(false));
+  }, [filterBody, page]);
+
+  const fetchSummary = useCallback(() => {
+    fetch("/api/db/authorships/summary", {
+      credentials: "same-origin", method: "POST", headers: apiHeaders,
+      body: JSON.stringify({ feed: "unassigned", searchTextInput: search }),
+    })
+      .then((r) => r.json()).then(setSummary).catch(() => setSummary(null));
+  }, [search]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+  useEffect(() => { fetchSummary(); }, [fetchSummary]);
+  // reset to first page when filters change
+  useEffect(() => { setPage(0); }, [lane, classification, search]);
+
+  const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
+  const classChips: Array<typeof classification> = ["all", "buried", "absent", "suggested"];
+
+  return (
+    <div style={{ padding: "24px 28px", fontFamily: "inherit" }}>
+      <h2 style={{ margin: 0, fontSize: 22 }}>Authorships</h2>
+      <p style={{ color: "#475467", marginTop: 4, maxWidth: 760 }}>
+        WCM-affiliated authorships not yet assigned to any identity. The high-precision lane
+        shows authorships where exactly one WCM identity matches the name — near-certain matches.
+        <strong> FG</strong> is the production score; <strong> IO</strong> is the identity-only score.
+      </p>
+
+      {/* summary */}
+      {summary && (
+        <div style={{ display: "flex", gap: 18, margin: "12px 0 18px", color: "#475467", fontSize: 13 }}>
+          <span><strong style={{ color: "#101828" }}>{summary.total.toLocaleString()}</strong> unassigned</span>
+          <span><strong style={{ color: "#101828" }}>{summary.single_candidate.toLocaleString()}</strong> single-candidate</span>
+          {Object.entries(summary.classes).map(([k, v]) => (
+            <span key={k}>{CLASS_META[k]?.label || k}: <strong style={{ color: "#101828" }}>{v.toLocaleString()}</strong></span>
+          ))}
+        </div>
+      )}
+
+      {/* lane toggle */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+        {([["single", "High-precision (single candidate)"], ["all", "All unassigned"]] as const).map(([key, label]) => (
+          <button key={key} onClick={() => setLane(key)} style={{
+            padding: "6px 14px", borderRadius: 8, border: "1px solid #d0d5dd", cursor: "pointer",
+            background: lane === key ? "#1570ef" : "#fff", color: lane === key ? "#fff" : "#344054",
+            fontWeight: 600, fontSize: 13,
+          }}>{label}</button>
+        ))}
+      </div>
+
+      {/* classification chips + search */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14, flexWrap: "wrap" }}>
+        {classChips.map((c) => (
+          <button key={c} onClick={() => setClassification(c)} style={{
+            padding: "4px 12px", borderRadius: 16, border: "1px solid #d0d5dd", cursor: "pointer",
+            background: classification === c ? "#eff8ff" : "#fff",
+            color: classification === c ? "#175cd3" : "#475467", fontSize: 12, fontWeight: 600,
+          }}>{c === "all" ? "All classes" : CLASS_META[c].label}</button>
+        ))}
+        <form onSubmit={(e) => { e.preventDefault(); setSearch(searchInput.trim()); }} style={{ marginLeft: "auto" }}>
+          <input value={searchInput} onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search name, CWID, or PMID"
+            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #d0d5dd", width: 240, fontSize: 13 }} />
+        </form>
+      </div>
+
+      {/* table */}
+      <div style={{ border: "1px solid #eaecf0", borderRadius: 10, overflow: "hidden" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+          <thead>
+            <tr style={{ background: "#f9fafb", textAlign: "left", color: "#475467" }}>
+              {["WCM author", "Proposed identity", "FG", "IO", "Class", "Cand.", "Conf.", "Article", ""].map((h, i) => (
+                <th key={i} style={{ padding: "10px 12px", fontWeight: 600, borderBottom: "1px solid #eaecf0", whiteSpace: "nowrap" }}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {loading && (
+              <tr><td colSpan={9} style={{ padding: 24, textAlign: "center", color: "#98a2b3" }}>Loading…</td></tr>
+            )}
+            {!loading && rows.length === 0 && (
+              <tr><td colSpan={9} style={{ padding: 24, textAlign: "center", color: "#98a2b3" }}>No authorships match these filters.</td></tr>
+            )}
+            {!loading && rows.map((r) => {
+              const meta = CLASS_META[r.classification || "absent"];
+              const isOpen = expanded === r.id;
+              let alternates: any[] = [];
+              if (isOpen && r.candidate_cwids_json) {
+                try { alternates = JSON.parse(r.candidate_cwids_json); } catch { alternates = []; }
+              }
+              return (
+                <>
+                  <tr key={r.id} style={{ borderBottom: "1px solid #f2f4f7" }}>
+                    <td style={{ padding: "10px 12px" }}>
+                      <div style={{ fontWeight: 600, color: "#101828" }}>{r.wcm_author}</div>
+                      <div style={{ color: "#98a2b3", fontSize: 11 }}>{r.author_position_label} author</div>
+                    </td>
+                    <td style={{ padding: "10px 12px" }}>
+                      <div style={{ color: "#101828" }}>{r.top_name} <span style={{ color: "#1570ef" }}>({r.top_cwid})</span></div>
+                      <div style={{ color: "#667085", fontSize: 11 }}>{r.top_person_type}{r.top_dept ? ` · ${r.top_dept}` : ""}</div>
+                    </td>
+                    <td style={{ padding: "10px 12px" }}><Score value={r.top_fg_score} kind="fg" /></td>
+                    <td style={{ padding: "10px 12px" }}><Score value={r.top_io_score} kind="io" /></td>
+                    <td style={{ padding: "10px 12px" }}><Badge text={meta.label} color={meta.color} title={meta.hint} /></td>
+                    <td style={{ padding: "10px 12px", whiteSpace: "nowrap" }}>
+                      {r.single_candidate
+                        ? <Badge text="1 ✓" color="#067647" title="Single candidate — near-certain" />
+                        : <button onClick={() => setExpanded(isOpen ? null : r.id)} style={{
+                            border: "1px solid #d0d5dd", background: "#fff", borderRadius: 6, padding: "2px 8px",
+                            cursor: "pointer", color: "#475467", fontSize: 12,
+                          }}>{r.n_candidates} ▾</button>}
+                    </td>
+                    <td style={{ padding: "10px 12px", color: "#475467" }}>{r.top_confidence?.toFixed(2)}</td>
+                    <td style={{ padding: "10px 12px", maxWidth: 360 }}>
+                      <div style={{ color: "#101828", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", maxWidth: 360 }} title={r.title}>{r.title}</div>
+                      <div style={{ color: "#667085", fontSize: 11 }}>{r.journal}{r.entrez_date ? ` · ${r.entrez_date}` : ""}</div>
+                    </td>
+                    <td style={{ padding: "10px 12px" }}>
+                      <a href={`https://pubmed.ncbi.nlm.nih.gov/${r.pmid}/`} target="_blank" rel="noreferrer"
+                        style={{ color: "#1570ef", textDecoration: "none", fontSize: 12 }}>{r.pmid} ↗</a>
+                    </td>
+                  </tr>
+                  {isOpen && alternates.length > 0 && (
+                    <tr key={`${r.id}-exp`} style={{ background: "#fcfcfd" }}>
+                      <td colSpan={9} style={{ padding: "8px 12px 12px 24px" }}>
+                        <div style={{ color: "#475467", fontSize: 12, marginBottom: 4 }}>Candidate identities (pick one when assigning):</div>
+                        <table style={{ fontSize: 12, borderCollapse: "collapse" }}>
+                          <tbody>
+                            {alternates.map((c, i) => (
+                              <tr key={i}>
+                                <td style={{ padding: "2px 12px 2px 0", color: "#101828" }}>{c.name} <span style={{ color: "#1570ef" }}>({c.cwid})</span></td>
+                                <td style={{ padding: "2px 12px", color: "#667085" }}>{c.person_type}{c.dept ? ` · ${c.dept}` : ""}</td>
+                                <td style={{ padding: "2px 12px" }}>IO <Score value={c.io_score} kind="io" /></td>
+                                <td style={{ padding: "2px 12px" }}>FG <Score value={c.final_score} kind="fg" /></td>
+                                <td style={{ padding: "2px 12px", color: "#667085" }}>conf {Number(c.confidence).toFixed(2)}{c.affil_dept_match ? " · affil✓" : ""}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  )}
+                </>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* pagination */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 14, color: "#475467", fontSize: 13 }}>
+        <span>{count.toLocaleString()} authorships · page {page + 1} of {totalPages}</span>
+        <span style={{ display: "flex", gap: 8 }}>
+          <button disabled={page === 0} onClick={() => setPage((p) => Math.max(0, p - 1))}
+            style={{ padding: "6px 12px", borderRadius: 8, border: "1px solid #d0d5dd", background: "#fff", cursor: page === 0 ? "default" : "pointer", opacity: page === 0 ? 0.5 : 1 }}>Previous</button>
+          <button disabled={page + 1 >= totalPages} onClick={() => setPage((p) => p + 1)}
+            style={{ padding: "6px 12px", borderRadius: 8, border: "1px solid #d0d5dd", background: "#fff", cursor: page + 1 >= totalPages ? "default" : "pointer", opacity: page + 1 >= totalPages ? 0.5 : 1 }}>Next</button>
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default AuthorshipsTabs;

--- a/src/components/elements/Navbar/SideNavbar.tsx
+++ b/src/components/elements/Navbar/SideNavbar.tsx
@@ -233,6 +233,16 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
       isRequired:true
     },
     {
+      title: 'Authorships',
+      to: '/authorships',
+      imgUrl: chartIcon,
+      imgUrlActive: chartIconActive,
+      muiIcon: <IconReports />,
+      disabled: false,
+      allowedRoleNames: ["Superuser", "Curator_All"],
+      isRequired:true
+    },
+    {
       title: 'Create Reports',
       to: '/report',
       imgUrl: chartIcon,
@@ -372,7 +382,7 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
             />
           )}
           {
-            menuItems.slice(0, 5).map((item: MenuItem, index: number) => {
+            menuItems.slice(0, 6).map((item: MenuItem, index: number) => {
               const matchedRoles = userPermissions.filter(role => item.allowedRoleNames.includes(role.roleLabel));
               if(matchedRoles.length >= 1 && item.isRequired){
               return item.nestedMenu ?
@@ -402,21 +412,21 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
             </Typography>
           )}
           {
-            menuItems.slice(5).map((item: MenuItem, index: number) => {
+            menuItems.slice(6).map((item: MenuItem, index: number) => {
               const matchedRoles = userPermissions.filter(role => item.allowedRoleNames.includes(role.roleLabel));
               if(matchedRoles.length >= 1 && item.isRequired){
               return item.nestedMenu ?
                 <NestedListItem
                   header={item.title}
                   menuItems={item.nestedMenu}
-                  key={index + 5}
+                  key={index + 6}
                   imgUrl={item.imgUrl}
                 />
                 :
                 <MenuListItem
                   title={item.title}
-                  key={index + 5}
-                  id={index + 5}
+                  key={index + 6}
+                  id={index + 6}
                   to={item.to}
                   imgUrl={item.imgUrl}
                   imgUrlActive={item.imgUrlActive}

--- a/src/db/models/AuthorshipReview.ts
+++ b/src/db/models/AuthorshipReview.ts
@@ -1,0 +1,139 @@
+import * as Sequelize from 'sequelize';
+import { DataTypes, Model, Optional } from 'sequelize';
+
+// Durable reciterdb table `authorship_review` (see ReCiterDB/setup/table_authorship_review.sql).
+// One row per WCM-affiliated authorship not assigned to any identity, written by the
+// adversarial-attribution-review producer. Column names are snake_case to match that table.
+export interface AuthorshipReviewAttributes {
+  id: number;
+  pmid: number;
+  author_key: string;
+  author_position?: number;
+  author_position_label?: string;
+  wcm_author?: string;
+  author_affiliation?: string;
+  entrez_date?: string;
+  title?: string;
+  journal?: string;
+  doi?: string;
+  classification?: 'assigned' | 'suggested' | 'buried' | 'absent';
+  top_cwid?: string;
+  top_name?: string;
+  top_person_type?: string;
+  top_dept?: string;
+  top_fg_score?: number;
+  top_io_score?: number;
+  top_confidence?: number;
+  top_cohort_size?: number;
+  top_given_match?: string;
+  top_affil_match?: boolean;
+  n_candidates?: number;
+  single_candidate?: boolean;
+  candidate_cwids_json?: string;
+  status: 'open' | 'assigned' | 'accepted' | 'rejected' | 'dismissed' | 'snoozed';
+  resolution_cwid?: string;
+  reviewer?: string;
+  note?: string;
+  snooze_until?: string;
+  resolved_at?: Date;
+  first_seen?: Date;
+  last_refreshed?: Date;
+  last_checked?: Date;
+}
+
+export type AuthorshipReviewPk = "id";
+export type AuthorshipReviewId = AuthorshipReview[AuthorshipReviewPk];
+export type AuthorshipReviewOptionalAttributes = "id" | "author_position" | "author_position_label" | "wcm_author" | "author_affiliation" | "entrez_date" | "title" | "journal" | "doi" | "classification" | "top_cwid" | "top_name" | "top_person_type" | "top_dept" | "top_fg_score" | "top_io_score" | "top_confidence" | "top_cohort_size" | "top_given_match" | "top_affil_match" | "n_candidates" | "single_candidate" | "candidate_cwids_json" | "status" | "resolution_cwid" | "reviewer" | "note" | "snooze_until" | "resolved_at" | "first_seen" | "last_refreshed" | "last_checked";
+export type AuthorshipReviewCreationAttributes = Optional<AuthorshipReviewAttributes, AuthorshipReviewOptionalAttributes>;
+
+export class AuthorshipReview extends Model<AuthorshipReviewAttributes, AuthorshipReviewCreationAttributes> implements AuthorshipReviewAttributes {
+  id!: number;
+  pmid!: number;
+  author_key!: string;
+  author_position?: number;
+  author_position_label?: string;
+  wcm_author?: string;
+  author_affiliation?: string;
+  entrez_date?: string;
+  title?: string;
+  journal?: string;
+  doi?: string;
+  classification?: 'assigned' | 'suggested' | 'buried' | 'absent';
+  top_cwid?: string;
+  top_name?: string;
+  top_person_type?: string;
+  top_dept?: string;
+  top_fg_score?: number;
+  top_io_score?: number;
+  top_confidence?: number;
+  top_cohort_size?: number;
+  top_given_match?: string;
+  top_affil_match?: boolean;
+  n_candidates?: number;
+  single_candidate?: boolean;
+  candidate_cwids_json?: string;
+  status!: 'open' | 'assigned' | 'accepted' | 'rejected' | 'dismissed' | 'snoozed';
+  resolution_cwid?: string;
+  reviewer?: string;
+  note?: string;
+  snooze_until?: string;
+  resolved_at?: Date;
+  first_seen?: Date;
+  last_refreshed?: Date;
+  last_checked?: Date;
+
+  static initModel(sequelize: Sequelize.Sequelize): typeof AuthorshipReview {
+    AuthorshipReview.init({
+      id: { autoIncrement: true, type: DataTypes.BIGINT, allowNull: false, primaryKey: true },
+      pmid: { type: DataTypes.BIGINT, allowNull: false },
+      author_key: { type: DataTypes.STRING(32), allowNull: false },
+      author_position: { type: DataTypes.INTEGER, allowNull: true },
+      author_position_label: { type: DataTypes.STRING(8), allowNull: true },
+      wcm_author: { type: DataTypes.STRING(255), allowNull: true },
+      author_affiliation: { type: DataTypes.TEXT, allowNull: true },
+      entrez_date: { type: DataTypes.DATEONLY, allowNull: true },
+      title: { type: DataTypes.TEXT, allowNull: true },
+      journal: { type: DataTypes.STRING(512), allowNull: true },
+      doi: { type: DataTypes.STRING(255), allowNull: true },
+      classification: { type: DataTypes.ENUM('assigned', 'suggested', 'buried', 'absent'), allowNull: true },
+      top_cwid: { type: DataTypes.STRING(32), allowNull: true },
+      top_name: { type: DataTypes.STRING(255), allowNull: true },
+      top_person_type: { type: DataTypes.STRING(64), allowNull: true },
+      top_dept: { type: DataTypes.STRING(255), allowNull: true },
+      top_fg_score: { type: DataTypes.FLOAT, allowNull: true },
+      top_io_score: { type: DataTypes.FLOAT, allowNull: true },
+      top_confidence: { type: DataTypes.FLOAT, allowNull: true },
+      top_cohort_size: { type: DataTypes.INTEGER, allowNull: true },
+      top_given_match: { type: DataTypes.STRING(16), allowNull: true },
+      top_affil_match: { type: DataTypes.BOOLEAN, allowNull: true },
+      n_candidates: { type: DataTypes.INTEGER, allowNull: true },
+      single_candidate: { type: DataTypes.BOOLEAN, allowNull: true },
+      candidate_cwids_json: { type: DataTypes.TEXT({ length: 'long' }), allowNull: true },
+      status: { type: DataTypes.ENUM('open', 'assigned', 'accepted', 'rejected', 'dismissed', 'snoozed'), allowNull: false, defaultValue: 'open' },
+      resolution_cwid: { type: DataTypes.STRING(32), allowNull: true },
+      reviewer: { type: DataTypes.STRING(64), allowNull: true },
+      note: { type: DataTypes.TEXT, allowNull: true },
+      snooze_until: { type: DataTypes.DATEONLY, allowNull: true },
+      resolved_at: { type: DataTypes.DATE, allowNull: true },
+      first_seen: { type: DataTypes.DATE, allowNull: true },
+      last_refreshed: { type: DataTypes.DATE, allowNull: true },
+      last_checked: { type: DataTypes.DATE, allowNull: true }
+    }, {
+      sequelize,
+      tableName: 'authorship_review',
+      timestamps: false,
+      indexes: [
+        { name: "PRIMARY", unique: true, using: "BTREE", fields: [{ name: "id" }] },
+        { name: "uq_author_key", unique: true, using: "BTREE", fields: [{ name: "author_key" }] },
+        { name: "ix_pmid", using: "BTREE", fields: [{ name: "pmid" }] },
+        { name: "ix_classification", using: "BTREE", fields: [{ name: "classification" }] },
+        { name: "ix_status", using: "BTREE", fields: [{ name: "status" }] },
+        { name: "ix_single_candidate", using: "BTREE", fields: [{ name: "single_candidate" }] },
+        { name: "ix_top_io_score", using: "BTREE", fields: [{ name: "top_io_score" }] },
+        { name: "ix_entrez_date", using: "BTREE", fields: [{ name: "entrez_date" }] },
+        { name: "ix_top_cwid", using: "BTREE", fields: [{ name: "top_cwid" }] },
+      ]
+    });
+    return AuthorshipReview;
+  }
+}

--- a/src/db/models/init-models.ts
+++ b/src/db/models/init-models.ts
@@ -5,6 +5,8 @@ import { AdminDepartment } from "./AdminDepartment";
 import type { AdminDepartmentAttributes, AdminDepartmentCreationAttributes } from "./AdminDepartment";
 import { AdminFeedbackLog } from "./AdminFeedbackLog";
 import type { AdminFeedbackLogAttributes, AdminFeedbackLogCreationAttributes } from "./AdminFeedbackLog";
+import { AuthorshipReview } from "./AuthorshipReview";
+import type { AuthorshipReviewAttributes, AuthorshipReviewCreationAttributes } from "./AuthorshipReview";
 import { AdminNotificationLog } from "./AdminNotificationLog";
 import type { AdminNotificationLogAttributes, AdminNotificationLogCreationAttributes } from "./AdminNotificationLog";
 import { AdminNotificationPreference } from "./AdminNotificationPreference";
@@ -93,6 +95,7 @@ export {
   Nlm,
   AdminDepartment,
   AdminFeedbackLog,
+  AuthorshipReview,
   AdminNotificationLog,
   AdminNotificationPreference,
   AdminPermission,
@@ -142,6 +145,8 @@ export type {
   AdminDepartmentCreationAttributes,
   AdminFeedbackLogAttributes,
   AdminFeedbackLogCreationAttributes,
+  AuthorshipReviewAttributes,
+  AuthorshipReviewCreationAttributes,
   AdminNotificationLogAttributes,
   AdminNotificationLogCreationAttributes,
   AdminNotificationPreferenceAttributes,
@@ -269,6 +274,7 @@ export function initModels(sequelize: Sequelize) {
   PersonPersonType.initModel(sequelize);
   ScienceMetrix.initModel(sequelize);
   AdminSettings.initModel(sequelize);
+  AuthorshipReview.initModel(sequelize);
 
   AdminUsersDepartment.belongsTo(AdminDepartment, { as: "department", foreignKey: "departmentID"});
   AdminDepartment.hasMany(AdminUsersDepartment, { as: "adminUsersDepartments", foreignKey: "departmentID"});
@@ -337,6 +343,7 @@ export function initModels(sequelize: Sequelize) {
     PersonArticleScopusTargetAuthorAffiliation: PersonArticleScopusTargetAuthorAffiliation,
     PersonPersonType: PersonPersonType,
     ScienceMetrix: ScienceMetrix,
-    AdminSettings:AdminSettings
+    AdminSettings:AdminSettings,
+    AuthorshipReview: AuthorshipReview
   };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,7 @@ export const ROUTE_PERMISSIONS: Record<string, string> = {
 
 // Middleware matcher — UNCHANGED from original
 export const config = {
-  matcher: ['/manageusers/:path*', '/curate/:path*', '/report', '/search', '/configuration', '/notifications/:path*', '/manageprofile/:path*'],
+  matcher: ['/manageusers/:path*', '/curate/:path*', '/report', '/search', '/configuration', '/notifications/:path*', '/manageprofile/:path*', '/authorships/:path*'],
 }
 
 export async function middleware(request: NextRequest) {
@@ -75,6 +75,19 @@ export async function middleware(request: NextRequest) {
 
       if (!hasPermission(permissions, requiredPermission)) {
         // User lacks permission for this route — redirect to their landing page (MW-05)
+        const landing = getLandingPageFromPermissions(permissions, userRoles)
+        return redirectToLandingPage(request, landing)
+      }
+    }
+
+    // Authorships review is restricted to Curator_All and Superuser. It is gated
+    // by role here (not via ROUTE_PERMISSIONS) because the data-driven permission
+    // set has no canAuthorships entry.
+    if (pathName.startsWith('/authorships')) {
+      const canAuthorships = userRoles.some(
+        (r: any) => r.roleLabel === 'Superuser' || r.roleLabel === 'Curator_All'
+      )
+      if (!canAuthorships) {
         const landing = getLandingPageFromPermissions(permissions, userRoles)
         return redirectToLandingPage(request, landing)
       }

--- a/src/pages/api/db/authorships/index.ts
+++ b/src/pages/api/db/authorships/index.ts
@@ -1,0 +1,17 @@
+import { listAuthorships } from "../../../../../controllers/db/authorships.controller"
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { reciterConfig } from '../../../../../config/local'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method === "POST") {
+        if (req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            await listAuthorships(req, res)
+        } else if (req.headers.authorization === undefined) {
+            res.status(400).send("Authorization header is needed")
+        } else {
+            res.status(401).send("Authorization header is incorrect")
+        }
+    } else {
+        res.status(400).send('HTTP Method supported is POST')
+    }
+}

--- a/src/pages/api/db/authorships/summary.ts
+++ b/src/pages/api/db/authorships/summary.ts
@@ -1,0 +1,17 @@
+import { authorshipSummary } from "../../../../../controllers/db/authorships.controller"
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { reciterConfig } from '../../../../../config/local'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method === "POST") {
+        if (req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            await authorshipSummary(req, res)
+        } else if (req.headers.authorization === undefined) {
+            res.status(400).send("Authorization header is needed")
+        } else {
+            res.status(401).send("Authorization header is incorrect")
+        }
+    } else {
+        res.status(400).send('HTTP Method supported is POST')
+    }
+}

--- a/src/pages/authorships/index.tsx
+++ b/src/pages/authorships/index.tsx
@@ -1,0 +1,16 @@
+import { AppLayout } from "../../components/layouts/AppLayout"
+import AuthorshipsTabs from "../../components/elements/Authorships/AuthorshipsTabs"
+
+const AuthorshipsPage = () => {
+    return (
+        <>
+            <AuthorshipsTabs />
+        </>
+    )
+}
+
+AuthorshipsPage.getLayout = (page) => (
+    <AppLayout>{page}</AppLayout>
+);
+
+export default AuthorshipsPage;


### PR DESCRIPTION
Ports the reciterdb-sourced **Authorships review tab** onto `dev_Upd_NextJS14SNode18` — the active branch that actually deploys to `reciter-pm-dev`. The tab was originally built on `dev` (#718), which is not deployed anywhere, so it never appeared in the dev environment.

## What's here
- 6 new files (AuthorshipReview model, authorships controller, /api/db/authorships{,/summary} routes, /authorships page, AuthorshipsTabs) — drop in clean; imports verified against dev_Upd (config/local backendApiKey, src/db/sequelize models, AppLayout).
- 3 integration edits: init-models registers the model; middleware gates /authorships to Curator_All/Superuser **by role** (dev_Upd's data-driven permission set has no canAuthorships); SideNavbar adds the nav item in the Navigation group with the Admin-section key offset corrected.
- Skipped: constants.js canAuthorships (unused on this branch) and the dev-only lockfile commit.

Build verification = the `-Dev-V2` pipeline on merge.