### PR TITLE
Authorships Phase C (PR-1): curator actions + status views

### DIFF
--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -1,6 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op, fn, col } from "sequelize";
+import { getToken } from "next-auth/jwt";
 import models from "../../src/db/sequelize";
+import { reciterConfig } from "../../config/local";
+import { updatePendingArticleCount } from "./person.controller";
 
 // Columns returned to the Authorships tab (one row per unassigned WCM authorship).
 const LIST_ATTRIBUTES = [
@@ -9,8 +12,10 @@ const LIST_ATTRIBUTES = [
   "top_cwid", "top_name", "top_person_type", "top_dept",
   "top_fg_score", "top_io_score", "top_confidence", "top_cohort_size",
   "top_given_match", "top_affil_match", "n_candidates", "single_candidate",
-  "candidate_cwids_json", "status",
+  "candidate_cwids_json", "status", "snooze_until", "reviewer", "resolved_at",
 ];
+
+const todayStr = () => new Date().toISOString().slice(0, 10);
 
 const SORTS: Record<string, any[]> = {
   // default: single-candidate (high-precision) first, then identity-only score desc
@@ -24,9 +29,25 @@ const SORTS: Record<string, any[]> = {
 function buildWhere(body: any): any {
   const and: any[] = [];
 
-  // feed: unassigned (open/snoozed) is the default; "all" drops the status filter
+  // status view: "open" (default) | "snoozed" | "dismissed"; feed="all" drops the status filter
   if (body.feed !== "all") {
-    and.push({ status: { [Op.in]: ["open", "snoozed"] } });
+    const view = body.statusView || "open";
+    const today = todayStr();
+    if (view === "snoozed") {
+      // still sleeping (wake date in the future)
+      and.push({ status: "snoozed", snooze_until: { [Op.gt]: today } });
+    } else if (view === "dismissed") {
+      and.push({ status: "dismissed" });
+    } else {
+      // open queue: truly open, plus snoozes whose timer has lapsed (or has no wake date)
+      and.push({
+        [Op.or]: [
+          { status: "open" },
+          { status: "snoozed", snooze_until: { [Op.lte]: today } },
+          { status: "snoozed", snooze_until: null as any },
+        ],
+      });
+    }
   }
   // classification lane: buried | suggested | absent
   if (body.classification && body.classification !== "all") {
@@ -111,5 +132,156 @@ export const authorshipSummary = async (req: NextApiRequest, res: NextApiRespons
   } catch (e) {
     console.log(e);
     res.status(500).send(e);
+  }
+};
+
+// ---- Phase C: curator actions -------------------------------------------------
+// Resolve the curator's identity + authorization server-side from the next-auth JWT.
+// The /api routes are NOT covered by middleware (matcher is page-only) and the
+// backendApiKey is a shared app secret, so identity/role must be enforced here.
+async function resolveCurator(req: NextApiRequest): Promise<{ userID?: number; cwid?: string; authorized: boolean }> {
+  const token: any = await getToken({ req: req as any, secret: process.env.NEXTAUTH_SECRET });
+  if (!token) return { authorized: false };
+  let userID: number | undefined = token.databaseUser?.userID;
+  const cwid: string | undefined = token.username;
+  // fallback: resolve the AdminUser id from the curator CWID if the JWT lacks databaseUser
+  if (!userID && cwid) {
+    const au: any = await models.AdminUser.findOne({ where: { personIdentifier: cwid }, attributes: ["userID"] });
+    userID = au?.userID;
+  }
+  let roles: any[] = [];
+  try { roles = token.userRoles ? JSON.parse(token.userRoles) : []; } catch { roles = []; }
+  const authorized = roles.some((r: any) => r.roleLabel === "Superuser" || r.roleLabel === "Curator_All");
+  return { userID, cwid, authorized };
+}
+
+// Gold-standard MERGE/DELETE via the ReCiter Java endpoint, tagged with the AAR source
+// and the curator's numeric userID. Returns the upstream HTTP status.
+async function writeGoldStandard(
+  uid: string, pmid: number, kind: "known" | "rejected", flag: "UPDATE" | "DELETE", curatedBy?: number,
+): Promise<number> {
+  const body: any = { uid };
+  if (kind === "known") body.knownPmids = [pmid]; else body.rejectedPmids = [pmid];
+  const curatedByQ = curatedBy != null ? `&curatedBy=${curatedBy}` : "";
+  try {
+    const resp = await fetch(
+      `${reciterConfig.reciter.reciterUpdateGoldStandardEndpoint}?goldStandardUpdateFlag=${flag}&source=adversarial-attribution-review${curatedByQ}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "api-key": reciterConfig.reciter.adminApiKey,
+          "User-Agent": "reciter-pub-manager-server",
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    return resp.status;
+  } catch (e) {
+    console.log("[authorships] gold-standard write failed:", e);
+    return 500;
+  }
+}
+
+// Append an AdminFeedbackLog row (accept/reject only). Mirrors createFeedbackLog:
+// validates the curator is an ACTIVE AdminUser, then writes + bumps the pending count.
+async function appendFeedbackLog(userID: number, personIdentifier: string, pmid: number, feedback: "ACCEPTED" | "REJECTED") {
+  const active: any = await models.AdminUser.findOne({ where: { userID, status: 1 }, attributes: ["userID"] });
+  if (!active) throw new Error(`userID ${userID} is not an active AdminUser`);
+  await models.AdminFeedbackLog.create({
+    userID, personIdentifier, articleIdentifier: pmid, feedback, createTimestamp: new Date(),
+  });
+  // same side-effect the normal curate flow has; never throws (own try/catch)
+  await updatePendingArticleCount(personIdentifier, feedback);
+}
+
+// POST /api/db/authorships/action — single-row curator action.
+// body: { id: number, action: "accept"|"reject"|"snooze"|"dismiss"|"reopen" }
+export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const curator = await resolveCurator(req);
+    if (!curator.authorized) return res.status(403).send("Not authorized for authorships review");
+    if (!curator.userID) return res.status(401).send("Could not resolve curator identity");
+
+    const body = req.body || {};
+    const id = Number(body.id);
+    const action = String(body.action || "");
+    if (!id || !action) return res.status(400).send("id and action are required");
+
+    const row: any = await models.AuthorshipReview.findByPk(id);
+    if (!row) return res.status(404).send("Authorship not found");
+
+    const pmid = Number(row.pmid);
+    const cwid = row.top_cwid as string | undefined;
+    const reviewer = curator.cwid || String(curator.userID);
+
+    switch (action) {
+      case "accept": {
+        if (!cwid) return res.status(409).send("No proposed identity to accept");
+        if (!row.single_candidate) return res.status(409).send("Multiple candidates — use Assign (next release)");
+        const gs = await writeGoldStandard(cwid, pmid, "known", "UPDATE", curator.userID);
+        if (gs !== 200) return res.status(502).send(`Gold-standard write failed (${gs})`);
+        await models.AuthorshipReview.update(
+          { status: "accepted", resolution_cwid: cwid, reviewer, resolved_at: new Date() },
+          { where: { id } },
+        );
+        // audit log is best-effort: a hiccup here must not undo the authoritative GS+status write
+        try { await appendFeedbackLog(curator.userID, cwid, pmid, "ACCEPTED"); }
+        catch (e) { console.log("[authorships] feedbacklog (accept) non-fatal:", e); }
+        break;
+      }
+      case "reject": {
+        if (!cwid) return res.status(409).send("No proposed identity to reject");
+        if (!row.single_candidate) return res.status(409).send("Multiple candidates — use Assign (next release)");
+        const gs = await writeGoldStandard(cwid, pmid, "rejected", "UPDATE", curator.userID);
+        if (gs !== 200) return res.status(502).send(`Gold-standard write failed (${gs})`);
+        await models.AuthorshipReview.update(
+          { status: "rejected", reviewer, resolved_at: new Date() },
+          { where: { id } },
+        );
+        // audit log is best-effort (see accept)
+        try { await appendFeedbackLog(curator.userID, cwid, pmid, "REJECTED"); }
+        catch (e) { console.log("[authorships] feedbacklog (reject) non-fatal:", e); }
+        break;
+      }
+      case "snooze": {
+        const wake = new Date(Date.now() + 90 * 86400000).toISOString().slice(0, 10);
+        await models.AuthorshipReview.update(
+          { status: "snoozed", snooze_until: wake, reviewer },
+          { where: { id } },
+        );
+        break;
+      }
+      case "dismiss": {
+        await models.AuthorshipReview.update(
+          { status: "dismissed", reviewer, resolved_at: new Date() },
+          { where: { id } },
+        );
+        break;
+      }
+      case "reopen": {
+        // reverse any prior gold-standard write before re-opening
+        if (row.status === "accepted" && cwid) {
+          const gs = await writeGoldStandard(cwid, pmid, "known", "DELETE", curator.userID);
+          if (gs !== 200) return res.status(502).send(`Gold-standard undo failed (${gs})`);
+        } else if (row.status === "rejected" && cwid) {
+          const gs = await writeGoldStandard(cwid, pmid, "rejected", "DELETE", curator.userID);
+          if (gs !== 200) return res.status(502).send(`Gold-standard undo failed (${gs})`);
+        }
+        await models.AuthorshipReview.update(
+          { status: "open", snooze_until: null, resolved_at: null, resolution_cwid: null, reviewer },
+          { where: { id } },
+        );
+        break;
+      }
+      default:
+        return res.status(400).send(`Unknown action: ${action}`);
+    }
+
+    const updated = await models.AuthorshipReview.findByPk(id, { attributes: LIST_ATTRIBUTES });
+    return res.send({ ok: true, row: updated });
+  } catch (e) {
+    console.log(e);
+    return res.status(500).send(String(e));
   }
 };

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
+import type { CSSProperties } from "react";
 import Tooltip from "@mui/material/Tooltip";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Snackbar from "@mui/material/Snackbar";
 import { reciterConfig } from "../../../../config/local";
 
 // ---- types ---------------------------------------------------------------
@@ -28,6 +32,9 @@ interface AuthorshipRow {
   single_candidate?: boolean;
   candidate_cwids_json?: string;
   status?: string;
+  snooze_until?: string;
+  reviewer?: string;
+  resolved_at?: string;
 }
 
 interface Summary { total: number; single_candidate: number; classes: Record<string, number>; }
@@ -58,8 +65,19 @@ const HEADERS: Array<{ label: string; hint?: string }> = [
   { label: "Date", hint: "Article publication date (Entrez date)." },
   { label: "Article" },
   { label: "" },
+  { label: "" },
 ];
 const COL_COUNT = HEADERS.length;
+
+const ACTION_LABEL: Record<string, string> = {
+  accept: "Accepted", reject: "Rejected", snooze: "Snoozed for 90 days", dismiss: "Dismissed",
+};
+// small inline button style for the per-row actions
+const abtn = (bg: string, color: string, busy: boolean): CSSProperties => ({
+  padding: "4px 10px", borderRadius: 6, border: `1px solid ${bg === "#fff" ? "#d0d5dd" : bg}`,
+  background: bg, color, cursor: busy ? "default" : "pointer", fontSize: 12, fontWeight: 600,
+  whiteSpace: "nowrap", opacity: busy ? 0.5 : 1,
+});
 
 // ---- small presentational bits -------------------------------------------
 const Badge = ({ text, color, title }: { text: string; color: string; title?: string }) => {
@@ -96,6 +114,11 @@ const AuthorshipsTabs = () => {
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [expanded, setExpanded] = useState<number | null>(null);
+  const [statusView, setStatusView] = useState<"open" | "snoozed" | "dismissed">("open");
+  const [actingId, setActingId] = useState<number | null>(null);
+  const [menu, setMenu] = useState<{ anchor: HTMLElement; row: AuthorshipRow } | null>(null);
+  const [undo, setUndo] = useState<{ row: AuthorshipRow; label: string } | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string>("");
 
   const filterBody = useCallback(() => ({
     feed: "unassigned",
@@ -105,7 +128,8 @@ const AuthorshipsTabs = () => {
     dateFrom,
     dateTo,
     sort,
-  }), [lane, classification, search, dateFrom, dateTo, sort]);
+    statusView,
+  }), [lane, classification, search, dateFrom, dateTo, sort, statusView]);
 
   const fetchData = useCallback(() => {
     setLoading(true);
@@ -122,10 +146,10 @@ const AuthorshipsTabs = () => {
   const fetchSummary = useCallback(() => {
     fetch("/api/db/authorships/summary", {
       credentials: "same-origin", method: "POST", headers: apiHeaders,
-      body: JSON.stringify({ feed: "unassigned", searchTextInput: search, dateFrom, dateTo }),
+      body: JSON.stringify({ feed: "unassigned", searchTextInput: search, dateFrom, dateTo, statusView }),
     })
       .then((r) => r.json()).then(setSummary).catch(() => setSummary(null));
-  }, [search, dateFrom, dateTo]);
+  }, [search, dateFrom, dateTo, statusView]);
 
   // live-filter: debounce the search box so the table narrows as you type (no Enter needed)
   useEffect(() => {
@@ -135,8 +159,44 @@ const AuthorshipsTabs = () => {
 
   useEffect(() => { fetchData(); }, [fetchData]);
   useEffect(() => { fetchSummary(); }, [fetchSummary]);
-  // reset to first page when filters or sort change
-  useEffect(() => { setPage(0); }, [lane, classification, search, dateFrom, dateTo, sort]);
+  // reset to first page when filters, sort, or status view change
+  useEffect(() => { setPage(0); }, [lane, classification, search, dateFrom, dateTo, sort, statusView]);
+
+  // perform a curator action: optimistically drop the row, POST, then offer Undo (or revert on failure)
+  const doAction = useCallback((row: AuthorshipRow, action: string) => {
+    setMenu(null);
+    setActingId(row.id);
+    setRows((rs) => rs.filter((x) => x.id !== row.id));
+    setCount((c) => Math.max(0, c - 1));
+    fetch("/api/db/authorships/action", {
+      credentials: "same-origin", method: "POST", headers: apiHeaders,
+      body: JSON.stringify({ id: row.id, action }),
+    })
+      .then(async (r) => {
+        if (!r.ok) throw new Error((await r.text()) || `HTTP ${r.status}`);
+        if (action !== "reopen") setUndo({ row, label: ACTION_LABEL[action] || "Done" });
+        fetchSummary();
+      })
+      .catch((e) => {
+        setErrorMsg(`Couldn't ${action} — ${String(e?.message || e)}`);
+        fetchData(); // restore the optimistically-removed row
+      })
+      .finally(() => setActingId(null));
+  }, [fetchData, fetchSummary]);
+
+  // undo = reopen (reverses any gold-standard write + sets status back to open)
+  const doUndo = useCallback(() => {
+    if (!undo) return;
+    const row = undo.row;
+    setUndo(null);
+    fetch("/api/db/authorships/action", {
+      credentials: "same-origin", method: "POST", headers: apiHeaders,
+      body: JSON.stringify({ id: row.id, action: "reopen" }),
+    })
+      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); })
+      .catch((e) => setErrorMsg(`Undo failed — ${String(e?.message || e)}`))
+      .finally(() => { fetchData(); fetchSummary(); });
+  }, [undo, fetchData, fetchSummary]);
 
   const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
   const classChips: Array<typeof classification> = ["all", "buried", "absent", "suggested"];
@@ -160,6 +220,17 @@ const AuthorshipsTabs = () => {
           ))}
         </div>
       )}
+
+      {/* status view: Open / Snoozed / Dismissed */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+        {([["open", "Open"], ["snoozed", "Snoozed"], ["dismissed", "Dismissed"]] as const).map(([key, label]) => (
+          <button key={key} onClick={() => setStatusView(key)} style={{
+            padding: "6px 14px", borderRadius: 8, border: "1px solid #d0d5dd", cursor: "pointer",
+            background: statusView === key ? "#0c111d" : "#fff", color: statusView === key ? "#fff" : "#344054",
+            fontWeight: 600, fontSize: 13,
+          }}>{label}</button>
+        ))}
+      </div>
 
       {/* lane toggle */}
       <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
@@ -284,6 +355,34 @@ const AuthorshipsTabs = () => {
                       <a href={`https://pubmed.ncbi.nlm.nih.gov/${r.pmid}/`} target="_blank" rel="noreferrer"
                         style={{ color: "#1570ef", textDecoration: "none", fontSize: 12 }}>{r.pmid} ↗</a>
                     </td>
+                    <td style={{ padding: "10px 12px", whiteSpace: "nowrap" }}>
+                      {statusView !== "open" ? (
+                        <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                          {statusView === "snoozed" && r.snooze_until && (
+                            <span style={{ color: "#98a2b3", fontSize: 11 }}>wakes {r.snooze_until}</span>
+                          )}
+                          <button disabled={actingId === r.id} onClick={() => doAction(r, "reopen")}
+                            style={abtn("#fff", "#175cd3", actingId === r.id)}>Reopen</button>
+                        </span>
+                      ) : r.single_candidate ? (
+                        <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                          <button disabled={actingId === r.id} onClick={() => doAction(r, "accept")}
+                            style={abtn("#067647", "#fff", actingId === r.id)}>✓ Accept</button>
+                          <button disabled={actingId === r.id} onClick={() => doAction(r, "reject")}
+                            style={abtn("#fff", "#b42318", actingId === r.id)}>✕ Reject</button>
+                          <button disabled={actingId === r.id} onClick={(e) => setMenu({ anchor: e.currentTarget, row: r })}
+                            style={abtn("#fff", "#475467", actingId === r.id)}>⋯</button>
+                        </span>
+                      ) : (
+                        <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                          <Tooltip title="Multiple candidates — Assign arrives in the next release" placement="top" arrow>
+                            <span style={{ color: "#98a2b3", fontSize: 11, cursor: "help" }}>needs review</span>
+                          </Tooltip>
+                          <button disabled={actingId === r.id} onClick={(e) => setMenu({ anchor: e.currentTarget, row: r })}
+                            style={abtn("#fff", "#475467", actingId === r.id)}>⋯</button>
+                        </span>
+                      )}
+                    </td>
                   </tr>
                   {isOpen && alternates.length > 0 && (
                     <tr key={`${r.id}-exp`} style={{ background: "#fcfcfd" }}>
@@ -322,6 +421,25 @@ const AuthorshipsTabs = () => {
             style={{ padding: "6px 12px", borderRadius: 8, border: "1px solid #d0d5dd", background: "#fff", cursor: page + 1 >= totalPages ? "default" : "pointer", opacity: page + 1 >= totalPages ? 0.5 : 1 }}>Next</button>
         </span>
       </div>
+
+      {/* overflow menu: Snooze / Dismiss */}
+      <Menu anchorEl={menu?.anchor} open={!!menu} onClose={() => setMenu(null)}>
+        <MenuItem onClick={() => menu && doAction(menu.row, "snooze")}>Snooze 90 days</MenuItem>
+        <MenuItem onClick={() => menu && doAction(menu.row, "dismiss")}>Dismiss</MenuItem>
+      </Menu>
+
+      {/* undo (immediate reversal) */}
+      <Snackbar open={!!undo} autoHideDuration={5000} onClose={() => setUndo(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        message={undo ? undo.label : ""}
+        action={
+          <button onClick={doUndo}
+            style={{ color: "#7cc4ff", background: "none", border: "none", cursor: "pointer", fontWeight: 700, fontSize: 13 }}>UNDO</button>
+        } />
+
+      {/* error */}
+      <Snackbar open={!!errorMsg} autoHideDuration={6000} onClose={() => setErrorMsg("")}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }} message={errorMsg} />
     </div>
   );
 };

--- a/src/pages/api/db/authorships/action.ts
+++ b/src/pages/api/db/authorships/action.ts
@@ -1,0 +1,20 @@
+import { authorshipAction } from "../../../../../controllers/db/authorships.controller"
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { reciterConfig } from '../../../../../config/local'
+
+// POST /api/db/authorships/action — single-row curator action (accept/reject/snooze/dismiss/reopen).
+// App-level gate via backendApiKey; the controller additionally derives the curator identity and
+// enforces the Superuser/Curator_All role from the next-auth JWT (middleware does not cover /api).
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method === "POST") {
+        if (req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            await authorshipAction(req, res)
+        } else if (req.headers.authorization === undefined) {
+            res.status(400).send("Authorization header is needed")
+        } else {
+            res.status(401).send("Authorization header is incorrect")
+        }
+    } else {
+        res.status(400).send('HTTP Method supported is POST')
+    }
+}


### PR DESCRIPTION
Phase C, **PR-1 of 2** — the per-row curator action layer on the `/authorships` tab. Built per `docs/AUTHORSHIP_REVIEW_PHASE_C_PR1_PLAN.md` (approved this session). **Writes to the production gold standard.**

## What this adds
- **Per-row actions:** ✓ Accept · ✕ Reject · ⋯ (Snooze · Dismiss) in the Open view; **Reopen** in the Snoozed/Dismissed views.
- **Status switch:** `Open · Snoozed · Dismissed`. The **Open** view re-surfaces snoozes whose 90-day timer has lapsed.
- **Optimistic + Undo:** the row drops out immediately; a 5s **Undo** (MUI Snackbar) reverses it. The Snoozed/Dismissed views + **Reopen** are the *durable* undo.

## Action semantics
| Action | Gold standard | `authorship_review` | Feedback log |
|--------|--------------|---------------------|--------------|
| Accept | UPDATE `knownPmids += pmid` (`source=adversarial-attribution-review`, `curatedBy=userID`) | `accepted` | `ACCEPTED` (best-effort) |
| Reject | UPDATE `rejectedPmids += pmid` | `rejected` | `REJECTED` (best-effort) |
| Snooze | — | `snoozed`, `snooze_until=+90d` | — |
| Dismiss | — | `dismissed` | — |
| Reopen | DELETE the pmid if previously accepted/rejected | `open` | — |

GS writes proxy the ReCiter Java `/reciter/goldstandard` endpoint; Undo uses `goldStandardUpdateFlag=DELETE` (single pmid, not a list re-submit). The GS write + status update are authoritative; the audit-log append is best-effort so it can't leave a partial state.

## Security
The new `POST /api/db/authorships/action` enforces auth **itself** — `middleware.matcher` is page-only and doesn't cover `/api`. It requires the `backendApiKey` header **and** derives the curator's identity/role server-side via `getToken` (Superuser/Curator_All). The curator's `userID` is taken from the session, not the request body.

## Scope / deferred to PR-2
- Multi-candidate rows defer Accept/Reject to **Assign** (next release) — they show "needs review" and can still Snooze/Dismiss. Single-candidate guard is enforced server-side too.
- Article-grouping by PMID, bulk "Accept all N", evidence panel, keyboard nav, and a durable **Resolved (Accepted/Rejected)** browse-and-reverse view are PR-2. (In PR-1, Accept/Reject reversal is the 5s toast.)
- No `authorship_review` schema change.

## Verification
- `tsc --noEmit` clean for the three touched files (the `next-auth/client` + `middleware.ts` errors are the known local node_modules noise, present on the base branch, resolved by the pipeline's `npm ci`).
- Runtime verify in dev after deploy: Accept lands the pmid in that uid's `knownPmids` (+ Undo removes it); Snooze/Dismiss move rows to their views; Reopen returns them. Worgall `42220538` stays untouched as the proof case.