### PR TITLE
Authorships: person-type filter + curate-profile link

### DIFF
--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -57,6 +57,10 @@ function buildWhere(body: any): any {
   if (body.precision === "single") {
     and.push({ single_candidate: true });
   }
+  // person-type filter (the proposed identity's person type, e.g. academic-faculty-weillfulltime)
+  if (body.personType && body.personType !== "all") {
+    and.push({ top_person_type: body.personType });
+  }
   // free-text search across author name, proposed identity, and pmid
   const search = (body.searchTextInput || "").trim();
   if (search) {
@@ -111,9 +115,9 @@ export const listAuthorships = async (req: NextApiRequest, res: NextApiResponse)
 // each lane shows its own total.
 export const authorshipSummary = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const body = { ...(req.body || {}), classification: "all", precision: "all" };
+    const body = { ...(req.body || {}), classification: "all", precision: "all", personType: "all" };
     const where = buildWhere(body);
-    const [total, single, byClass] = await Promise.all([
+    const [total, single, byClass, byType] = await Promise.all([
       models.AuthorshipReview.count({ where }),
       models.AuthorshipReview.count({ where: { [Op.and]: [where, { single_candidate: true }] } }),
       models.AuthorshipReview.findAll({
@@ -125,10 +129,23 @@ export const authorshipSummary = async (req: NextApiRequest, res: NextApiRespons
         group: ["classification"],
         raw: true,
       }),
+      models.AuthorshipReview.findAll({
+        attributes: [
+          "top_person_type",
+          [fn("COUNT", col("id")), "n"],
+        ],
+        where,
+        group: ["top_person_type"],
+        raw: true,
+      }),
     ]);
     const classes: Record<string, number> = {};
     (byClass as any[]).forEach((r) => { classes[r.classification] = Number(r.n); });
-    res.send({ total, single_candidate: single, classes });
+    const personTypes = (byType as any[])
+      .filter((r) => r.top_person_type)
+      .map((r) => ({ type: r.top_person_type as string, n: Number(r.n) }))
+      .sort((a, b) => b.n - a.n);
+    res.send({ total, single_candidate: single, classes, personTypes });
   } catch (e) {
     console.log(e);
     res.status(500).send(e);

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -37,7 +37,7 @@ interface AuthorshipRow {
   resolved_at?: string;
 }
 
-interface Summary { total: number; single_candidate: number; classes: Record<string, number>; }
+interface Summary { total: number; single_candidate: number; classes: Record<string, number>; personTypes?: Array<{ type: string; n: number }>; }
 
 const PAGE_SIZE = 25;
 const apiHeaders = {
@@ -113,6 +113,7 @@ const AuthorshipsTabs = () => {
   const [sort, setSort] = useState("precision");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
+  const [personType, setPersonType] = useState("all");
   const [expanded, setExpanded] = useState<number | null>(null);
   const [statusView, setStatusView] = useState<"open" | "snoozed" | "dismissed">("open");
   const [actingId, setActingId] = useState<number | null>(null);
@@ -125,11 +126,12 @@ const AuthorshipsTabs = () => {
     precision: lane === "single" ? "single" : "all",
     classification,
     searchTextInput: search,
+    personType,
     dateFrom,
     dateTo,
     sort,
     statusView,
-  }), [lane, classification, search, dateFrom, dateTo, sort, statusView]);
+  }), [lane, classification, search, personType, dateFrom, dateTo, sort, statusView]);
 
   const fetchData = useCallback(() => {
     setLoading(true);
@@ -160,7 +162,7 @@ const AuthorshipsTabs = () => {
   useEffect(() => { fetchData(); }, [fetchData]);
   useEffect(() => { fetchSummary(); }, [fetchSummary]);
   // reset to first page when filters, sort, or status view change
-  useEffect(() => { setPage(0); }, [lane, classification, search, dateFrom, dateTo, sort, statusView]);
+  useEffect(() => { setPage(0); }, [lane, classification, search, personType, dateFrom, dateTo, sort, statusView]);
 
   // perform a curator action: optimistically drop the row, POST, then offer Undo (or revert on failure)
   const doAction = useCallback((row: AuthorshipRow, action: string) => {
@@ -257,6 +259,16 @@ const AuthorshipsTabs = () => {
         ))}
         <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
           <label style={{ fontSize: 12, color: "#475467", display: "flex", alignItems: "center", gap: 6 }}>
+            Type
+            <select value={personType} onChange={(e) => setPersonType(e.target.value)}
+              style={{ padding: "6px 8px", borderRadius: 8, border: "1px solid #d0d5dd", fontSize: 13, color: "#344054", maxWidth: 220 }}>
+              <option value="all">All types</option>
+              {(summary?.personTypes || []).map((pt) => (
+                <option key={pt.type} value={pt.type}>{pt.type} ({pt.n.toLocaleString()})</option>
+              ))}
+            </select>
+          </label>
+          <label style={{ fontSize: 12, color: "#475467", display: "flex", alignItems: "center", gap: 6 }}>
             Sort
             <select value={sort} onChange={(e) => setSort(e.target.value)}
               style={{ padding: "6px 8px", borderRadius: 8, border: "1px solid #d0d5dd", fontSize: 13, color: "#344054" }}>
@@ -331,7 +343,17 @@ const AuthorshipsTabs = () => {
                       <div style={{ color: "#98a2b3", fontSize: 11 }}>{r.author_position_label} author</div>
                     </td>
                     <td style={{ padding: "10px 12px" }}>
-                      <div style={{ color: "#101828" }}>{r.top_name} <span style={{ color: "#1570ef" }}>({r.top_cwid})</span></div>
+                      <div style={{ color: "#101828" }}>
+                        {r.top_cwid ? (
+                          <a href={`/curate/${r.top_cwid}`} target="_blank" rel="noreferrer"
+                            title={`Open ${r.top_name || r.top_cwid}'s curate profile`}
+                            style={{ color: "#101828", textDecoration: "none" }}>
+                            {r.top_name} <span style={{ color: "#1570ef", textDecoration: "underline" }}>({r.top_cwid}) ↗</span>
+                          </a>
+                        ) : (
+                          <>{r.top_name}</>
+                        )}
+                      </div>
                       <div style={{ color: "#667085", fontSize: 11 }}>{r.top_person_type}{r.top_dept ? ` · ${r.top_dept}` : ""}</div>
                     </td>
                     <td style={{ padding: "10px 12px" }}><Score value={r.top_fg_score} kind="fg" /></td>


### PR DESCRIPTION
Two small enhancements requested after Phase C PR-1 went live. Read-only — no gold-standard writes.

**1. Person-type filter.** A new **Type** dropdown filters the queue by the proposed identity's `top_person_type`. Options (with counts) come from a distinct `top_person_type` aggregate added to the summary endpoint; `buildWhere` filters on `top_person_type`. The list is computed over the current feed/search/date/status view, independent of the selected type.

**2. Proposed identity → curate profile.** The proposed identity (name + CWID) now links to that person's curate profile at `/curate/<cwid>` (opens in a new tab so the curator keeps their place in the queue). Falls back to plain text if a row has no `top_cwid`.

## Verification
- `tsc --noEmit` clean for both files (the usual local `next-auth/client` + `middleware.ts` node_modules noise is pre-existing on the base branch).
- Runtime check in dev after deploy: the Type dropdown lists person types with counts and filters the table; clicking a proposed identity opens `/curate/<cwid>`.