### PR TITLE
Authorships Phase C PR-2 — card redesign + multi-candidate Assign

### DIFF
--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -18,37 +18,45 @@ const LIST_ATTRIBUTES = [
 const todayStr = () => new Date().toISOString().slice(0, 10);
 
 const SORTS: Record<string, any[]> = {
-  // default: single-candidate (high-precision) first, then identity-only score desc
-  precision: [["single_candidate", "DESC"], ["top_io_score", "DESC"]],
-  confidence: [["top_confidence", "DESC"]],
-  io: [["top_io_score", "DESC"]],
-  fg: [["top_fg_score", "DESC"]],
-  date: [["entrez_date", "DESC"]],
+  // default: single-candidate (high-precision) first, then identity-only score desc.
+  // ["pmid","DESC"] is appended to every entry as a secondary key so same-paper
+  // authorships land adjacent within a sort tie (PR-2 correction 6).
+  precision: [["single_candidate", "DESC"], ["top_io_score", "DESC"], ["pmid", "DESC"]],
+  confidence: [["top_confidence", "DESC"], ["pmid", "DESC"]],
+  io: [["top_io_score", "DESC"], ["pmid", "DESC"]],
+  fg: [["top_fg_score", "DESC"], ["pmid", "DESC"]],
+  date: [["entrez_date", "DESC"], ["pmid", "DESC"]],
 };
+
+// The status-view predicate for the current view ("open" | "snoozed" | "dismissed"),
+// or null when feed="all" (no status filter). Factored out of buildWhere so the
+// per-paper sibling count (B2) respects the same status view as the list itself.
+function openStatusWhere(body: any): any {
+  if (body.feed === "all") return null;
+  const view = body.statusView || "open";
+  const today = todayStr();
+  if (view === "snoozed") {
+    // still sleeping (wake date in the future)
+    return { status: "snoozed", snooze_until: { [Op.gt]: today } };
+  } else if (view === "dismissed") {
+    return { status: "dismissed" };
+  }
+  // open queue: truly open, plus snoozes whose timer has lapsed (or has no wake date)
+  return {
+    [Op.or]: [
+      { status: "open" },
+      { status: "snoozed", snooze_until: { [Op.lte]: today } },
+      { status: "snoozed", snooze_until: null as any },
+    ],
+  };
+}
 
 function buildWhere(body: any): any {
   const and: any[] = [];
 
   // status view: "open" (default) | "snoozed" | "dismissed"; feed="all" drops the status filter
-  if (body.feed !== "all") {
-    const view = body.statusView || "open";
-    const today = todayStr();
-    if (view === "snoozed") {
-      // still sleeping (wake date in the future)
-      and.push({ status: "snoozed", snooze_until: { [Op.gt]: today } });
-    } else if (view === "dismissed") {
-      and.push({ status: "dismissed" });
-    } else {
-      // open queue: truly open, plus snoozes whose timer has lapsed (or has no wake date)
-      and.push({
-        [Op.or]: [
-          { status: "open" },
-          { status: "snoozed", snooze_until: { [Op.lte]: today } },
-          { status: "snoozed", snooze_until: null as any },
-        ],
-      });
-    }
-  }
+  const status = openStatusWhere(body);
+  if (status) and.push(status);
   // classification lane: buried | suggested | absent
   if (body.classification && body.classification !== "all") {
     and.push({ classification: body.classification });
@@ -103,7 +111,29 @@ export const listAuthorships = async (req: NextApiRequest, res: NextApiResponse)
       limit,
     });
 
-    res.send({ rows, count, limit, offset });
+    // Per-paper sibling count (B2): one grouped COUNT over the page's distinct pmids,
+    // scoped to the active status-view predicate so we don't count e.g. dismissed
+    // siblings while in the Open view. Accurate even when siblings are off-page.
+    const pmids = [...new Set(rows.map((r: any) => r.pmid))];
+    let sibMap: Record<string, number> = {};
+    if (pmids.length) {
+      const sibWhere: any = { pmid: { [Op.in]: pmids } };
+      const status = openStatusWhere(body);
+      const sibCountWhere = status ? { [Op.and]: [sibWhere, status] } : sibWhere;
+      const sib: any[] = await models.AuthorshipReview.findAll({
+        attributes: ["pmid", [fn("COUNT", col("id")), "n"]],
+        where: sibCountWhere,
+        group: ["pmid"],
+        raw: true,
+      });
+      sibMap = Object.fromEntries(sib.map((s) => [String(s.pmid), Number(s.n)]));
+    }
+    const out = rows.map((r: any) => ({
+      ...r.toJSON(),
+      pmid_sibling_count: sibMap[String(r.pmid)] || 1,
+    }));
+
+    res.send({ rows: out, count, limit, offset });
   } catch (e) {
     console.log(e);
     res.status(500).send(e);
@@ -213,7 +243,8 @@ async function appendFeedbackLog(userID: number, personIdentifier: string, pmid:
 }
 
 // POST /api/db/authorships/action — single-row curator action.
-// body: { id: number, action: "accept"|"reject"|"snooze"|"dismiss"|"reopen" }
+// body: { id: number, action: "accept"|"reject"|"snooze"|"dismiss"|"assign"|"reopen", cwid?: string }
+// cwid is required only for "assign" (the chosen multi-candidate WCM homonym).
 export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const curator = await resolveCurator(req);
@@ -235,7 +266,7 @@ export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse
     switch (action) {
       case "accept": {
         if (!cwid) return res.status(409).send("No proposed identity to accept");
-        if (!row.single_candidate) return res.status(409).send("Multiple candidates — use Assign (next release)");
+        if (!row.single_candidate) return res.status(409).send("Multiple candidates — use \"Pick one\" to assign");
         const gs = await writeGoldStandard(cwid, pmid, "known", "UPDATE", curator.userID);
         if (gs !== 200) return res.status(502).send(`Gold-standard write failed (${gs})`);
         await models.AuthorshipReview.update(
@@ -249,7 +280,7 @@ export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse
       }
       case "reject": {
         if (!cwid) return res.status(409).send("No proposed identity to reject");
-        if (!row.single_candidate) return res.status(409).send("Multiple candidates — use Assign (next release)");
+        if (!row.single_candidate) return res.status(409).send("Multiple candidates — use \"Pick one\" to assign");
         const gs = await writeGoldStandard(cwid, pmid, "rejected", "UPDATE", curator.userID);
         if (gs !== 200) return res.status(502).send(`Gold-standard write failed (${gs})`);
         await models.AuthorshipReview.update(
@@ -276,13 +307,54 @@ export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse
         );
         break;
       }
+      case "assign": {
+        // multi-candidate disambiguation: curator picks the chosen WCM homonym.
+        // No single_candidate guard — assign is precisely the multi-candidate path.
+        const chosen = String(body.cwid || "");
+        if (!chosen) return res.status(400).send("cwid is required for assign");
+        // Integrity boundary: assign writes the authoritative gold standard, so the server —
+        // not the client — must verify the chosen cwid is actually a candidate for this
+        // authorship. accept/reject derive cwid server-side from top_cwid and can't be
+        // spoofed; assign trusts a client-supplied cwid, so validate it against the
+        // candidate set (plus top_cwid) before any GS write.
+        let candidateCwids: string[] = [];
+        try {
+          const parsed = JSON.parse(row.candidate_cwids_json || "[]");
+          if (Array.isArray(parsed)) {
+            candidateCwids = parsed
+              .map((c: any) => (typeof c === "string" ? c : c?.cwid))
+              .filter(Boolean)
+              .map(String);
+          }
+        } catch { candidateCwids = []; }
+        const allowed = new Set([row.top_cwid, ...candidateCwids].filter(Boolean).map(String));
+        if (!allowed.has(chosen)) {
+          return res.status(400).send("cwid is not a candidate for this authorship");
+        }
+        const gs = await writeGoldStandard(chosen, pmid, "known", "UPDATE", curator.userID);
+        if (gs !== 200) return res.status(502).send(`Gold-standard write failed (${gs})`);
+        await models.AuthorshipReview.update(
+          { status: "assigned", resolution_cwid: chosen, reviewer, resolved_at: new Date() },
+          { where: { id } },
+        );
+        // audit log is best-effort (see accept)
+        try { await appendFeedbackLog(curator.userID, chosen, pmid, "ACCEPTED"); }
+        catch (e) { console.log("[authorships] feedbacklog (assign) non-fatal:", e); }
+        break;
+      }
       case "reopen": {
-        // reverse any prior gold-standard write before re-opening
-        if (row.status === "accepted" && cwid) {
-          const gs = await writeGoldStandard(cwid, pmid, "known", "DELETE", curator.userID);
+        // reverse any prior gold-standard write before re-opening.
+        // accept/assign both wrote a "known" GS entry; the assigned chosen cwid lives
+        // in resolution_cwid (top_cwid is the matcher's default, not the curator's pick).
+        const reverseCwid = row.resolution_cwid || cwid;
+        if (row.status === "accepted" && reverseCwid) {
+          const gs = await writeGoldStandard(reverseCwid, pmid, "known", "DELETE", curator.userID);
           if (gs !== 200) return res.status(502).send(`Gold-standard undo failed (${gs})`);
-        } else if (row.status === "rejected" && cwid) {
-          const gs = await writeGoldStandard(cwid, pmid, "rejected", "DELETE", curator.userID);
+        } else if (row.status === "assigned" && reverseCwid) {
+          const gs = await writeGoldStandard(reverseCwid, pmid, "known", "DELETE", curator.userID);
+          if (gs !== 200) return res.status(502).send(`Gold-standard undo failed (${gs})`);
+        } else if (row.status === "rejected" && reverseCwid) {
+          const gs = await writeGoldStandard(reverseCwid, pmid, "rejected", "DELETE", curator.userID);
           if (gs !== 200) return res.status(502).send(`Gold-standard undo failed (${gs})`);
         }
         await models.AuthorshipReview.update(

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
-import type { CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import Tooltip from "@mui/material/Tooltip";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
@@ -33,10 +33,22 @@ interface AuthorshipRow {
   n_candidates?: number;
   single_candidate?: boolean;
   candidate_cwids_json?: string;
+  pmid_sibling_count?: number;
   status?: string;
   snooze_until?: string;
   reviewer?: string;
   resolved_at?: string;
+}
+
+interface Candidate {
+  cwid: string;
+  name?: string;
+  person_type?: string;
+  dept?: string;
+  io_score?: number;
+  final_score?: number;
+  confidence?: number;
+  affil_dept_match?: boolean;
 }
 
 interface Summary { total: number; single_candidate: number; classes: Record<string, number>; personTypes?: Array<{ type: string; n: number }>; }
@@ -48,6 +60,9 @@ const apiHeaders = {
   Authorization: reciterConfig.backendApiKey,
 };
 
+// case-insensitive WCM institution token matcher (F6) — longest variants first
+const WCM_RE = /Weill Cornell(?:\s+(?:Medicine|Medical College|Medical Cent(?:er|re)))?/i;
+
 const CLASS_META: Record<string, { label: string; color: string; hint: string }> = {
   buried: { label: "Buried", color: "#b42318", hint: "Production buried it (final < 30)" },
   absent: { label: "Never retrieved", color: "#8a5a00", hint: "Production never scored this person" },
@@ -55,31 +70,30 @@ const CLASS_META: Record<string, { label: string; color: string; hint: string }>
   assigned: { label: "Assigned", color: "#067647", hint: "Accepted by a WCM person" },
 };
 
-// Column headers; `hint` (when present) renders a hover tooltip explaining the jargon.
-const HEADERS: Array<{ label: string; hint?: string }> = [
-  { label: "" },
-  { label: "WCM author" },
-  { label: "Proposed identity" },
-  { label: "FG", hint: "Production (final-gate) score: the authorship-likelihood score ReCiter assigns in production (0–100). Below 30 means production buried this person." },
-  { label: "IO", hint: "Identity-only score: likelihood from identity evidence alone (name, affiliation, etc.), ignoring curator feedback (0–100)." },
-  { label: "Class", hint: "How production currently treats this authorship — Buried (final < 30), Never retrieved (never scored), Suggested (already pending), or Assigned (accepted)." },
-  { label: "Cand.", hint: "Number of WCM identities matching this author name. “1 ✓” = a single, near-certain candidate." },
-  { label: "Conf.", hint: "Confidence that the proposed WCM identity is the correct author of this article (0–1)." },
-  { label: "Date", hint: "Article publication date (Entrez date)." },
-  { label: "Article" },
-  { label: "" },
-];
-const COL_COUNT = HEADERS.length;
-
 const ACTION_LABEL: Record<string, string> = {
-  accept: "Accepted", reject: "Rejected", snooze: "Snoozed for 90 days", dismiss: "Dismissed",
+  accept: "Accepted", reject: "Rejected", snooze: "Snoozed for 90 days", dismiss: "Dismissed", assign: "Assigned",
 };
-// small inline button style for the per-row actions
-const abtn = (bg: string, color: string, busy: boolean): CSSProperties => ({
-  padding: "4px 10px", borderRadius: 6, border: `1px solid ${bg === "#fff" ? "#d0d5dd" : bg}`,
-  background: bg, color, cursor: busy ? "default" : "pointer", fontSize: 12, fontWeight: 600,
-  whiteSpace: "nowrap", opacity: busy ? 0.5 : 1,
+
+// ---- inline Lucide SVG icons (no npm deps) -------------------------------
+type IconProps = { size?: number; style?: CSSProperties };
+const svgBase = (size: number, style?: CSSProperties): CSSProperties => ({
+  width: size, height: size, flex: "none", stroke: "currentColor", fill: "none",
+  strokeWidth: 2, strokeLinecap: "round", strokeLinejoin: "round", verticalAlign: -2, ...style,
 });
+const Icon = ({ size = 15, style, children }: IconProps & { children: ReactNode }) => (
+  <svg viewBox="0 0 24 24" aria-hidden style={svgBase(size, style)}>{children}</svg>
+);
+const IconCheck = (p: IconProps) => <Icon {...p}><path d="M20 6 9 17l-5-5" /></Icon>;
+const IconChecks = (p: IconProps) => <Icon {...p}><path d="M18 6 7 17l-5-5" /><path d="m22 10-7.5 7.5L13 16" /></Icon>;
+const IconX = (p: IconProps) => <Icon {...p}><path d="M18 6 6 18M6 6l12 12" /></Icon>;
+const IconChevR = (p: IconProps) => <Icon {...p}><path d="m9 18 6-6-6-6" /></Icon>;
+const IconChevD = (p: IconProps) => <Icon {...p}><path d="m6 9 6 6 6-6" /></Icon>;
+const IconExt = (p: IconProps) => <Icon {...p}><path d="M15 3h6v6" /><path d="M10 14 21 3" /><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /></Icon>;
+const IconPin = (p: IconProps) => <Icon {...p}><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" /><circle cx="12" cy="10" r="3" /></Icon>;
+const IconInfo = (p: IconProps) => <Icon {...p}><circle cx="12" cy="12" r="10" /><path d="M12 16v-4M12 8h.01" /></Icon>;
+const IconAlert = (p: IconProps) => <Icon {...p}><path d="m21.7 18-8-14a2 2 0 0 0-3.4 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.7-3Z" /><path d="M12 9v4M12 17h.01" /></Icon>;
+const IconMore = (p: IconProps) => <Icon {...p}><circle cx="12" cy="12" r="1" /><circle cx="19" cy="12" r="1" /><circle cx="5" cy="12" r="1" /></Icon>;
+const IconUsers = (p: IconProps) => <Icon {...p}><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" /></Icon>;
 
 // ---- small presentational bits -------------------------------------------
 // MUI Tooltip with a larger, more readable font (the default tooltip text is tiny).
@@ -90,23 +104,86 @@ const Tip = ({ children, ...rest }: any) => (
   </Tooltip>
 );
 
-const Badge = ({ text, color, title }: { text: string; color: string; title?: string }) => {
-  const chip = (
-    <span style={{
-      background: color, color: "#fff", borderRadius: 10, padding: "1px 8px",
-      fontSize: 11, fontWeight: 600, whiteSpace: "nowrap", cursor: title ? "help" : "default",
-    }}>{text}</span>
+// ---- pure helpers --------------------------------------------------------
+const hasWcm = (aff?: string) => !!aff && WCM_RE.test(aff);
+
+// Wrap the WCM institution token in <mark>. Returns React nodes (one match).
+const highlightAffiliation = (text?: string): ReactNode => {
+  if (!text) return null;
+  const m = text.match(WCM_RE);
+  if (!m || m.index === undefined) return text;
+  const before = text.slice(0, m.index);
+  const matched = text.slice(m.index, m.index + m[0].length);
+  const after = text.slice(m.index + m[0].length);
+  return (
+    <>
+      {before}
+      <mark style={{ background: "#f0fdf4", color: "#15803d", padding: "0 3px", borderRadius: 3, fontWeight: 600 }}>{matched}</mark>
+      {after}
+    </>
   );
-  return title ? <Tip title={title} placement="top" arrow>{chip}</Tip> : chip;
 };
 
-const Score = ({ value, kind }: { value?: number; kind: "fg" | "io" }) => {
-  if (value === null || value === undefined) return <span style={{ color: "#98a2b3" }}>—</span>;
-  // IO high = strong identity (green). FG low = buried (red), high = already suggested (grey).
-  let color = "#475467";
-  if (kind === "io") color = value >= 90 ? "#067647" : value >= 50 ? "#475467" : "#98a2b3";
-  if (kind === "fg") color = value < 30 ? "#b42318" : "#475467";
-  return <span style={{ color, fontWeight: 600 }}>{value.toFixed(1)}</span>;
+// IO color band (F2): >=90 green, 50-89 amber, <50 muted grey
+const ioColor = (v?: number) => (v == null ? "#94a3b8" : v >= 90 ? "#15803d" : v >= 50 ? "#b45309" : "#94a3b8");
+const fmtScore = (v?: number) => (v == null ? "—" : Number.isInteger(v) ? String(v) : v.toFixed(1));
+// confidence band (F10): >=0.8 High, 0.5-0.79 Medium, <0.5 Low
+const confBand = (c?: number) => (c == null ? "—" : c >= 0.8 ? "High" : c >= 0.5 ? "Medium" : "Low");
+
+const parseCandidates = (json?: string): Candidate[] => {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+// inline IO/FG explanation (F8)
+const ioFgNote = (r: AuthorshipRow): string => {
+  if (r.top_io_score == null) {
+    const wcm = hasWcm(r.author_affiliation);
+    return wcm
+      ? `Never retrieved — no IO/FG. The affiliation names Weill Cornell${r.top_dept ? ` and the department (${r.top_dept})` : " and the surname is unique"}; production never scored this person.`
+      : `Never retrieved — no IO/FG. The surname is unique among WCM identities (${r.top_cohort_size ?? 1} homonym); production never scored this person.`;
+  }
+  const io = fmtScore(r.top_io_score);
+  const fg = fmtScore(r.top_fg_score);
+  if (hasWcm(r.author_affiliation)) {
+    return `IO ${io} — unique match; FG fell to ${fg} even though the affiliation names Weill Cornell — production under-scored a clear WCM authorship.`;
+  }
+  return `IO ${io} — name uniquely matches ${r.top_cwid || "this identity"} (${r.top_cohort_size ?? 1} WCM homonym); FG fell to ${fg} because the affiliation names an external institution, not WCM. Identity carries it.`;
+};
+
+const btn = (variant: "accept" | "soft" | "ghost", disabled?: boolean): CSSProperties => {
+  const base: CSSProperties = {
+    display: "inline-flex", alignItems: "center", gap: 6, borderRadius: 7, padding: "6px 12px",
+    font: "inherit", fontSize: 13, fontWeight: 600, cursor: disabled ? "default" : "pointer",
+    border: "1px solid transparent", whiteSpace: "nowrap", opacity: disabled ? 0.5 : 1,
+  };
+  if (variant === "accept") return { ...base, background: "#16a34a", color: "#fff" };
+  if (variant === "soft") return { ...base, background: "#f0fdf4", color: "#15803d", borderColor: "#bbf7d0" };
+  return { ...base, background: "#fff", color: "#475569", borderColor: "#dde3ea" };
+};
+const iconBtn = (disabled?: boolean): CSSProperties => ({
+  background: "transparent", border: "none", color: "#94a3b8", padding: 6, borderRadius: 6,
+  cursor: disabled ? "default" : "pointer", display: "inline-flex", opacity: disabled ? 0.5 : 1,
+});
+
+// signal chips (F7)
+const Chip = ({ kind, children }: { kind: "ok" | "warn" | "neutral"; children: ReactNode }) => {
+  const styles: Record<string, CSSProperties> = {
+    ok: { background: "#f0fdf4", color: "#15803d", borderColor: "transparent" },
+    warn: { background: "#fffbeb", color: "#b45309", borderColor: "transparent" },
+    neutral: { background: "#fff", color: "#475569", borderColor: "#dde3ea" },
+  };
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 4, fontSize: 11.5, padding: "2px 9px",
+      borderRadius: 6, border: "1px solid #dde3ea", ...styles[kind],
+    }}>{children}</span>
+  );
 };
 
 // ---- main component ------------------------------------------------------
@@ -120,7 +197,7 @@ const AuthorshipsTabs = () => {
   const [classification, setClassification] = useState<"all" | "buried" | "absent" | "suggested">("all");
   const [search, setSearch] = useState("");
   const [searchInput, setSearchInput] = useState("");
-  const [sort, setSort] = useState("precision");
+  const [sort, setSort] = useState("io"); // F3: default sort = IO
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
@@ -129,8 +206,16 @@ const AuthorshipsTabs = () => {
   const [statusView, setStatusView] = useState<"open" | "snoozed" | "dismissed">("open");
   const [actingId, setActingId] = useState<number | null>(null);
   const [menu, setMenu] = useState<{ anchor: HTMLElement; row: AuthorshipRow } | null>(null);
-  const [undo, setUndo] = useState<{ row: AuthorshipRow; label: string } | null>(null);
+  // F4: undo holds a BATCH of rows (single-row actions push a 1-element batch)
+  const [undo, setUndo] = useState<{ rows: AuthorshipRow[]; label: string } | null>(null);
   const [errorMsg, setErrorMsg] = useState<string>("");
+  // selection (bulk) — single-candidate rows only
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  // multi-candidate: chosen cwid per row id
+  const [picked, setPicked] = useState<Record<number, string>>({});
+  // F13: keyboard focus
+  const [focusedId, setFocusedId] = useState<number | null>(null);
+  const cardRefs = useRef<Record<number, HTMLElement | null>>({});
 
   const filterBody = useCallback(() => ({
     feed: "unassigned",
@@ -164,7 +249,7 @@ const AuthorshipsTabs = () => {
       .then((r) => r.json()).then(setSummary).catch(() => setSummary(null));
   }, [search, dateFrom, dateTo, statusView]);
 
-  // live-filter: debounce the search box so the table narrows as you type (no Enter needed)
+  // live-filter: debounce the search box so the queue narrows as you type (no Enter needed)
   useEffect(() => {
     const t = setTimeout(() => setSearch(searchInput.trim()), 300);
     return () => clearTimeout(t);
@@ -174,20 +259,31 @@ const AuthorshipsTabs = () => {
   useEffect(() => { fetchSummary(); }, [fetchSummary]);
   // reset to first page when filters, sort, or status view change
   useEffect(() => { setPage(0); }, [lane, classification, search, selectedTypes, dateFrom, dateTo, sort, statusView]);
+  // clear transient per-page UI state when the page contents change
+  useEffect(() => { setSelected(new Set()); setExpanded(null); setPicked({}); }, [rows]);
 
-  // perform a curator action: optimistically drop the row, POST, then offer Undo (or revert on failure)
-  const doAction = useCallback((row: AuthorshipRow, action: string) => {
-    setMenu(null);
-    setActingId(row.id);
+  // perform a curator action: optimistically drop the row, POST, then offer Undo (or revert on failure).
+  // `extra` carries the assign cwid; the returned promise lets bulk loops await settlement.
+  const doActionAsync = useCallback((row: AuthorshipRow, action: string, extra?: Record<string, any>): Promise<boolean> => {
     setRows((rs) => rs.filter((x) => x.id !== row.id));
     setCount((c) => Math.max(0, c - 1));
-    fetch("/api/db/authorships/action", {
+    return fetch("/api/db/authorships/action", {
       credentials: "same-origin", method: "POST", headers: apiHeaders,
-      body: JSON.stringify({ id: row.id, action }),
+      body: JSON.stringify({ id: row.id, action, ...extra }),
     })
       .then(async (r) => {
         if (!r.ok) throw new Error((await r.text()) || `HTTP ${r.status}`);
-        if (action !== "reopen") setUndo({ row, label: ACTION_LABEL[action] || "Done" });
+        return true;
+      });
+  }, []);
+
+  // single-row action with its own optimistic remove + Undo (PR-1 behaviour, extended for assign)
+  const doAction = useCallback((row: AuthorshipRow, action: string, extra?: Record<string, any>) => {
+    setMenu(null);
+    setActingId(row.id);
+    doActionAsync(row, action, extra)
+      .then(() => {
+        if (action !== "reopen") setUndo({ rows: [row], label: ACTION_LABEL[action] || "Done" });
         fetchSummary();
       })
       .catch((e) => {
@@ -195,271 +291,275 @@ const AuthorshipsTabs = () => {
         fetchData(); // restore the optimistically-removed row
       })
       .finally(() => setActingId(null));
-  }, [fetchData, fetchSummary]);
+  }, [doActionAsync, fetchData, fetchSummary]);
 
-  // undo = reopen (reverses any gold-standard write + sets status back to open)
+  // F5: bulk orchestration — accept a batch of rows, collect into one Undo batch
+  const doBulkAccept = useCallback((batch: AuthorshipRow[]) => {
+    if (batch.length === 0) return;
+    setMenu(null);
+    Promise.allSettled(batch.map((row) => doActionAsync(row, "accept")))
+      .then((results) => {
+        const failed = results.some((r) => r.status === "rejected");
+        const ok = batch.filter((_, i) => results[i].status === "fulfilled");
+        if (ok.length > 0) setUndo({ rows: ok, label: `Accepted ${ok.length}` });
+        if (failed) {
+          setErrorMsg("Some accepts failed — refreshing");
+          fetchData();
+        }
+        fetchSummary();
+      });
+    setSelected(new Set());
+  }, [doActionAsync, fetchData, fetchSummary]);
+
+  // undo = reopen over the whole batch (F4: extends PR-1's single-row undo)
   const doUndo = useCallback(() => {
     if (!undo) return;
-    const row = undo.row;
+    const batch = undo.rows;
     setUndo(null);
-    fetch("/api/db/authorships/action", {
-      credentials: "same-origin", method: "POST", headers: apiHeaders,
-      body: JSON.stringify({ id: row.id, action: "reopen" }),
-    })
-      .then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); })
-      .catch((e) => setErrorMsg(`Undo failed — ${String(e?.message || e)}`))
-      .finally(() => { fetchData(); fetchSummary(); });
+    Promise.allSettled(batch.map((row) =>
+      fetch("/api/db/authorships/action", {
+        credentials: "same-origin", method: "POST", headers: apiHeaders,
+        body: JSON.stringify({ id: row.id, action: "reopen" }),
+      }).then((r) => { if (!r.ok) throw new Error(`HTTP ${r.status}`); })
+    )).then((results) => {
+      if (results.some((r) => r.status === "rejected")) setErrorMsg("Undo failed for one or more rows");
+    }).finally(() => { fetchData(); fetchSummary(); });
   }, [undo, fetchData, fetchSummary]);
+
+  // F12: clicking "+N more" narrows the view to the pmid. The sibling count is scoped
+  // only to the status view (it deliberately ignores lane/classification/type/date), so to
+  // actually surface all N siblings we must relax those list filters too — otherwise the
+  // default single-candidate lane would hide multi-candidate siblings and "+2 more" could
+  // narrow to fewer than 2 cards. Lane→all + classification→all matches the count; the
+  // person-type/date filters are left intact (they aren't part of the sibling-count scope
+  // either, but relaxing lane+classification is what makes the primary mismatch go away).
+  const narrowToPmid = useCallback((pmid: number) => {
+    setLane("all");
+    setClassification("all");
+    setSearchInput(String(pmid));
+    setSearch(String(pmid));
+  }, []);
+
+  const toggleSelect = useCallback((row: AuthorshipRow) => {
+    if (!row.single_candidate || statusView !== "open") return; // multi rows aren't bulk-selectable
+    setSelected((s) => {
+      const next = new Set(s);
+      next.has(row.id) ? next.delete(row.id) : next.add(row.id);
+      return next;
+    });
+  }, [statusView]);
+
+  // F13: keyboard nav — J/K move, Y accept (single), N reject, S snooze, X select, Enter open PubMed
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement)?.tagName?.toLowerCase();
+      if (tag === "input" || tag === "select" || tag === "textarea") return;
+      const visible = rows;
+      if (visible.length === 0) return;
+      const idx = focusedId == null ? -1 : visible.findIndex((r) => r.id === focusedId);
+      const focus = (i: number) => {
+        const r = visible[Math.max(0, Math.min(visible.length - 1, i))];
+        if (r) { setFocusedId(r.id); cardRefs.current[r.id]?.scrollIntoView({ block: "nearest" }); }
+      };
+      const k = e.key.toLowerCase();
+      if (k === "j") { focus(idx + 1); e.preventDefault(); return; }
+      if (k === "k") { focus(idx < 0 ? 0 : idx - 1); e.preventDefault(); return; }
+      if (focusedId == null) return;
+      const row = visible.find((r) => r.id === focusedId);
+      if (!row) return;
+      if (k === "y") { if (row.single_candidate && statusView === "open") doAction(row, "accept"); else setErrorMsg("Use Pick one ▾ to assign a multi-candidate authorship"); e.preventDefault(); }
+      else if (k === "n") { if (statusView === "open") { if (row.single_candidate) doAction(row, "reject"); else setErrorMsg("Use Pick one ▾ / None of these for a multi-candidate authorship"); } e.preventDefault(); }
+      else if (k === "s") { if (statusView === "open") doAction(row, "snooze"); e.preventDefault(); }
+      else if (k === "x") { toggleSelect(row); e.preventDefault(); }
+      else if (e.key === "Enter") { window.open(`https://pubmed.ncbi.nlm.nih.gov/${row.pmid}/`, "_blank", "noreferrer"); e.preventDefault(); }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [rows, focusedId, statusView, doAction, toggleSelect]);
 
   const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
   const classChips: Array<typeof classification> = ["all", "buried", "absent", "suggested"];
 
+  // F4: near-certain bulk = visible single-candidate rows with IO >= 95
+  const nearCertain = rows.filter((r) => r.single_candidate && (r.top_io_score ?? 0) >= 95);
+  const selectedRows = rows.filter((r) => selected.has(r.id));
+
   return (
-    <div style={{ padding: "24px 28px", fontFamily: "inherit" }}>
-      <h2 style={{ margin: 0, fontSize: 22 }}>Authorships</h2>
-      <p style={{ color: "#475467", marginTop: 4, maxWidth: 760 }}>
-        WCM-affiliated authorships not yet assigned to any identity. The high-precision lane
-        shows authorships where exactly one WCM identity matches the name — near-certain matches.
-        <strong> FG</strong> is the production score; <strong> IO</strong> is the identity-only score.
+    <div style={{ padding: "24px 28px", fontFamily: "Inter, system-ui, -apple-system, 'Segoe UI', sans-serif", color: "#0f172a", maxWidth: 1040, margin: "0 auto" }}>
+      <h2 style={{ margin: "0 0 4px", fontSize: 24, fontWeight: 700, letterSpacing: "-0.01em" }}>Authorships</h2>
+      <p style={{ color: "#475569", marginTop: 0, marginBottom: 20, maxWidth: 760, fontSize: 14, lineHeight: 1.45 }}>
+        WCM-affiliated authorships not yet assigned to an identity. Each card is one decision: is this author the
+        proposed WCM person? <strong style={{ color: "#0f172a", fontWeight: 600 }}>IO</strong> (identity-only, the trusted
+        signal) leads; <strong style={{ color: "#0f172a", fontWeight: 600 }}>FG</strong> (production) is shown small as
+        the diagnosis. Expand a card for the affiliation and evidence.
       </p>
 
       {/* summary */}
       {summary && (
-        <div style={{ display: "flex", gap: 18, margin: "12px 0 18px", color: "#475467", fontSize: 13 }}>
-          <span><strong style={{ color: "#101828" }}>{summary.total.toLocaleString()}</strong> unassigned</span>
-          <span><strong style={{ color: "#101828" }}>{summary.single_candidate.toLocaleString()}</strong> single-candidate</span>
+        <div style={{ display: "flex", gap: 18, margin: "12px 0 18px", color: "#475569", fontSize: 13, flexWrap: "wrap" }}>
+          <span><strong style={{ color: "#0f172a" }}>{summary.total.toLocaleString()}</strong> unassigned</span>
+          <span><strong style={{ color: "#0f172a" }}>{summary.single_candidate.toLocaleString()}</strong> single-candidate</span>
           {Object.entries(summary.classes).map(([k, v]) => (
-            <span key={k}>{CLASS_META[k]?.label || k}: <strong style={{ color: "#101828" }}>{v.toLocaleString()}</strong></span>
+            <span key={k}>{CLASS_META[k]?.label || k}: <strong style={{ color: "#0f172a" }}>{v.toLocaleString()}</strong></span>
           ))}
         </div>
       )}
 
-      {/* status view: Open / Snoozed / Dismissed */}
-      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
-        {([["open", "Open"], ["snoozed", "Snoozed"], ["dismissed", "Dismissed"]] as const).map(([key, label]) => (
-          <button key={key} onClick={() => setStatusView(key)} style={{
-            padding: "6px 14px", borderRadius: 8, border: "1px solid #d0d5dd", cursor: "pointer",
-            background: statusView === key ? "#0c111d" : "#fff", color: statusView === key ? "#fff" : "#344054",
-            fontWeight: 600, fontSize: 13,
-          }}>{label}</button>
-        ))}
+      {/* row 1: status view + sort + keyboard help */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10, flexWrap: "wrap" }}>
+        <div style={{ display: "inline-flex", background: "#eef2f7", borderRadius: 7, padding: 2 }}>
+          {([["open", "Open"], ["snoozed", "Snoozed"], ["dismissed", "Dismissed"]] as const).map(([key, label]) => (
+            <button key={key} onClick={() => setStatusView(key)} style={{
+              border: "none", padding: "5px 12px", font: "inherit", fontSize: 13, fontWeight: 600, borderRadius: 5,
+              cursor: "pointer", background: statusView === key ? "#fff" : "transparent",
+              color: statusView === key ? "#0f172a" : "#475569",
+              boxShadow: statusView === key ? "0 1px 2px rgba(15,23,42,.08)" : "none",
+            }}>{label}</button>
+          ))}
+        </div>
+        <span style={{ marginLeft: "auto", display: "inline-flex", alignItems: "center", gap: 5, color: "#94a3b8", fontSize: 12 }}>
+          <IconInfo size={13} /> <kbd style={kbdStyle}>J</kbd><kbd style={kbdStyle}>K</kbd> move · <kbd style={kbdStyle}>Y</kbd> accept · <kbd style={kbdStyle}>N</kbd> reject · <kbd style={kbdStyle}>S</kbd> snooze
+        </span>
+        <label style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 13, color: "#475569" }}>
+          Sort
+          <select value={sort} onChange={(e) => setSort(e.target.value)}
+            style={{ height: 32, border: "1px solid #dde3ea", borderRadius: 7, background: "#fff", font: "inherit", fontSize: 13, color: "#0f172a", padding: "0 10px", cursor: "pointer" }}>
+            <option value="io">Identity-only (IO) — strongest first</option>
+            <option value="date">Newest</option>
+            <option value="confidence">Confidence</option>
+            <option value="precision">Best match</option>
+            <option value="fg">Production score</option>
+          </select>
+        </label>
       </div>
 
-      {/* lane toggle */}
-      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
-        {([["single", "High-precision (single candidate)"], ["all", "All unassigned"]] as const).map(([key, label]) => (
-          <button key={key} onClick={() => setLane(key)} style={{
-            padding: "6px 14px", borderRadius: 8, border: "1px solid #d0d5dd", cursor: "pointer",
-            background: lane === key ? "#1570ef" : "#fff", color: lane === key ? "#fff" : "#344054",
-            fontWeight: 600, fontSize: 13,
-          }}>{label}</button>
-        ))}
-      </div>
-
-      {/* classification chips + sort + date filter + search */}
-      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14, flexWrap: "wrap" }}>
-        {classChips.map((c) => (
-          <Tip key={c} title={c === "all" ? "Show every classification" : CLASS_META[c].hint} placement="top" arrow>
-            <button onClick={() => setClassification(c)}
-              style={{
-                padding: "4px 12px", borderRadius: 16, border: "1px solid #d0d5dd", cursor: "pointer",
-                background: classification === c ? "#eff8ff" : "#fff",
-                color: classification === c ? "#175cd3" : "#475467", fontSize: 12, fontWeight: 600,
+      {/* row 2: lane + classification chips + type + dates + search */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10, flexWrap: "wrap" }}>
+        <div style={{ display: "inline-flex", background: "#eef2f7", borderRadius: 7, padding: 2 }}>
+          {([["single", "High-precision"], ["all", "All unassigned"]] as const).map(([key, label]) => (
+            <Tip key={key} title={key === "single" ? "Only authorships where exactly one WCM identity matches the name" : "Every unassigned authorship"} placement="top" arrow>
+              <button onClick={() => setLane(key)} style={{
+                border: "none", padding: "5px 11px", font: "inherit", fontSize: 13, fontWeight: 500, borderRadius: 5,
+                cursor: "pointer", background: lane === key ? "#fff" : "transparent",
+                color: lane === key ? "#2563eb" : "#475569",
+                boxShadow: lane === key ? "0 1px 2px rgba(15,23,42,.08)" : "none",
+              }}>{label}</button>
+            </Tip>
+          ))}
+        </div>
+        <div style={{ display: "inline-flex", background: "#eef2f7", borderRadius: 7, padding: 2 }}>
+          {classChips.map((c) => (
+            <Tip key={c} title={c === "all" ? "Show every classification" : CLASS_META[c].hint} placement="top" arrow>
+              <button onClick={() => setClassification(c)} style={{
+                border: "none", padding: "5px 11px", font: "inherit", fontSize: 13, fontWeight: 500, borderRadius: 5,
+                cursor: "pointer", background: classification === c ? "#fff" : "transparent",
+                color: classification === c ? "#2563eb" : "#475569",
+                boxShadow: classification === c ? "0 1px 2px rgba(15,23,42,.08)" : "none",
               }}>{c === "all" ? "All classes" : CLASS_META[c].label}</button>
-          </Tip>
-        ))}
-        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-          <label style={{ fontSize: 12, color: "#475467", display: "flex", alignItems: "center", gap: 6 }}>
-            Type
-            <button type="button" onClick={(e) => setTypeAnchor(e.currentTarget)}
-              style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #d0d5dd", background: "#fff", cursor: "pointer", fontSize: 13, color: "#344054", maxWidth: 240, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-              {selectedTypes.length === 0 ? "All types" : selectedTypes.length === 1 ? selectedTypes[0] : `${selectedTypes.length} types`} ▾
-            </button>
-          </label>
-          <label style={{ fontSize: 12, color: "#475467", display: "flex", alignItems: "center", gap: 6 }}>
-            Sort
-            <select value={sort} onChange={(e) => setSort(e.target.value)}
-              style={{ padding: "6px 8px", borderRadius: 8, border: "1px solid #d0d5dd", fontSize: 13, color: "#344054" }}>
-              <option value="precision">Best match</option>
-              <option value="confidence">Confidence</option>
-              <option value="date">Newest</option>
-              <option value="io">Identity-only score</option>
-              <option value="fg">Production score</option>
-            </select>
-          </label>
-          <label style={{ fontSize: 12, color: "#475467", display: "flex", alignItems: "center", gap: 6 }}
-            title="Filter by article publication date (from)">
+            </Tip>
+          ))}
+        </div>
+        <button type="button" onClick={(e) => setTypeAnchor(e.currentTarget)}
+          style={{ height: 32, display: "inline-flex", alignItems: "center", gap: 6, border: "1px solid #dde3ea", borderRadius: 7, background: "#fff", cursor: "pointer", fontSize: 13, color: "#0f172a", padding: "0 10px", maxWidth: 220, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {selectedTypes.length === 0 ? "All types" : selectedTypes.length === 1 ? selectedTypes[0] : `Type: ${selectedTypes.length}`} <IconChevD size={13} />
+        </button>
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <label style={{ fontSize: 12, color: "#475569", display: "flex", alignItems: "center", gap: 6 }} title="Filter by article publication date (from)">
             From
             <input type="date" value={dateFrom} onChange={(e) => setDateFrom(e.target.value)}
-              style={{ padding: "5px 8px", borderRadius: 8, border: "1px solid #d0d5dd", fontSize: 13, color: "#344054" }} />
+              style={{ padding: "5px 8px", borderRadius: 7, border: "1px solid #dde3ea", fontSize: 13, color: "#0f172a" }} />
           </label>
-          <label style={{ fontSize: 12, color: "#475467", display: "flex", alignItems: "center", gap: 6 }}
-            title="Filter by article publication date (to)">
+          <label style={{ fontSize: 12, color: "#475569", display: "flex", alignItems: "center", gap: 6 }} title="Filter by article publication date (to)">
             To
             <input type="date" value={dateTo} onChange={(e) => setDateTo(e.target.value)}
-              style={{ padding: "5px 8px", borderRadius: 8, border: "1px solid #d0d5dd", fontSize: 13, color: "#344054" }} />
+              style={{ padding: "5px 8px", borderRadius: 7, border: "1px solid #dde3ea", fontSize: 13, color: "#0f172a" }} />
           </label>
           {(dateFrom || dateTo) && (
             <button type="button" onClick={() => { setDateFrom(""); setDateTo(""); }}
-              style={{ padding: "5px 10px", borderRadius: 8, border: "1px solid #d0d5dd", background: "#fff", cursor: "pointer", color: "#475467", fontSize: 12 }}>
+              style={{ padding: "5px 10px", borderRadius: 7, border: "1px solid #dde3ea", background: "#fff", cursor: "pointer", color: "#475569", fontSize: 12 }}>
               Clear dates
             </button>
           )}
           <form onSubmit={(e) => { e.preventDefault(); setSearch(searchInput.trim()); }}>
             <input value={searchInput} onChange={(e) => setSearchInput(e.target.value)}
               placeholder="Filter by name, CWID, or PMID"
-              style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #d0d5dd", width: 240, fontSize: 13 }} />
+              style={{ padding: "6px 10px", borderRadius: 7, border: "1px solid #dde3ea", width: 220, fontSize: 13 }} />
           </form>
         </div>
       </div>
 
-      {/* table */}
-      <div style={{ border: "1px solid #eaecf0", borderRadius: 10, overflow: "hidden" }}>
-        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
-          <thead>
-            <tr style={{ background: "#f9fafb", textAlign: "left", color: "#475467" }}>
-              {HEADERS.map((h, i) => (
-                <th key={i} style={{ padding: "10px 12px", fontWeight: 600, borderBottom: "1px solid #eaecf0", whiteSpace: "nowrap" }}>
-                  {h.hint
-                    ? <Tip title={h.hint} placement="top" arrow>
-                        <span style={{ borderBottom: "1px dotted #98a2b3", cursor: "help" }}>{h.label}</span>
-                      </Tip>
-                    : h.label}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {loading && (
-              <tr><td colSpan={COL_COUNT} style={{ padding: 24, textAlign: "center", color: "#98a2b3" }}>Loading…</td></tr>
-            )}
-            {!loading && rows.length === 0 && (
-              <tr><td colSpan={COL_COUNT} style={{ padding: 24, textAlign: "center", color: "#98a2b3" }}>No authorships match these filters.</td></tr>
-            )}
-            {!loading && rows.map((r) => {
-              const meta = CLASS_META[r.classification || "absent"];
-              const isOpen = expanded === r.id;
-              let alternates: any[] = [];
-              if (isOpen && r.candidate_cwids_json) {
-                try { alternates = JSON.parse(r.candidate_cwids_json); } catch { alternates = []; }
-              }
-              return (
-                <>
-                  <tr key={r.id} style={{ borderBottom: "1px solid #f2f4f7" }}>
-                    <td style={{ padding: "10px 12px", whiteSpace: "nowrap" }}>
-                      {statusView !== "open" ? (
-                        <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                          {statusView === "snoozed" && r.snooze_until && (
-                            <span style={{ color: "#98a2b3", fontSize: 11 }}>wakes {r.snooze_until}</span>
-                          )}
-                          <button disabled={actingId === r.id} onClick={() => doAction(r, "reopen")}
-                            style={abtn("#fff", "#175cd3", actingId === r.id)}>Reopen</button>
-                        </span>
-                      ) : r.single_candidate ? (
-                        <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                          <button disabled={actingId === r.id} onClick={() => doAction(r, "accept")}
-                            style={abtn("#067647", "#fff", actingId === r.id)}>✓ Accept</button>
-                          <button disabled={actingId === r.id} onClick={() => doAction(r, "reject")}
-                            style={abtn("#fff", "#b42318", actingId === r.id)}>✕ Reject</button>
-                          <button disabled={actingId === r.id} onClick={(e) => setMenu({ anchor: e.currentTarget, row: r })}
-                            style={abtn("#fff", "#475467", actingId === r.id)}>⋯</button>
-                        </span>
-                      ) : (
-                        <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                          <Tip title="Multiple candidates — Assign arrives in the next release" placement="top" arrow>
-                            <span style={{ color: "#98a2b3", fontSize: 11, cursor: "help" }}>needs review</span>
-                          </Tip>
-                          <button disabled={actingId === r.id} onClick={(e) => setMenu({ anchor: e.currentTarget, row: r })}
-                            style={abtn("#fff", "#475467", actingId === r.id)}>⋯</button>
-                        </span>
-                      )}
-                    </td>
-                    <td style={{ padding: "10px 12px" }}>
-                      {r.author_affiliation ? (
-                        <Tip title={r.author_affiliation} placement="top-start" arrow>
-                          <div style={{ fontWeight: 600, color: "#101828", cursor: "help", borderBottom: "1px dotted #cbd2da", display: "inline-block" }}>{r.wcm_author}</div>
-                        </Tip>
-                      ) : (
-                        <div style={{ fontWeight: 600, color: "#101828" }}>{r.wcm_author}</div>
-                      )}
-                      <div style={{ color: "#98a2b3", fontSize: 11 }}>{r.author_position_label} author</div>
-                    </td>
-                    <td style={{ padding: "10px 12px" }}>
-                      <div style={{ color: "#101828" }}>
-                        {r.top_cwid ? (
-                          <a href={`/curate/${r.top_cwid}`} target="_blank" rel="noreferrer"
-                            title={`Open ${r.top_name || r.top_cwid}'s curate profile`}
-                            style={{ color: "#101828", textDecoration: "none" }}>
-                            {r.top_name} <span style={{ color: "#1570ef", textDecoration: "underline" }}>({r.top_cwid}) ↗</span>
-                          </a>
-                        ) : (
-                          <>{r.top_name}</>
-                        )}
-                      </div>
-                      <div style={{ color: "#667085", fontSize: 11 }}>{r.top_person_type}{r.top_dept ? ` · ${r.top_dept}` : ""}</div>
-                    </td>
-                    <td style={{ padding: "10px 12px" }}><Score value={r.top_fg_score} kind="fg" /></td>
-                    <td style={{ padding: "10px 12px" }}><Score value={r.top_io_score} kind="io" /></td>
-                    <td style={{ padding: "10px 12px" }}><Badge text={meta.label} color={meta.color} title={meta.hint} /></td>
-                    <td style={{ padding: "10px 12px", whiteSpace: "nowrap" }}>
-                      {r.single_candidate
-                        ? <Badge text="1 ✓" color="#067647" title="Single candidate — near-certain" />
-                        : <button onClick={() => setExpanded(isOpen ? null : r.id)} style={{
-                            border: "1px solid #d0d5dd", background: "#fff", borderRadius: 6, padding: "2px 8px",
-                            cursor: "pointer", color: "#475467", fontSize: 12,
-                          }}>{r.n_candidates} ▾</button>}
-                    </td>
-                    <td style={{ padding: "10px 12px", color: "#475467" }}>{r.top_confidence?.toFixed(2)}</td>
-                    <td style={{ padding: "10px 12px", whiteSpace: "nowrap", color: "#475467" }}>{r.entrez_date || "—"}</td>
-                    <td style={{ padding: "10px 12px", maxWidth: 360 }}>
-                      <div style={{ color: "#101828", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", maxWidth: 360 }} title={r.title}>{r.title}</div>
-                      <div style={{ color: "#667085", fontSize: 11 }}>{r.journal}</div>
-                    </td>
-                    <td style={{ padding: "10px 12px" }}>
-                      <a href={`https://pubmed.ncbi.nlm.nih.gov/${r.pmid}/`} target="_blank" rel="noreferrer"
-                        style={{ color: "#1570ef", textDecoration: "none", fontSize: 12 }}>{r.pmid} ↗</a>
-                    </td>
-                  </tr>
-                  {isOpen && alternates.length > 0 && (
-                    <tr key={`${r.id}-exp`} style={{ background: "#fcfcfd" }}>
-                      <td colSpan={COL_COUNT} style={{ padding: "8px 12px 12px 24px" }}>
-                        <div style={{ color: "#475467", fontSize: 12, marginBottom: 4 }}>Candidate identities (pick one when assigning):</div>
-                        <table style={{ fontSize: 12, borderCollapse: "collapse" }}>
-                          <tbody>
-                            {alternates.map((c, i) => (
-                              <tr key={i}>
-                                <td style={{ padding: "2px 12px 2px 0", color: "#101828" }}>{c.name} <span style={{ color: "#1570ef" }}>({c.cwid})</span></td>
-                                <td style={{ padding: "2px 12px", color: "#667085" }}>{c.person_type}{c.dept ? ` · ${c.dept}` : ""}</td>
-                                <td style={{ padding: "2px 12px" }}>IO <Score value={c.io_score} kind="io" /></td>
-                                <td style={{ padding: "2px 12px" }}>FG <Score value={c.final_score} kind="fg" /></td>
-                                <td style={{ padding: "2px 12px", color: "#667085" }}>conf {Number(c.confidence).toFixed(2)}{c.affil_dept_match ? " · affil✓" : ""}</td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </td>
-                    </tr>
-                  )}
-                </>
-              );
-            })}
-          </tbody>
-        </table>
+      {/* F4: bulk bar (slim) */}
+      {statusView === "open" && (
+        <div style={{ display: "flex", alignItems: "center", gap: 12, margin: "6px 0 18px", fontSize: 13, color: "#475569", flexWrap: "wrap" }}>
+          <Tip title="Acts on single-candidate rows with IO ≥ 95 on this page only (bounded blast radius)" placement="top" arrow>
+            <button disabled={nearCertain.length === 0} style={btn("soft", nearCertain.length === 0)}
+              onClick={() => doBulkAccept(nearCertain)}>
+              <IconChecks /> Accept near-certain · IO ≥ 95 <strong style={{ fontVariantNumeric: "tabular-nums" }}>({nearCertain.length})</strong>
+            </button>
+          </Tip>
+          {selectedRows.length > 0 && (
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+              — <strong>{selectedRows.length}</strong> selected
+              <button style={{ ...btn("accept"), padding: "4px 10px" }} onClick={() => doBulkAccept(selectedRows)}>
+                <IconCheck /> Accept selected
+              </button>
+            </span>
+          )}
+          <span style={{ marginLeft: "auto", fontSize: 12, color: "#94a3b8" }}>Bulk acts on single-candidate rows on this page</span>
+        </div>
+      )}
+
+      {/* card queue */}
+      <div>
+        {loading && <div style={{ padding: 24, textAlign: "center", color: "#94a3b8" }}>Loading…</div>}
+        {!loading && rows.length === 0 && (
+          <div style={{ padding: 24, textAlign: "center", color: "#94a3b8" }}>No authorships match these filters.</div>
+        )}
+        {!loading && rows.map((r) => (
+          <AuthorshipCard
+            key={r.id}
+            row={r}
+            statusView={statusView}
+            isExpanded={expanded === r.id}
+            isSelected={selected.has(r.id)}
+            isFocused={focusedId === r.id}
+            acting={actingId === r.id}
+            pickedCwid={picked[r.id]}
+            registerRef={(el) => { cardRefs.current[r.id] = el; }}
+            onFocus={() => setFocusedId(r.id)}
+            onToggleExpand={() => setExpanded((e) => (e === r.id ? null : r.id))}
+            onToggleSelect={() => toggleSelect(r)}
+            onPick={(cwid) => setPicked((p) => ({ ...p, [r.id]: cwid }))}
+            onAction={(action, extra) => doAction(r, action, extra)}
+            onMenu={(anchor) => setMenu({ anchor, row: r })}
+            onNarrowPmid={() => narrowToPmid(r.pmid)}
+          />
+        ))}
       </div>
 
       {/* pagination */}
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 14, color: "#475467", fontSize: 13 }}>
-        <span>{count.toLocaleString()} authorships · page {page + 1} of {totalPages}</span>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 18, color: "#475569", fontSize: 13 }}>
+        <span style={{ fontVariantNumeric: "tabular-nums" }}>{count.toLocaleString()} authorships · page {page + 1} of {totalPages}</span>
         <span style={{ display: "flex", gap: 8 }}>
-          <button disabled={page === 0} onClick={() => setPage((p) => Math.max(0, p - 1))}
-            style={{ padding: "6px 12px", borderRadius: 8, border: "1px solid #d0d5dd", background: "#fff", cursor: page === 0 ? "default" : "pointer", opacity: page === 0 ? 0.5 : 1 }}>Previous</button>
-          <button disabled={page + 1 >= totalPages} onClick={() => setPage((p) => p + 1)}
-            style={{ padding: "6px 12px", borderRadius: 8, border: "1px solid #d0d5dd", background: "#fff", cursor: page + 1 >= totalPages ? "default" : "pointer", opacity: page + 1 >= totalPages ? 0.5 : 1 }}>Next</button>
+          <button disabled={page === 0} onClick={() => setPage((p) => Math.max(0, p - 1))} style={btn("ghost", page === 0)}>Previous</button>
+          <button disabled={page + 1 >= totalPages} onClick={() => setPage((p) => p + 1)} style={btn("ghost", page + 1 >= totalPages)}>Next</button>
         </span>
       </div>
 
-      {/* overflow menu: Snooze / Dismiss */}
+      {/* overflow menu: Reject / Snooze / Dismiss.
+          Reject writes a "rejected" gold-standard entry against top_cwid — valid only for
+          single-candidate rows (the backend 409s on multi). For multi-candidate rows the
+          equivalent "this isn't any of them" action is None of these → dismiss. */}
       <Menu anchorEl={menu?.anchor} open={!!menu} onClose={() => setMenu(null)}>
+        {menu?.row.single_candidate ? (
+          <MenuItem onClick={() => menu && doAction(menu.row, "reject")} style={{ color: "#b91c1c" }}>
+            <IconX size={14} style={{ marginRight: 8 }} /> Reject
+          </MenuItem>
+        ) : (
+          <MenuItem onClick={() => menu && doAction(menu.row, "dismiss")} style={{ color: "#b91c1c" }}>
+            <IconX size={14} style={{ marginRight: 8 }} /> None of these
+          </MenuItem>
+        )}
         <MenuItem onClick={() => menu && doAction(menu.row, "snooze")}>Snooze 90 days</MenuItem>
         <MenuItem onClick={() => menu && doAction(menu.row, "dismiss")}>Dismiss</MenuItem>
       </Menu>
@@ -480,8 +580,8 @@ const AuthorshipsTabs = () => {
         )}
       </Menu>
 
-      {/* undo (immediate reversal) */}
-      <Snackbar open={!!undo} autoHideDuration={5000} onClose={() => setUndo(null)}
+      {/* undo (immediate reversal, batched) */}
+      <Snackbar open={!!undo} autoHideDuration={6000} onClose={() => setUndo(null)}
         anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
         message={undo ? undo.label : ""}
         action={
@@ -495,5 +595,329 @@ const AuthorshipsTabs = () => {
     </div>
   );
 };
+
+const kbdStyle: CSSProperties = {
+  font: "inherit", fontSize: 11, background: "#eef2f7", border: "1px solid #dde3ea", borderBottomWidth: 2,
+  borderRadius: 4, padding: "0 5px", color: "#475569",
+};
+
+// ---- card ----------------------------------------------------------------
+interface CardProps {
+  row: AuthorshipRow;
+  statusView: "open" | "snoozed" | "dismissed";
+  isExpanded: boolean;
+  isSelected: boolean;
+  isFocused: boolean;
+  acting: boolean;
+  pickedCwid?: string;
+  registerRef: (el: HTMLElement | null) => void;
+  onFocus: () => void;
+  onToggleExpand: () => void;
+  onToggleSelect: () => void;
+  onPick: (cwid: string) => void;
+  onAction: (action: string, extra?: Record<string, any>) => void;
+  onMenu: (anchor: HTMLElement) => void;
+  onNarrowPmid: () => void;
+}
+
+const AuthorshipCard = ({
+  row: r, statusView, isExpanded, isSelected, isFocused, acting, pickedCwid,
+  registerRef, onFocus, onToggleExpand, onToggleSelect, onPick, onAction, onMenu, onNarrowPmid,
+}: CardProps) => {
+  const isMulti = !r.single_candidate && (r.n_candidates ?? 0) > 1;
+  const isAbsent = r.top_io_score == null;
+  const wcm = hasWcm(r.author_affiliation);
+  const candidates = isMulti ? parseCandidates(r.candidate_cwids_json) : [];
+  const meta = CLASS_META[r.classification || "absent"];
+
+  const cardStyle: CSSProperties = {
+    background: isSelected ? "#eff6ff" : "#fff",
+    border: "1px solid #e8edf2",
+    borderRadius: 10,
+    marginBottom: 11,
+    boxShadow: isFocused ? "0 0 0 2px #2563eb" : "0 1px 2px rgba(15,23,42,.04)",
+    transition: "box-shadow 150ms, background 150ms",
+  };
+
+  return (
+    <article ref={registerRef} tabIndex={0} onFocus={onFocus} onMouseEnter={onFocus} style={cardStyle}>
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 12, padding: "13px 15px" }}>
+        {/* selection checkbox — single-candidate open rows only */}
+        <input type="checkbox" disabled={!r.single_candidate || statusView !== "open"}
+          checked={isSelected} onChange={onToggleSelect}
+          aria-label={`select ${r.wcm_author || ""}`}
+          style={{ width: 16, height: 16, marginTop: 3, accentColor: "#2563eb", cursor: r.single_candidate && statusView === "open" ? "pointer" : "default", flex: "none", opacity: r.single_candidate && statusView === "open" ? 1 : 0.3 }} />
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {/* L1 — WCM author + position */}
+          <div style={{ display: "flex", alignItems: "baseline", gap: 8, flexWrap: "wrap" }}>
+            <span style={{ fontSize: 15, fontWeight: 600, color: "#0f172a" }}>{r.wcm_author}</span>
+            <span style={{ fontSize: 12, color: "#94a3b8" }}>{r.author_position_label} author</span>
+            {(r.pmid_sibling_count ?? 1) > 1 && (
+              <Tip title="Show all WCM authorships on this paper" placement="top" arrow>
+                <button onClick={onNarrowPmid} style={{
+                  display: "inline-flex", alignItems: "center", gap: 4, border: "1px solid #e2e9f3", background: "#f4f7fc",
+                  color: "#2563eb", borderRadius: 12, padding: "1px 8px", fontSize: 11, fontWeight: 600, cursor: "pointer",
+                }}>
+                  <IconUsers size={12} /> +{(r.pmid_sibling_count as number) - 1} more WCM authors on this paper
+                </button>
+              </Tip>
+            )}
+          </div>
+
+          {/* L2 — proposed identity */}
+          <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 3, fontSize: 13, color: "#475569", flexWrap: "wrap" }}>
+            <span style={{ color: "#94a3b8" }}>→</span>
+            {isMulti ? (
+              <span style={{ color: "#94a3b8" }}>choose among {r.n_candidates} WCM homonyms</span>
+            ) : (
+              <>
+                <span style={{ fontWeight: 600, color: "#0f172a" }}>{r.top_name}</span>
+                {r.top_cwid && (
+                  <a href={`/curate/${r.top_cwid}`} target="_blank" rel="noreferrer"
+                    title={`Open ${r.top_name || r.top_cwid}'s curate profile`}
+                    style={{ color: "#2563eb", textDecoration: "none" }}>{r.top_cwid}</a>
+                )}
+                <span style={{ color: "#94a3b8" }}>· {r.top_person_type}{r.top_dept ? `, ${r.top_dept}` : ""}</span>
+              </>
+            )}
+          </div>
+
+          {/* L3 — paper meta (quiet/truncated) */}
+          <div style={{ fontSize: 12.5, color: "#94a3b8", marginTop: 4, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={r.title}>
+            {r.title} · <i>{r.journal}</i>{r.entrez_date ? ` · ${r.entrez_date}` : ""} ·{" "}
+            <a href={`https://pubmed.ncbi.nlm.nih.gov/${r.pmid}/`} target="_blank" rel="noreferrer" style={{ color: "#94a3b8", textDecoration: "none" }}>
+              PMID {r.pmid} <IconExt size={13} />
+            </a>
+          </div>
+
+          {/* L4 — affiliation one line (WCM highlighted, full on hover) + disclosure */}
+          <div style={{ display: "flex", alignItems: "center", gap: 7, marginTop: 7, fontSize: 12.5, color: "#475569" }}>
+            <Tip title={r.author_affiliation || "No affiliation"} placement="top-start" arrow>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, minWidth: 0, cursor: "help" }}>
+                <IconPin size={15} style={{ color: "#94a3b8" }} />
+                <span style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", maxWidth: 440 }}>
+                  {r.author_affiliation ? highlightAffiliation(r.author_affiliation) : "—"}
+                </span>
+              </span>
+            </Tip>
+            <button onClick={onToggleExpand} aria-expanded={isExpanded} style={{
+              display: "inline-flex", alignItems: "center", gap: 4, marginLeft: "auto", background: "none", border: "none",
+              font: "inherit", fontSize: 12, fontWeight: 600, color: isExpanded ? "#2563eb" : "#475569", cursor: "pointer",
+              padding: "2px 4px", borderRadius: 5, flex: "none",
+            }}>
+              {isMulti ? "Pick one" : "Evidence"} {isExpanded ? <IconChevD size={13} /> : <IconChevR size={13} />}
+            </button>
+          </div>
+        </div>
+
+        {/* right rail: score block + primary action + overflow */}
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flex: "none" }}>
+          <ScoreRail row={r} isMulti={isMulti} isAbsent={isAbsent} candidates={candidates} />
+          {statusView === "open" ? (
+            isMulti ? (
+              <button style={btn("ghost")} onClick={onToggleExpand}>Pick one <IconChevR size={13} /></button>
+            ) : (
+              <button style={btn("accept", acting)} disabled={acting} onClick={() => onAction("accept")}>
+                <IconCheck /> Accept
+              </button>
+            )
+          ) : (
+            <button style={btn("ghost", acting)} disabled={acting} onClick={() => onAction("reopen")}>Reopen</button>
+          )}
+          {statusView === "open" && (
+            <button style={iconBtn(acting)} disabled={acting} aria-label="More actions"
+              onClick={(e) => onMenu(e.currentTarget)}><IconMore /></button>
+          )}
+        </div>
+      </div>
+
+      {/* snoozed wake-time hint */}
+      {statusView === "snoozed" && r.snooze_until && (
+        <div style={{ padding: "0 15px 10px 43px", fontSize: 11, color: "#94a3b8" }}>Wakes {r.snooze_until}</div>
+      )}
+
+      {/* expanded evidence / pick-one */}
+      {isExpanded && (
+        <div style={{ padding: "0 15px 14px 43px", fontSize: 13, color: "#475569" }}>
+          {isMulti ? (
+            <MultiEvidence row={r} candidates={candidates} pickedCwid={pickedCwid} acting={acting}
+              onPick={onPick} onAction={onAction} />
+          ) : (
+            <SingleEvidence row={r} wcm={wcm} isAbsent={isAbsent} />
+          )}
+        </div>
+      )}
+    </article>
+  );
+};
+
+// right-rail score block
+const ScoreRail = ({ row: r, isMulti, isAbsent, candidates }: { row: AuthorshipRow; isMulti: boolean; isAbsent: boolean; candidates: Candidate[] }) => {
+  if (isMulti) {
+    const total = r.n_candidates ?? candidates.length;
+    return (
+      <div style={{ textAlign: "right", minWidth: 46 }}>
+        <span style={{ display: "inline-block", fontSize: 11, fontWeight: 600, padding: "3px 9px", borderRadius: 20, whiteSpace: "nowrap", background: "#fffbeb", color: "#b45309" }}>
+          {total} candidates
+        </span>
+        {r.top_io_score != null && (
+          <span style={{ display: "block", fontSize: 10.5, color: "#94a3b8", marginTop: 3, textAlign: "right", fontWeight: 500 }}>
+            top IO {fmtScore(r.top_io_score)}
+          </span>
+        )}
+      </div>
+    );
+  }
+  if (isAbsent) {
+    return (
+      <div style={{ textAlign: "right", minWidth: 46 }}>
+        <span style={{ display: "inline-block", fontSize: 11, fontWeight: 600, padding: "3px 9px", borderRadius: 20, whiteSpace: "nowrap", background: "#fffbeb", color: "#b45309" }}>
+          Never retrieved
+        </span>
+        <span style={{ display: "block", fontSize: 10.5, color: "#94a3b8", marginTop: 3, textAlign: "right", fontWeight: 500 }}>
+          conf: {confBand(r.top_confidence)}
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div style={{ textAlign: "right", minWidth: 46 }}>
+      <div style={{ fontSize: 22, fontWeight: 700, lineHeight: 1, letterSpacing: "-0.02em", fontVariantNumeric: "tabular-nums", color: ioColor(r.top_io_score) }}>
+        {fmtScore(r.top_io_score)}
+      </div>
+      {r.top_fg_score != null && (
+        <div style={{ fontSize: 11, color: "#c2410c", marginTop: 3, fontWeight: 600, fontVariantNumeric: "tabular-nums" }}>
+          FG {fmtScore(r.top_fg_score)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// single-candidate / absent evidence panel
+const SingleEvidence = ({ row: r, wcm, isAbsent }: { row: AuthorshipRow; wcm: boolean; isAbsent: boolean }) => (
+  <>
+    {r.author_affiliation && (
+      <div style={{ background: "#f8fafc", border: "1px solid #e8edf2", borderRadius: 7, padding: "9px 11px", lineHeight: 1.55, marginBottom: 9 }}>
+        <span style={{ color: "#94a3b8", fontSize: 11, textTransform: "uppercase", letterSpacing: ".04em", display: "block", marginBottom: 3 }}>PubMed affiliation</span>
+        {highlightAffiliation(r.author_affiliation)}
+      </div>
+    )}
+    {/* absent → labeled facts, no score blocks (F10) */}
+    {isAbsent && (
+      <div style={{ display: "flex", gap: 22, marginBottom: 10 }}>
+        <div><div style={{ fontSize: 14, fontWeight: 600, color: "#0f172a" }}>{confBand(r.top_confidence)}</div><div style={factLabel}>Confidence</div></div>
+        <div><div style={{ fontSize: 14, fontWeight: 600, color: "#0f172a", fontVariantNumeric: "tabular-nums" }}>{r.top_cohort_size ?? "—"}</div><div style={factLabel}>WCM homonym</div></div>
+        <div><div style={{ fontSize: 14, fontWeight: 600, color: "#0f172a" }}>{r.top_given_match || "—"}</div><div style={factLabel}>Given name</div></div>
+      </div>
+    )}
+    {/* signal chips (F7) */}
+    <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 9 }}>
+      {wcm
+        ? <Chip kind="ok"><IconCheck size={13} /> WCM affiliation match</Chip>
+        : <Chip kind="warn"><IconAlert size={13} /> No WCM string in affiliation</Chip>}
+      {r.top_affil_match
+        ? <Chip kind="neutral">Dept: {r.top_dept} ✓</Chip>
+        : <Chip kind="neutral">Dept ≠ affiliation</Chip>}
+    </div>
+    {/* inline IO/FG note (F8) */}
+    <div style={{
+      display: "flex", gap: 7, fontSize: 12.5, lineHeight: 1.5, borderRadius: 7, padding: "8px 10px",
+      background: isAbsent ? "#fffbeb" : "#eff6ff", color: isAbsent ? "#b45309" : "#475569",
+    }}>
+      {isAbsent ? <IconAlert size={15} style={{ marginTop: 1, color: "#b45309" }} /> : <IconInfo size={15} style={{ marginTop: 1, color: "#2563eb" }} />}
+      <span>{ioFgNote(r)}</span>
+    </div>
+  </>
+);
+
+// multi-candidate disambiguation panel (F11)
+const MultiEvidence = ({ row: r, candidates, pickedCwid, acting, onPick, onAction }: {
+  row: AuthorshipRow; candidates: Candidate[]; pickedCwid?: string; acting: boolean;
+  onPick: (cwid: string) => void; onAction: (action: string, extra?: Record<string, any>) => void;
+}) => {
+  // rank by IO desc; null IO sinks last
+  const ranked = [...candidates].sort((a, b) => (b.io_score ?? -1) - (a.io_score ?? -1));
+  const scored = ranked.filter((c) => c.io_score != null);
+  const unscored = ranked.filter((c) => c.io_score == null);
+  const [showAll, setShowAll] = useState(false);
+  const anyDeptMatch = candidates.some((c) => c.affil_dept_match);
+  const lead = scored[0];
+  // The Assign button writes the PRODUCTION gold standard, so it must reflect an
+  // EXPLICIT curator pick — never a silent default. We highlight the highest-IO
+  // candidate (lead) as a visual hint only; selectedCwid drives the radio state but
+  // Assign is gated on pickedCwid below so opening/mis-clicking a card can't write GS.
+  const selectedCwid = pickedCwid;
+  // when no candidate has an IO score, there is nothing to show in the default view —
+  // auto-expand the unscored list so the curator always has a visible choice to pick.
+  const visible = showAll || scored.length === 0 ? ranked : scored;
+
+  return (
+    <>
+      {r.author_affiliation && (
+        <div style={{ background: "#f8fafc", border: "1px solid #e8edf2", borderRadius: 7, padding: "9px 11px", lineHeight: 1.55, marginBottom: 9 }}>
+          <span style={{ color: "#94a3b8", fontSize: 11, textTransform: "uppercase", letterSpacing: ".04em", display: "block", marginBottom: 3 }}>PubMed affiliation</span>
+          {highlightAffiliation(r.author_affiliation)}
+        </div>
+      )}
+      {!anyDeptMatch && (
+        <div style={{ display: "flex", gap: 7, fontSize: 12.5, lineHeight: 1.5, borderRadius: 7, padding: "8px 10px", background: "#fffbeb", color: "#b45309", marginBottom: 10 }}>
+          <IconAlert size={15} style={{ marginTop: 1 }} />
+          <span>The affiliation names Weill Cornell but no department — ranked by identity-only (IO).</span>
+        </div>
+      )}
+      <div>
+        {visible.map((c, i) => {
+          const isLead = c.cwid === lead?.cwid;
+          const checked = c.cwid === selectedCwid;
+          return (
+            <label key={c.cwid || i} style={{
+              display: "flex", alignItems: "center", gap: 11, padding: "9px 11px",
+              border: `1px solid ${isLead ? "#bbf7d0" : "#e8edf2"}`, borderRadius: 7, marginBottom: 7, cursor: "pointer",
+              background: isLead ? "#f0fdf4" : "#fff",
+            }}>
+              <input type="radio" name={`m${r.id}`} checked={checked} onChange={() => onPick(c.cwid)}
+                style={{ accentColor: "#2563eb", flex: "none" }} />
+              <span style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ fontSize: 13.5, fontWeight: 600, color: "#0f172a" }}>
+                  {c.name}{" "}
+                  {c.cwid && <a href={`/curate/${c.cwid}`} target="_blank" rel="noreferrer" style={{ color: "#2563eb", textDecoration: "none", fontWeight: 400 }}>{c.cwid}</a>}
+                </span>
+                <span style={{ display: "block", fontSize: 12, color: "#94a3b8" }}>
+                  {c.person_type}{c.dept ? ` · ${c.dept}` : ""}{c.affil_dept_match ? " · dept✓" : ""}{!hasWcm(r.author_affiliation) ? " · ⚠ no WCM string" : ""}
+                </span>
+              </span>
+              <span style={{ textAlign: "right" }}>
+                <span style={{ display: "block", fontSize: 16, fontWeight: 700, lineHeight: 1, fontVariantNumeric: "tabular-nums", color: ioColor(c.io_score) }}>
+                  {fmtScore(c.io_score)}
+                </span>
+                {c.final_score != null && (
+                  <span style={{ display: "block", fontSize: 10.5, color: "#c2410c", marginTop: 2, fontVariantNumeric: "tabular-nums" }}>FG {fmtScore(c.final_score)}</span>
+                )}
+              </span>
+            </label>
+          );
+        })}
+        {!showAll && scored.length > 0 && unscored.length > 0 && (
+          <button onClick={() => setShowAll(true)} style={{ background: "none", border: "none", color: "#2563eb", fontSize: 12, cursor: "pointer", padding: "2px 0", marginBottom: 8 }}>
+            Show all {ranked.length} ({unscored.length} never retrieved, IO unavailable)
+          </button>
+        )}
+      </div>
+      <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+        <button style={btn("accept", acting || !pickedCwid)} disabled={acting || !pickedCwid}
+          onClick={() => pickedCwid && onAction("assign", { cwid: pickedCwid })}>
+          <IconCheck /> Assign selected
+        </button>
+        <button style={btn("ghost", acting)} disabled={acting} onClick={() => onAction("dismiss")}>
+          <IconX /> None of these
+        </button>
+      </div>
+    </>
+  );
+};
+
+const factLabel: CSSProperties = { fontSize: 10.5, color: "#94a3b8", textTransform: "uppercase", letterSpacing: ".04em", marginTop: 1 };
 
 export default AuthorshipsTabs;


### PR DESCRIPTION
## Summary

Replaces the dense Authorships table with a **card-per-authorship** layout and adds multi-candidate disambiguation. Stacks on PR-1 (curator actions), based off `dev_Upd_NextJS14SNode18`.

**Visual hierarchy — the decision is the hero:** proposed identity + large green **IO** score + Accept; **FG** demoted to a small red diagnostic (in this feed every row is FG < 30 or never scored). Secondary actions (Reject / Snooze / Dismiss) move into an overflow menu. Full affiliation, signal chips, and the IO/FG explanation are progressively disclosed behind an **Evidence** expander (full affiliation also on hover).

**Multi-candidate disambiguation** (~51% of the feed): a **Pick one** expander with IO-ranked candidate radios, **Assign** (writes the gold standard to the curator-chosen homonym), and **None of these** (dismiss). Assign requires an explicit pick — no pre-armed default — and the chosen cwid is validated server-side against the candidate set before any GS write.

**Other:**
- **Absent card** (~49% — never retrieved): confidence band / WCM-homonym count / given-name match instead of empty score chips.
- **Bulk** Accept near-certain (single-candidate · IO ≥ 95), page-scoped, with batched Undo; plus Accept selected.
- **Per-paper adjacency**: "+N more WCM authors on this paper" narrows the view to that PMID.
- **Keyboard nav**: J/K move · Y accept · N reject · S snooze · X select · Enter open.
- Default sort is now identity-only (IO).

## Backend (`controllers/db/authorships.controller.ts`)
- `pmid` secondary sort key on all sort entries (adjacency).
- Per-row `pmid_sibling_count` (one grouped COUNT scoped to the active status view).
- `assign` action (validates cwid ∈ candidate set) + assigned-aware `reopen` reversal keyed on `resolution_cwid`.
- **No schema change** — the `status` ENUM already has `assigned`.

## Verification
- `tsc --noEmit` clean for both touched files (the repo's pre-existing `next-auth/client` + `middleware.ts` + `__tests__` `@types/jest` errors are unrelated noise).
- Adversarial multi-agent review (correctness · v4-mock fidelity + 8 design corrections · gold-standard-write & auth safety); all critical/high/medium findings fixed — notably gating multi-candidate Assign on an explicit pick + server-side candidate validation.
- Functional verification is by curator login in dev after deploy (SAML/NextAuth wall blocks automated page access).

Design reference: `authorship_centric_review_queue_v4.html` + `docs/AUTHORSHIP_REVIEW_PHASE_C_PR2_PLAN.md` (in the ReCiter Research project).