### PR TITLE
Authorship Review: send entryPath=PM_AUTHOR on gold-standard writes

### DIFF
--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -212,7 +212,7 @@ async function writeGoldStandard(
   const curatedByQ = curatedBy != null ? `&curatedBy=${curatedBy}` : "";
   try {
     const resp = await fetch(
-      `${reciterConfig.reciter.reciterUpdateGoldStandardEndpoint}?goldStandardUpdateFlag=${flag}&source=adversarial-attribution-review${curatedByQ}`,
+      `${reciterConfig.reciter.reciterUpdateGoldStandardEndpoint}?goldStandardUpdateFlag=${flag}&source=adversarial-attribution-review&entryPath=PM_AUTHOR${curatedByQ}`,
       {
         method: "POST",
         headers: {


### PR DESCRIPTION
Companion to ReCiter Java PR #631. The Authorship Review tab now sends `entryPath=PM_AUTHOR` on every gold-standard accept/reject/assign/undo, so these curations are tagged distinctly in ArticleProvenance (`rs`/`ads` = `PM_AUTHOR`) instead of defaulting to `CANDIDATE_LIST`.

One-line change in `writeGoldStandard()` (`controllers/db/authorships.controller.ts`). Requires the Java side to recognize `EntryPath.PM_AUTHOR` (PR #631) for the marker to be written; unknown `entryPath` values fall back to `CANDIDATE_LIST` on the Java side, so deploy order doesn't matter.

tsc clean for the edited file. Functional verify after both deploy: an Authorship-tab Accept should leave `PM_AUTHOR` in that pmid's `ArticleProvenance.ads`.