### PR TITLE
Authorship Review: make the rolling-queue refill fluid (no full-page swap, no resurrected cards)

### DIFF
--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -230,6 +230,10 @@ const AuthorshipsTabs = () => {
   // F13: keyboard focus
   const [focusedId, setFocusedId] = useState<number | null>(null);
   const cardRefs = useRef<Record<number, HTMLElement | null>>({});
+  // ids optimistically removed by a curator action whose server write may still be in flight.
+  // Guards the rolling-queue refill (topUp/fetchData) from resurrecting a just-actioned row when
+  // a sibling action hasn't committed yet (rapid-accept race). Cleared per-id once its POST settles.
+  const pendingRemoved = useRef<Set<number>>(new Set());
 
   const filterBody = useCallback(() => ({
     feed: "unassigned",
@@ -250,16 +254,23 @@ const AuthorshipsTabs = () => {
       body: JSON.stringify({ ...filterBody(), limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
     })
       .then((r) => r.json())
-      .then((d) => { setRows(d.rows || []); setCount(d.count || 0); })
+      .then((d) => {
+        // never show a row whose removal is still in flight (race protection, same as topUp)
+        setRows((d.rows || []).filter((row: AuthorshipRow) => !pendingRemoved.current.has(row.id)));
+        setCount(d.count || 0);
+      })
       .catch((e) => console.error("[authorships]", e))
       .finally(() => setLoading(false));
   }, [filterBody, page]);
 
-  // Rolling queue: silently refill the visible set back up to PAGE_SIZE after a curator
-  // action — NO loading flash (unlike fetchData), so the queue stays on screen and the next
-  // pending authorship slides into the freed slot. Accept 1 → that row drops and the next is
-  // pulled in ("19 remains, add one"); clear the whole set → the next set loads. Steps back a
-  // page if the tail empties so you're never stranded on a now-empty trailing page.
+  // Rolling queue: silently refill the visible set back up to PAGE_SIZE after a curator action —
+  // NO loading flash (unlike fetchData) and, critically, ADDITIVE rather than a wholesale swap.
+  // The rows already on screen stay exactly where they are (no reflow of what the curator is
+  // reading at the top); only genuinely-new rows are appended into the freed slots at the bottom,
+  // out of the curator's focus area — so the late-arriving refill (gated on the slow gold-standard
+  // write) is invisible. Filtering against pendingRemoved stops a refetch from resurrecting a row
+  // a sibling action just removed but whose write hasn't committed yet (rapid-accept race). Steps
+  // back a page only when this offset is genuinely empty, so you're never stranded on a dead tail.
   const topUp = useCallback(() => {
     fetch("/api/db/authorships", {
       credentials: "same-origin", method: "POST", headers: apiHeaders,
@@ -267,10 +278,16 @@ const AuthorshipsTabs = () => {
     })
       .then((r) => r.json())
       .then((d) => {
-        const next = d.rows || [];
-        if (next.length === 0 && page > 0) { setPage((p) => Math.max(0, p - 1)); return; }
-        setRows(next);
+        const fetched: AuthorshipRow[] = (d.rows || []).filter(
+          (row: AuthorshipRow) => !pendingRemoved.current.has(row.id),
+        );
         setCount(d.count || 0);
+        if (fetched.length === 0 && page > 0) { setPage((p) => Math.max(0, p - 1)); return; }
+        setRows((current) => {
+          const visibleIds = new Set(current.map((r) => r.id));
+          const additions = fetched.filter((r) => !visibleIds.has(r.id));
+          return [...current, ...additions].slice(0, PAGE_SIZE);
+        });
       })
       .catch((e) => console.error("[authorships]", e));
   }, [filterBody, page]);
@@ -293,12 +310,17 @@ const AuthorshipsTabs = () => {
   useEffect(() => { fetchSummary(); }, [fetchSummary]);
   // reset to first page when filters, sort, or status view change
   useEffect(() => { setPage(0); }, [lane, classification, search, selectedTypes, dateFrom, dateTo, sort, statusView]);
-  // clear transient per-page UI state when the page contents change
-  useEffect(() => { setSelected(new Set()); setExpanded(null); setPicked({}); }, [rows]);
+  // clear transient per-page UI state on deliberate navigation only (filter/sort/status/page) —
+  // NOT on every `rows` change, so a silent rolling-queue refill (topUp) after a single action
+  // doesn't collapse the card the curator is mid-read on or wipe an in-progress bulk selection.
+  // Stale ids left in selected/picked when a row drops are harmless (they match no visible row).
+  useEffect(() => { setSelected(new Set()); setExpanded(null); setPicked({}); },
+    [lane, classification, search, selectedTypes, dateFrom, dateTo, sort, statusView, page]);
 
   // perform a curator action: optimistically drop the row, POST, then offer Undo (or revert on failure).
   // `extra` carries the assign cwid; the returned promise lets bulk loops await settlement.
   const doActionAsync = useCallback((row: AuthorshipRow, action: string, extra?: Record<string, any>): Promise<boolean> => {
+    pendingRemoved.current.add(row.id);
     setRows((rs) => rs.filter((x) => x.id !== row.id));
     setCount((c) => Math.max(0, c - 1));
     return fetch("/api/db/authorships/action", {
@@ -308,7 +330,10 @@ const AuthorshipsTabs = () => {
       .then(async (r) => {
         if (!r.ok) throw new Error((await r.text()) || `HTTP ${r.status}`);
         return true;
-      });
+      })
+      // settled (DB write committed on success, or failed): the id no longer needs guarding.
+      // Runs before the caller's .then(topUp), so this row is clear while siblings stay guarded.
+      .finally(() => { pendingRemoved.current.delete(row.id); });
   }, []);
 
   // single-row action with its own optimistic remove + Undo (PR-1 behaviour, extended for assign)


### PR DESCRIPTION
## Problem

After PR #730 (rolling queue), accepting a card felt jittery: a pause, then either the whole list re-laid-out with a new card popping in at the top, or a pub the curator had *just* accepted briefly reappeared.

Root cause was the post-action refill (`topUp`):

1. **Full-page swap.** `topUp` did a blind `setRows(next)` — replacing the entire visible page — so the accepted card didn't just drop; the whole list re-rendered and a new card appeared at the top, right where the curator's eyes were.
2. **Resurrected cards (race).** The Accept POST writes the gold standard to the ReCiter Java endpoint (→ DynamoDB) *before* the MySQL status update. The refetch at a fixed offset wasn't guarded, so a sibling accept whose write hadn't committed yet was pulled back in and re-rendered.
3. **Collapsed evidence panel.** A reset effect keyed on `[rows]` cleared `expanded`/`selected` on *every* refill, so accepting one card collapsed an evidence panel open elsewhere.

## Fix (single file: `AuthorshipsTabs.tsx`)

- **Additive, bottom-anchored refill** — rows on screen stay exactly in place; `topUp` only appends genuinely-new rows into the freed slots at the bottom, out of the curator's focus, so the late-arriving refill (gated on the slow GS write) is invisible.
- **`pendingRemoved` ref** tracks optimistically-removed ids and filters them from every refetch, so an action mid-commit can never be resurrected (rapid-accept race). Cleared per-id once each POST settles.
- **Scoped the transient-state reset** to deliberate navigation (filter/sort/status/page) instead of every `rows` change, so a silent refill no longer collapses the card the curator is mid-read on.

Net effect: accept → the card drops, everything shifts up by one, nothing else moves, and the next pub fills in quietly at the bottom.

## Verification

- `tsc --noEmit` clean for the changed file.
- Behavioral verification pending deploy to `reciter-pm-dev` (tab is SAML-walled for direct testing).