### PR TITLE
feat(impersonation): Superuser "View as" (act-as) — flag-gated [DRAFT]

### DIFF
--- a/controllers/db/admin.feedbacklog.controller.ts
+++ b/controllers/db/admin.feedbacklog.controller.ts
@@ -27,7 +27,7 @@ export const findFeedbackLogByUid = async (req: NextApiRequest, res: NextApiResp
 
 
 export const createFeedbackLog = async (req: NextApiRequest, res: NextApiResponse) => {
-    const { userID, personIdentifier, articleIdentifier, feedback } = req.body;
+    const { userID, impersonatedByUserID, personIdentifier, articleIdentifier, feedback } = req.body;
     try {
         if(userID && personIdentifier && articleIdentifier && feedback) {
             const isUserExistAndActive = await models.AdminUser.findOne({
@@ -42,6 +42,7 @@ export const createFeedbackLog = async (req: NextApiRequest, res: NextApiRespons
                 articleIdentifier.forEach((element: number) => {
                     data.push({
                         userID: isUserExistAndActive.userID,
+                        impersonatedByUserID: impersonatedByUserID ?? null,
                         personIdentifier: personIdentifier,
                         articleIdentifier: element,
                         feedback: feedback,

--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -4,6 +4,7 @@ import { getToken } from "next-auth/jwt";
 import models from "../../src/db/sequelize";
 import { reciterConfig } from "../../config/local";
 import { updatePendingArticleCount } from "./person.controller";
+import { getEffectiveRolesScope } from "../../src/utils/effectiveSession";
 
 // Columns returned to the Authorships tab (one row per unassigned WCM authorship).
 const LIST_ATTRIBUTES = [
@@ -189,6 +190,9 @@ export const authorshipSummary = async (req: NextApiRequest, res: NextApiRespons
 async function resolveCurator(req: NextApiRequest): Promise<{ userID?: number; cwid?: string; authorized: boolean }> {
   const token: any = await getToken({ req: req as any, secret: process.env.NEXTAUTH_SECRET });
   if (!token) return { authorized: false };
+  // AUDIT identity stays REAL: the JWT is never overlaid server-side, so
+  // databaseUser.userID / username are always the real signed-in superuser.
+  // curatedBy / reviewer / feedbacklog are stamped with this real user.
   let userID: number | undefined = token.databaseUser?.userID;
   const cwid: string | undefined = token.username;
   // fallback: resolve the AdminUser id from the curator CWID if the JWT lacks databaseUser
@@ -196,8 +200,11 @@ async function resolveCurator(req: NextApiRequest): Promise<{ userID?: number; c
     const au: any = await models.AdminUser.findOne({ where: { personIdentifier: cwid }, attributes: ["userID"] });
     userID = au?.userID;
   }
-  let roles: any[] = [];
-  try { roles = token.userRoles ? JSON.parse(token.userRoles) : []; } catch { roles = []; }
+  // AUTHORIZATION uses the EFFECTIVE roles: the TARGET's when impersonating
+  // (faithful act-as), the REAL user's (read from the token, byte-identical to
+  // before) otherwise. getEffectiveRolesScope returns userRoles already parsed.
+  const effective = await getEffectiveRolesScope(token, req);
+  const roles: any[] = effective.userRoles;
   const authorized = roles.some((r: any) => r.roleLabel === "Superuser" || r.roleLabel === "Curator_All");
   return { userID, cwid, authorized };
 }

--- a/scripts/migrations/add-impersonated-by-feedbacklog.sql
+++ b/scripts/migrations/add-impersonated-by-feedbacklog.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- Migration: Add impersonatedByUserID column to admin_feedback_log
+-- Feature: "View as" (impersonation) — honest "logged to you" attribution
+--
+-- Records the REAL superuser on every curation feedback-log write while the
+-- existing userID column stays the EFFECTIVE target (the person being acted as).
+-- Nullable FK to admin_users.userID; NULL for all non-impersonated writes.
+--
+-- Apply schedule:
+--   dev reciterDB: with the impersonation feature branch (flag still off)
+--   prod reciterDB: after the impersonation feature is verified on dev
+--
+-- Idempotency: Running this script a second time will produce a
+--   "Duplicate column name" error, which is harmless (column already exists).
+-- ============================================================================
+
+ALTER TABLE admin_feedback_log
+  ADD COLUMN impersonatedByUserID INT DEFAULT NULL;  -- nullable FK -> admin_users.userID
+
+-- Verification (run manually after applying):
+-- DESCRIBE admin_feedback_log;
+-- Expected: new column impersonatedByUserID of type int, nullable, default NULL

--- a/src/components/elements/Impersonation/ViewAsControls.module.css
+++ b/src/components/elements/Impersonation/ViewAsControls.module.css
@@ -1,0 +1,218 @@
+/* "View as" (impersonation) controls — calm design system.
+   Navy CTA #1a2133 / white, 6px radius, Inter (inherited), subtle warm borders.
+   Amber banner #FEF3C7 bg / #92400E text / darker-amber left accent. */
+
+/* ---- Entry trigger (top-right user bar) ---- */
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  color: #5a6478;
+  background: #fff;
+  border: 1px solid #ddd7ce;
+  border-radius: 6px;
+  padding: 5px 12px;
+  cursor: pointer;
+}
+.trigger:hover {
+  background: #faf8f5;
+  border-color: #bbb5aa;
+  color: #1a2133;
+}
+
+/* ---- Picker modal ---- */
+.pickerSubtitle {
+  font-size: 13px;
+  color: #5a6478;
+  margin-bottom: 16px;
+}
+.searchInput {
+  width: 100%;
+  background: #fff;
+  border: 1px solid #ddd7ce;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  color: #1a2133;
+}
+.searchInput::placeholder {
+  color: #8a94a6;
+}
+.searchInput:focus {
+  outline: none;
+  border-color: #2563a8;
+  box-shadow: 0 0 0 3px rgba(37, 99, 168, 0.1);
+}
+
+.results {
+  margin-top: 12px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.resultsHint {
+  text-align: center;
+  padding: 20px;
+  font-size: 13px;
+  color: #8a94a6;
+}
+.resultRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 4px;
+  border-bottom: 1px solid #f0ece5;
+}
+.resultRow:last-child {
+  border-bottom: none;
+}
+.resultInfo {
+  min-width: 0;
+}
+.resultName {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a2133;
+}
+.resultMeta {
+  font-size: 12px;
+  color: #8a94a6;
+  margin-top: 2px;
+}
+.rowAction {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  font-size: 13px;
+  font-family: inherit;
+  color: #5a6478;
+  background: #fff;
+  border: 1px solid #ddd7ce;
+  border-radius: 6px;
+  padding: 5px 12px;
+  cursor: pointer;
+}
+.rowAction:hover {
+  background: #faf8f5;
+  border-color: #bbb5aa;
+  color: #1a2133;
+}
+
+.inlineError {
+  margin-top: 12px;
+  font-size: 13px;
+  color: #c0392b;
+}
+
+/* ---- Confirm dialog ---- */
+.confirmBody {
+  font-size: 13px;
+  line-height: 1.6;
+  color: #1a2133;
+}
+
+/* ---- Shared modal footer / buttons ---- */
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px;
+  border-top: 1px solid #e8e2d9;
+}
+.btnPrimary {
+  background: #1a2133;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+}
+.btnPrimary:hover {
+  background: #252d42;
+}
+.btnPrimary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btnCancel {
+  background: transparent;
+  color: #5a6478;
+  border: 1px solid #ddd7ce;
+  border-radius: 6px;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+}
+.btnCancel:hover {
+  background: #faf8f5;
+  border-color: #bbb5aa;
+  color: #1a2133;
+}
+.btnCancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ---- Amber impersonation banner ---- */
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  background: #fef3c7;
+  color: #92400e;
+  border-left: 4px solid #b45309;
+  border-radius: 6px;
+  padding: 10px 16px;
+  margin-bottom: 16px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.bannerText {
+  min-width: 0;
+}
+.bannerText strong {
+  font-weight: 600;
+}
+.bannerRole {
+  color: #92400e;
+}
+.bannerRight {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex: 0 0 auto;
+}
+.bannerExpires {
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: #92400e;
+}
+.bannerExit {
+  background: #1a2133;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+}
+.bannerExit:hover {
+  background: #252d42;
+}
+.bannerExit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/components/elements/Impersonation/ViewAsControls.tsx
+++ b/src/components/elements/Impersonation/ViewAsControls.tsx
@@ -1,0 +1,418 @@
+/**
+ * "View as" (impersonation) controls for the app shell.
+ *
+ * Mounted by AppLayout in the top-right user bar. The client learns impersonation
+ * state ONLY from session.data (via useSession()) — there is no separate state
+ * endpoint and the overlay cookie is HttpOnly:
+ *
+ *   - NOT impersonating: session.data is the real user. session.data.impersonating
+ *     is absent/falsey. The "View as…" entry shows only for Superusers.
+ *   - Impersonating: /api/auth/session is overlaid, so session.data carries the
+ *     TARGET's username/userRoles/databaseUser, PLUS impersonating:true,
+ *     realUser, realUserName, expiresAt (epoch seconds). The amber banner shows
+ *     and "Return to my view" exits.
+ *
+ * Server-only impersonation utils (src/utils/impersonation.ts, effectiveSession.ts)
+ * are NEVER imported here — role parsing is done inline from session.data.userRoles,
+ * the same way other client components do it.
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useSession } from 'next-auth/client';
+import { Modal } from 'react-bootstrap';
+import { reciterConfig } from '../../../../config/local';
+import styles from './ViewAsControls.module.css';
+
+interface SearchRow {
+  userID: number;
+  personIdentifier: string;
+  nameFirst: string;
+  nameMiddle: string;
+  nameLast: string;
+  // search-users does not return a role label; kept optional so the UI can show
+  // it if a future row ever carries one.
+  roleLabel?: string;
+}
+
+interface ParsedRole {
+  roleLabel?: string;
+}
+
+// ---- inline role parsing (client-safe; mirrors existing components) ----
+function parseRoles(userRoles: unknown): ParsedRole[] {
+  if (!userRoles) return [];
+  try {
+    const parsed = typeof userRoles === 'string' ? JSON.parse(userRoles) : userRoles;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function isSuperuserRoles(userRoles: unknown): boolean {
+  return parseRoles(userRoles).some((r) => r && r.roleLabel === 'Superuser');
+}
+
+function primaryRoleLabel(userRoles: unknown): string {
+  const roles = parseRoles(userRoles);
+  const labels = roles.map((r) => (r && r.roleLabel ? r.roleLabel : '')).filter(Boolean);
+  if (labels.length === 0) return 'No role';
+  // Make the scoped-curator label readable, matching UsersTable's treatment.
+  return labels.map((l) => (l === 'Curator_Scoped' ? 'Curator — Scoped' : l)).join(', ');
+}
+
+function rowName(row: SearchRow): string {
+  return [row.nameFirst, row.nameLast].filter(Boolean).join(' ').trim() || row.personIdentifier;
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function formatRemaining(secondsLeft: number): string {
+  const safe = Math.max(0, secondsLeft);
+  const m = Math.floor(safe / 60);
+  const s = safe % 60;
+  return `${pad2(m)}:${pad2(s)}`;
+}
+
+const EyeIcon: React.FC = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    style={{ display: 'block' }}
+  >
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+// ============================================================================
+// Banner — shown while impersonating
+// ============================================================================
+const ImpersonationBanner: React.FC = () => {
+  const [session] = useSession();
+  const data: any = session?.data || {};
+
+  const targetName = useMemo(() => {
+    const du = data.databaseUser || {};
+    const name = [du.nameFirst, du.nameLast].filter(Boolean).join(' ').trim();
+    return name || data.username || 'this user';
+  }, [data]);
+
+  const targetRole = useMemo(() => primaryRoleLabel(data.userRoles), [data.userRoles]);
+  const realUserName: string = data.realUserName || data.realUser || 'you';
+  const expiresAt: number = Number(data.expiresAt) || 0;
+
+  const [remaining, setRemaining] = useState<number>(() =>
+    expiresAt ? Math.max(0, expiresAt - Math.floor(Date.now() / 1000)) : 0
+  );
+  const [exiting, setExiting] = useState(false);
+  const reloadedRef = useRef(false);
+
+  useEffect(() => {
+    if (!expiresAt) return undefined;
+    const tick = () => {
+      const left = Math.max(0, expiresAt - Math.floor(Date.now() / 1000));
+      setRemaining(left);
+      if (left <= 0 && !reloadedRef.current) {
+        // Cookie has (or is about to) expire — re-resolve the session.
+        reloadedRef.current = true;
+        window.location.reload();
+      }
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+
+  const handleReturn = async () => {
+    setExiting(true);
+    try {
+      await fetch('/api/impersonation', { method: 'DELETE' });
+    } catch {
+      // Even if the call fails, reload so the user isn't stuck; the cookie may
+      // already be cleared and the session will re-resolve to the real user.
+    }
+    window.location.reload();
+  };
+
+  return (
+    <div className={styles.banner} role="status" aria-live="polite">
+      <div className={styles.bannerText}>
+        Viewing as <strong>{targetName}</strong>
+        {targetRole ? <span className={styles.bannerRole}> · {targetRole}</span> : null}
+        {' — you are '}
+        <strong>{realUserName}</strong>. Changes are logged to you.
+      </div>
+      <div className={styles.bannerRight}>
+        {expiresAt ? (
+          <span className={styles.bannerExpires}>Expires in {formatRemaining(remaining)}</span>
+        ) : null}
+        <button
+          type="button"
+          className={styles.bannerExit}
+          onClick={handleReturn}
+          disabled={exiting}
+        >
+          {exiting ? 'Returning…' : 'Return to my view'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ============================================================================
+// Picker modal + confirm dialog
+// ============================================================================
+const ViewAsPicker: React.FC<{ show: boolean; onHide: () => void }> = ({ show, onHide }) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchRow[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [confirmTarget, setConfirmTarget] = useState<SearchRow | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!show) {
+      // Reset everything when the picker closes.
+      setQuery('');
+      setResults([]);
+      setSearching(false);
+      setSearchError(null);
+      setConfirmTarget(null);
+      setSubmitting(false);
+      setActionError(null);
+      if (searchTimer.current) {
+        clearTimeout(searchTimer.current);
+        searchTimer.current = null;
+      }
+    }
+  }, [show]);
+
+  const runSearch = (value: string) => {
+    setQuery(value);
+    setSearchError(null);
+    if (searchTimer.current) {
+      clearTimeout(searchTimer.current);
+    }
+    if (!value || value.trim().length < 2) {
+      setResults([]);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    searchTimer.current = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/db/admin/proxy/search-users?q=${encodeURIComponent(value.trim())}`,
+          { headers: { Authorization: reciterConfig.backendApiKey } }
+        );
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const raw = await res.json();
+        const rows: SearchRow[] = (Array.isArray(raw) ? raw : []).map((item: any) => ({
+          userID: item.userID,
+          personIdentifier: item.personIdentifier || '',
+          nameFirst: item.nameFirst || '',
+          nameMiddle: item.nameMiddle || '',
+          nameLast: item.nameLast || '',
+          roleLabel: item.roleLabel,
+        }));
+        setResults(rows);
+      } catch (err) {
+        console.error('[ViewAsControls] search error:', err);
+        setResults([]);
+        setSearchError('Could not search people. Please try again.');
+      } finally {
+        setSearching(false);
+      }
+    }, 300);
+  };
+
+  const startImpersonation = async (target: SearchRow) => {
+    setSubmitting(true);
+    setActionError(null);
+    try {
+      const res = await fetch('/api/impersonation', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetPersonIdentifier: target.personIdentifier }),
+      });
+      if (res.status === 200) {
+        // Re-resolve /api/auth/session to the target by reloading.
+        window.location.reload();
+        return;
+      }
+      let message = 'Could not start View as. Please try again.';
+      if (res.status === 400) message = 'You cannot view as this user.';
+      else if (res.status === 403) message = 'You cannot view as another superuser.';
+      else if (res.status === 404) message = 'That user was not found. They may not have signed in yet.';
+      else if (res.status === 422) message = 'That user has no email on record, so their access cannot be verified.';
+      try {
+        const body = await res.json();
+        if (body && body.error) message = body.error;
+      } catch {
+        /* keep default message */
+      }
+      setActionError(message);
+      setSubmitting(false);
+    } catch (err) {
+      console.error('[ViewAsControls] impersonation error:', err);
+      setActionError('Could not start View as. Please try again.');
+      setSubmitting(false);
+    }
+  };
+
+  const confirmName = confirmTarget ? rowName(confirmTarget) : '';
+
+  return (
+    <>
+      <Modal show={show && !confirmTarget} onHide={onHide} centered size="lg">
+        <Modal.Header closeButton>
+          <Modal.Title style={{ fontSize: 13, fontWeight: 600, color: '#1a2133' }}>
+            View as another user
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className={styles.pickerSubtitle}>
+            Search for a person to see Publication Manager exactly as they do.
+          </div>
+          <input
+            type="text"
+            className={styles.searchInput}
+            placeholder="Search by name or CWID…"
+            value={query}
+            autoFocus
+            onChange={(e) => runSearch(e.target.value)}
+          />
+
+          {searchError && <div className={styles.inlineError}>{searchError}</div>}
+
+          <div className={styles.results}>
+            {searching && <div className={styles.resultsHint}>Searching…</div>}
+            {!searching && query.trim().length >= 2 && results.length === 0 && !searchError && (
+              <div className={styles.resultsHint}>No users found matching your search.</div>
+            )}
+            {!searching && query.trim().length < 2 && (
+              <div className={styles.resultsHint}>Type at least 2 characters to search.</div>
+            )}
+            {results.map((row) => (
+              <div key={row.userID} className={styles.resultRow}>
+                <div className={styles.resultInfo}>
+                  <div className={styles.resultName}>{rowName(row)}</div>
+                  <div className={styles.resultMeta}>
+                    {row.roleLabel ? `${row.roleLabel} · ` : ''}
+                    {row.personIdentifier}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className={styles.rowAction}
+                  onClick={() => {
+                    setActionError(null);
+                    setConfirmTarget(row);
+                  }}
+                >
+                  View as
+                </button>
+              </div>
+            ))}
+          </div>
+        </Modal.Body>
+        <div className={styles.footer}>
+          <button type="button" className={styles.btnCancel} onClick={onHide}>
+            Cancel
+          </button>
+        </div>
+      </Modal>
+
+      {/* Confirm dialog */}
+      <Modal
+        show={show && !!confirmTarget}
+        onHide={() => !submitting && setConfirmTarget(null)}
+        centered
+        size="sm"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title style={{ fontSize: 13, fontWeight: 600, color: '#1a2133' }}>
+            View as {confirmName}?
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className={styles.confirmBody}>
+            You&apos;ll see Publication Manager exactly as {confirmName} does. Actions are applied as
+            them but logged to you.
+          </div>
+          {actionError && <div className={styles.inlineError}>{actionError}</div>}
+        </Modal.Body>
+        <div className={styles.footer}>
+          <button
+            type="button"
+            className={styles.btnCancel}
+            onClick={() => setConfirmTarget(null)}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={styles.btnPrimary}
+            onClick={() => confirmTarget && startImpersonation(confirmTarget)}
+            disabled={submitting}
+          >
+            {submitting ? 'Starting…' : `View as ${confirmName}`}
+          </button>
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+// ============================================================================
+// Entry control (the "View as…" trigger in the top bar)
+// ============================================================================
+export const ViewAsTrigger: React.FC = () => {
+  const [session] = useSession();
+  const [showPicker, setShowPicker] = useState(false);
+  const data: any = session?.data || {};
+
+  const impersonating = !!data.impersonating;
+  const realIsSuperuser = useMemo(() => isSuperuserRoles(data.userRoles), [data.userRoles]);
+
+  // Entry shows ONLY when the real user is a Superuser AND not already impersonating.
+  // While impersonating, session.data.userRoles is the target's, so this hides
+  // naturally; the banner's "Return to my view" is the exit.
+  if (impersonating || !realIsSuperuser) {
+    return null;
+  }
+
+  return (
+    <>
+      <button type="button" className={styles.trigger} onClick={() => setShowPicker(true)}>
+        <EyeIcon />
+        View as…
+      </button>
+      <ViewAsPicker show={showPicker} onHide={() => setShowPicker(false)} />
+    </>
+  );
+};
+
+// ============================================================================
+// Default export — banner only (mounted at top of content)
+// ============================================================================
+const ViewAsControls: React.FC = () => {
+  const [session] = useSession();
+  const data: any = session?.data || {};
+  if (!data.impersonating) return null;
+  return <ImpersonationBanner />;
+};
+
+export default ViewAsControls;

--- a/src/components/elements/Impersonation/ViewAsControls.tsx
+++ b/src/components/elements/Impersonation/ViewAsControls.tsx
@@ -137,10 +137,11 @@ const ImpersonationBanner: React.FC = () => {
     try {
       await fetch('/api/impersonation', { method: 'DELETE' });
     } catch {
-      // Even if the call fails, reload so the user isn't stuck; the cookie may
-      // already be cleared and the session will re-resolve to the real user.
+      // Even if the call fails, navigate away so the user isn't stuck; the cookie
+      // may already be cleared and the session will re-resolve to the real user.
     }
-    window.location.reload();
+    // Back to your own landing page (e.g. /search) rather than a target-specific URL.
+    window.location.href = '/';
   };
 
   return (
@@ -247,8 +248,11 @@ const ViewAsPicker: React.FC<{ show: boolean; onHide: () => void }> = ({ show, o
         body: JSON.stringify({ targetPersonIdentifier: target.personIdentifier }),
       });
       if (res.status === 200) {
-        // Re-resolve /api/auth/session to the target by reloading.
-        window.location.reload();
+        // Land the target on THEIR page: navigating to "/" runs index.js
+        // getServerSideProps, which (under the now-active overlay) routes to
+        // getLandingPageFromPermissions(target) — e.g. /curate/{pid} for a
+        // Curator_Self — instead of stranding you on a page the target can't see.
+        window.location.href = '/';
         return;
       }
       let message = 'Could not start View as. Please try again.';

--- a/src/components/layouts/AppLayout.jsx
+++ b/src/components/layouts/AppLayout.jsx
@@ -9,6 +9,7 @@ import styles from "./AppLayout.module.css";
 import NoAccess from "../elements/NoAccess/NoAccess";
 import Loader from "../elements/Common/Loader";
 import ToastContainerWrapper from "../elements/ToastContainerWrapper/ToastContainerWrapper";
+import ViewAsControls, { ViewAsTrigger } from "../elements/Impersonation/ViewAsControls";
 import { reciterConfig } from "../../../config/local";
 import { useDispatch } from "react-redux";
 import { clearPubSearchFilters, getAdminDepartments, getAdminRoles, notificationEmail } from "../../redux/actions/actions";
@@ -64,6 +65,7 @@ export const AppLayout = ({ children }) => {
       <div className={expandedNav ? styles.expandedSideBarContent : styles.nonExpandedSideBarContent}>
         {session?.data?.username && (
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8, marginBottom: 16 }}>
+            <ViewAsTrigger />
             <span style={{ fontSize: 13, color: '#6b6560', padding: '5px 12px', borderRadius: 20, background: '#f3f1ed' }}>{session.data.username}</span>
             <button
               type="button"
@@ -72,6 +74,7 @@ export const AppLayout = ({ children }) => {
             >Logout</button>
           </div>
         )}
+        <ViewAsControls />
         {children}
         <Footer />
         {reciterConfig?.showToasts ? <ToastContainerWrapper /> : null}

--- a/src/db/models/AdminFeedbackLog.ts
+++ b/src/db/models/AdminFeedbackLog.ts
@@ -5,6 +5,7 @@ import type { AdminUser, AdminUserId } from './AdminUser';
 export interface AdminFeedbackLogAttributes {
   feedbackID: number;
   userID?: number;
+  impersonatedByUserID?: number;
   personIdentifier?: string;
   articleIdentifier?: number;
   feedback?: string;
@@ -14,12 +15,13 @@ export interface AdminFeedbackLogAttributes {
 
 export type AdminFeedbackLogPk = "feedbackID";
 export type AdminFeedbackLogId = AdminFeedbackLog[AdminFeedbackLogPk];
-export type AdminFeedbackLogOptionalAttributes = "feedbackID" | "userID" | "personIdentifier" | "articleIdentifier" | "feedback" | "createTimestamp" | "modifyTimestamp";
+export type AdminFeedbackLogOptionalAttributes = "feedbackID" | "userID" | "impersonatedByUserID" | "personIdentifier" | "articleIdentifier" | "feedback" | "createTimestamp" | "modifyTimestamp";
 export type AdminFeedbackLogCreationAttributes = Optional<AdminFeedbackLogAttributes, AdminFeedbackLogOptionalAttributes>;
 
 export class AdminFeedbackLog extends Model<AdminFeedbackLogAttributes, AdminFeedbackLogCreationAttributes> implements AdminFeedbackLogAttributes {
   feedbackID!: number;
   userID?: number;
+  impersonatedByUserID?: number;
   personIdentifier?: string;
   articleIdentifier?: number;
   feedback?: string;
@@ -41,6 +43,14 @@ export class AdminFeedbackLog extends Model<AdminFeedbackLogAttributes, AdminFee
       primaryKey: true
     },
     userID: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'adminUsers',
+        key: 'userID'
+      }
+    },
+    impersonatedByUserID: {
       type: DataTypes.INTEGER,
       allowNull: true,
       references: {

--- a/src/db/models/init-models.ts
+++ b/src/db/models/init-models.ts
@@ -287,6 +287,7 @@ export function initModels(sequelize: Sequelize) {
   AdminPermissionResource.belongsTo(AdminPermission, { as: "permission", foreignKey: "permissionID" });
   AdminPermission.hasMany(AdminPermissionResource, { as: "adminPermissionResources", foreignKey: "permissionID" });
   AdminFeedbackLog.belongsTo(AdminUser, { as: "user", foreignKey: "userID"});
+  AdminFeedbackLog.belongsTo(AdminUser, { as: "impersonatedBy", foreignKey: "impersonatedByUserID"});
   AdminUser.hasMany(AdminFeedbackLog, { as: "adminFeedbackLogs", foreignKey: "userID"});
   AdminNotificationLog.belongsTo(AdminUser, { as: "user", foreignKey: "userID"});
   AdminUser.hasMany(AdminNotificationLog, { as: "adminNotificationLogs", foreignKey: "userID"});

--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -10,6 +10,13 @@ import { createAdminUser } from "../../../redux/actions/actions";
 import { reciterConfig } from "../../../../config/local";
 import { findOnePerson } from "../../../../controllers/db/person.controller";
 import { allowedPermissions } from "../../../utils/constants";
+import {
+    impersonationEnabled,
+    readOverlay,
+    isSuperuser,
+    IMPERSONATION_TTL_SECONDS,
+} from "../../../utils/impersonation";
+import { resolveEffectiveSessionData } from "../../../utils/effectiveSession";
 
 // Determine the condition for choosing the authentication method
 const isSamlEnabled = process.env.SAML_ENABLED === 'true';
@@ -17,7 +24,56 @@ const EMAIL ='email'
 const PERSONIDENTIFIER  = 'personIdentifier'
 
 
+const isSessionGet = (req) =>
+    req.method === 'GET' &&
+    Array.isArray(req.query?.nextauth) &&
+    req.query.nextauth[0] === 'session';
+
 const authHandler = async (req, res) => {
+    // "View as" overlay: when a Superuser has a live impersonation cookie,
+    // return the TARGET's session.data from GET /api/auth/session so every client
+    // useSession()/getSession() consumer (and SSR getSession(ctx)) sees the
+    // target transparently — no per-component change. Dark unless the flag is on.
+    // The next-auth JWT itself is never mutated (v3 can't mid-request); only this
+    // response body is rewritten. resolveEffectiveSessionData is awaited BEFORE
+    // NextAuth so the res.json patch stays synchronous.
+    if (impersonationEnabled() && isSessionGet(req)) {
+        const overlay = readOverlay(req);
+        if (overlay) {
+            let eff = null;
+            try {
+                eff = await resolveEffectiveSessionData(overlay.targetPersonIdentifier, overlay.targetEmail);
+            } catch (err) {
+                console.error('[impersonation] resolveEffectiveSessionData failed', err);
+            }
+            if (eff) {
+                const realJson = res.json.bind(res);
+                res.json = (body) => {
+                    // Re-check binding + Superuser against the REAL session body
+                    // (the JWT belongs to the real signed-in user): only overlay
+                    // when this overlay belongs to this user AND they are a Superuser.
+                    if (
+                        body && body.data &&
+                        body.data.username === overlay.realPersonIdentifier &&
+                        isSuperuser(body.data.userRoles)
+                    ) {
+                        const du = body.data.databaseUser || {};
+                        const realUserName =
+                            [du.nameFirst, du.nameLast].filter(Boolean).join(' ') || overlay.realPersonIdentifier;
+                        body.data = {
+                            ...body.data,
+                            ...eff,
+                            impersonating: true,
+                            realUser: overlay.realPersonIdentifier,
+                            realUserName,
+                            expiresAt: overlay.startedAt + IMPERSONATION_TTL_SECONDS,
+                        };
+                    }
+                    return realJson(body);
+                };
+            }
+        }
+    }
     await NextAuth(req, res, options);
 };
 
@@ -163,11 +219,17 @@ const options = {
                     const adminUser = await findOrCreateAdminUsers(credentials.username,credentials.email,credentials.firstName,credentials.lastName)
                     apiResponse.databaseUser = adminUser;
                     const assignedRoles = await grantDefaultRolesToAdminUser(adminUser)
-                    const userRoles = await findUserPermissions([EMAIL, PERSONIDENTIFIER], [credentials.email, credentials.username]);
+                    // Local login sends no email, but role/permission resolution keys on
+                    // (personIdentifier AND email). Resolve the email from the matched
+                    // admin_users row so roles load (otherwise the user lands on /noaccess).
+                    // Production uses SAML, not this direct_login provider, so this is local-dev only.
+                    const resolveEmail = (adminUser && (adminUser.email || adminUser.samlEmail)) || credentials.email || '';
+                    apiResponse.email = apiResponse.email || resolveEmail;
+                    const userRoles = await findUserPermissions([EMAIL, PERSONIDENTIFIER], [resolveEmail, credentials.username]);
                     apiResponse.userRoles = userRoles;
                     // Phase 15: Resolve permissions from DB tables
                     try {
-                        const enriched = await findUserPermissionsEnriched([EMAIL, PERSONIDENTIFIER], [credentials.email, credentials.username]);
+                        const enriched = await findUserPermissionsEnriched([EMAIL, PERSONIDENTIFIER], [resolveEmail, credentials.username]);
                         apiResponse.permissions = enriched.permissions;
                         apiResponse.permissionResources = enriched.permissionResources;
                     } catch(err) {

--- a/src/pages/api/db/admin/feedbacklog/create/index.ts
+++ b/src/pages/api/db/admin/feedbacklog/create/index.ts
@@ -1,12 +1,47 @@
 import { createFeedbackLog } from "../../../../../../../controllers/db/admin.feedbacklog.controller"
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { getToken } from 'next-auth/jwt'
 import { AdminFeedbackLog } from '../../../../../../db/models/AdminFeedbackLog'
 import { reciterConfig } from '../../../../../../../config/local'
+import { getEffectiveIdentity } from '../../../../../../utils/impersonation'
+import { findAdminUser } from '../../../../../../../controllers/db/admin.users.controller'
+
+/**
+ * Resolve the REAL superuser's numeric userID for audit attribution.
+ *
+ * This is a same-origin browser fetch, so the next-auth cookie AND the
+ * pm_impersonation cookie ride along on `req` even though the route also gates
+ * on the shared backendApiKey header. When a live overlay exists, the client
+ * sends the TARGET's userID (the overlay flips session.data.databaseUser.userID
+ * to the target). The one thing the client cannot know is the REAL superuser, so
+ * we resolve it server-side from the overlay and stamp impersonatedByUserID.
+ *
+ * Fully backward compatible: no cookie / server-to-server call → token is null →
+ * impersonatedByUserID stays null and the existing flow is untouched.
+ */
+async function resolveImpersonatedByUserID(req: NextApiRequest): Promise<number | null> {
+    try {
+        const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+        if (!token) return null;
+        const eff = getEffectiveIdentity(token, req);
+        if (!eff.impersonating || !eff.realPersonIdentifier) return null;
+        const realUser = await findAdminUser(['personIdentifier'], [eff.realPersonIdentifier]);
+        if (!realUser) return null;
+        const plain: any = realUser.get({ plain: true });
+        return plain?.userID ?? null;
+    } catch (e) {
+        console.log(e);
+        return null;
+    }
+}
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminFeedbackLog | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            // Stamp the REAL superuser for "logged to you" honesty; keep userID
+            // as the EFFECTIVE target (already set by the client overlay).
+            req.body.impersonatedByUserID = await resolveImpersonatedByUserID(req);
             await createFeedbackLog(req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/impersonation/index.ts
+++ b/src/pages/api/impersonation/index.ts
@@ -1,0 +1,131 @@
+/**
+ * "View as" (impersonation) start/stop — Superuser only.
+ *
+ *   POST   { targetPersonIdentifier }  → begin acting as the target (sets the signed overlay cookie)
+ *   DELETE                             → stop ("Return to my view"; clears the cookie)
+ *
+ * Gated by IMPERSONATION_ENABLED (off → 404, feature dark). The caller's session
+ * is read from the next-auth JWT; only Superusers pass. You cannot view-as
+ * yourself or another Superuser. The real superuser is recorded in the overlay so
+ * downstream actions stay "logged to you".
+ */
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+import { findUserPermissions } from '../../../../controllers/db/userroles.controller';
+import { findAdminUser } from '../../../../controllers/db/admin.users.controller';
+import {
+  IMPERSONATION_COOKIE,
+  IMPERSONATION_TTL_SECONDS,
+  impersonationEnabled,
+  canViewAs,
+  isSuperuser,
+  signOverlay,
+  nowSeconds,
+} from '../../../utils/impersonation';
+
+const EMAIL = 'email';
+const PERSONIDENTIFIER = 'personIdentifier';
+
+function setOverlayCookie(res: NextApiResponse, value: string, maxAgeSeconds: number): void {
+  const parts = [
+    `${IMPERSONATION_COOKIE}=${value}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${maxAgeSeconds}`,
+  ];
+  if (process.env.NODE_ENV === 'production') parts.push('Secure');
+  res.setHeader('Set-Cookie', parts.join('; '));
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  // Feature dark when the flag is off.
+  if (!impersonationEnabled()) {
+    res.status(404).end();
+    return;
+  }
+
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  if (!token || !token.username) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return;
+  }
+  if (!canViewAs(token)) {
+    res.status(403).json({ error: 'Not authorized' });
+    return;
+  }
+  const realPersonIdentifier = String(token.username);
+
+  // Stop impersonating.
+  if (req.method === 'DELETE') {
+    setOverlayCookie(res, '', 0);
+    res.status(200).json({ ok: true, impersonating: false });
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const targetPersonIdentifier = String(req.body?.targetPersonIdentifier || '').trim();
+    if (!targetPersonIdentifier) {
+      res.status(400).json({ error: 'targetPersonIdentifier is required' });
+      return;
+    }
+    if (targetPersonIdentifier === realPersonIdentifier) {
+      res.status(400).json({ error: 'You cannot view as yourself' });
+      return;
+    }
+
+    // Resolve the target's admin_users row. Role/scope resolution keys on
+    // personIdentifier + email, so we MUST use the email actually stored — never
+    // an empty fallback. Otherwise the superuser-target guard below could be
+    // bypassed: an empty email resolves zero roles, making isSuperuser() falsely
+    // return false and permitting a view-as of an actual Superuser. Fail closed.
+    let adminUser: any;
+    try {
+      adminUser = await findAdminUser([PERSONIDENTIFIER], [targetPersonIdentifier]);
+    } catch (err) {
+      console.error('[impersonation] target lookup failed', err);
+      res.status(502).json({ error: 'Could not verify target user' });
+      return;
+    }
+    if (!adminUser) {
+      res.status(404).json({ error: 'Target user not found' });
+      return;
+    }
+    const targetEmail = String(adminUser.email || '').trim();
+    if (!targetEmail) {
+      res.status(422).json({ error: 'Target has no email on record; cannot verify roles' });
+      return;
+    }
+
+    let targetRoles: unknown;
+    try {
+      targetRoles = await findUserPermissions([EMAIL, PERSONIDENTIFIER], [targetEmail, targetPersonIdentifier]);
+    } catch (err) {
+      console.error('[impersonation] target role resolution failed', err);
+      res.status(502).json({ error: 'Could not verify target user' });
+      return;
+    }
+    if (isSuperuser(targetRoles)) {
+      res.status(403).json({ error: 'You cannot view as another superuser' });
+      return;
+    }
+
+    const overlay = {
+      targetPersonIdentifier,
+      targetEmail,
+      realPersonIdentifier,
+      startedAt: nowSeconds(),
+    };
+    setOverlayCookie(res, signOverlay(overlay), IMPERSONATION_TTL_SECONDS);
+    res.status(200).json({
+      ok: true,
+      impersonating: true,
+      target: { personIdentifier: targetPersonIdentifier },
+      expiresInSeconds: IMPERSONATION_TTL_SECONDS,
+    });
+    return;
+  }
+
+  res.setHeader('Allow', 'POST, DELETE');
+  res.status(405).end();
+}

--- a/src/utils/checkCurationScope.ts
+++ b/src/utils/checkCurationScope.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest } from 'next'
 import { getToken } from 'next-auth/jwt'
 import { getCapabilities } from './constants'
 import { isPersonInScope, isProxyFor, ScopeData } from './scopeResolver'
+import { getEffectiveRolesScope } from './effectiveSession'
 import models from '../db/sequelize'
 
 interface ScopeCheckResult {
@@ -32,7 +33,11 @@ export async function checkCurationScope(
     return { allowed: false, status: 401, message: 'Not authenticated' }
   }
 
-  const roles = token.userRoles ? JSON.parse(token.userRoles as string) : []
+  // Effective roles/scope/proxy: the TARGET's when impersonating (faithful act-as),
+  // the REAL user's (read from the token, byte-identical to before) otherwise.
+  const effective = await getEffectiveRolesScope(token, req)
+
+  const roles = effective.userRoles
   const caps = getCapabilities(roles)
 
   // 1. Superuser / Curator_All — unrestricted
@@ -46,18 +51,14 @@ export async function checkCurationScope(
   }
 
   // 3. Proxy holder
-  const proxyPersonIds: string[] = token.proxyPersonIds
-    ? JSON.parse(token.proxyPersonIds as string)
-    : []
+  const proxyPersonIds: string[] = effective.proxyPersonIds
   if (isProxyFor(proxyPersonIds, targetUid)) {
     return { allowed: true }
   }
 
   // 4. Scoped curator — check against person's org unit and person types
   if (caps.canCurate.scoped) {
-    const scopeData: ScopeData = token.scopeData
-      ? JSON.parse(token.scopeData as string)
-      : null
+    const scopeData: ScopeData = effective.scopeData as ScopeData
 
     // Fail closed: a scoped curator with no configured scope can curate no one.
     // isPersonInScope treats a null/empty scope as "no restriction" (allow-all) —

--- a/src/utils/effectiveSession.ts
+++ b/src/utils/effectiveSession.ts
@@ -1,0 +1,261 @@
+/**
+ * "View as" (impersonation) — effective session resolver.
+ *
+ * Rebuilds the `session.data` payload the target user would have at login, so the
+ * next-auth `/api/auth/session` overlay (see `[...nextauth].jsx`) can return the
+ * TARGET's identity/roles/scope/permissions to every client `useSession()`
+ * consumer transparently. Mirrors the login-time `jwt` callback exactly — same
+ * resolver functions, same JSON-string serialization — so the body is
+ * byte-compatible with existing consumers (parseRoles, getCapabilities,
+ * checkCurationScope, usePermissions).
+ *
+ * Server-only (imports DB controllers) — never import into a client component.
+ */
+import { findAdminUser } from '../../controllers/db/admin.users.controller';
+import {
+  findUserPermissions,
+  findUserPermissionsEnriched,
+  findUserScope,
+} from '../../controllers/db/userroles.controller';
+import { getEffectiveIdentity, isSuperuser } from './impersonation';
+
+const EMAIL = 'email';
+const PERSONIDENTIFIER = 'personIdentifier';
+
+/** A login-shaped `session.data` slice for the impersonation target. */
+export interface EffectiveSessionData {
+  username: string;
+  email: string;
+  databaseUser: Record<string, unknown>;
+  /** JSON string of role objects (matches token.userRoles from login). */
+  userRoles: string;
+  /** JSON string (matches token.permissions from login). */
+  permissions: string;
+  /** JSON string (matches token.permissionResources from login). */
+  permissionResources: string;
+  /** JSON string (matches token.scopeData from login). */
+  scopeData: string;
+}
+
+/**
+ * Resolve the target's effective `session.data`, reproducing the login `jwt`
+ * callback for the target's (personIdentifier, email). Returns null when the
+ * target cannot be resolved OR is itself a Superuser — a read-time re-check of
+ * the start-time guard, so a stale overlay can never surface Superuser data.
+ */
+export async function resolveEffectiveSessionData(
+  targetPersonIdentifier: string,
+  targetEmail: string,
+): Promise<EffectiveSessionData | null> {
+  if (!targetPersonIdentifier) return null;
+
+  // Canonical admin_users row: authoritative email (role/scope queries key on
+  // it), name, status and userID. findAdminUser returns a Sequelize model.
+  let row: any;
+  try {
+    row = await findAdminUser([PERSONIDENTIFIER, EMAIL], [targetPersonIdentifier, targetEmail || '']);
+  } catch (err) {
+    console.error('[impersonation] effective admin_users lookup failed', err);
+    return null;
+  }
+  if (!row) return null;
+  const plain: any = typeof row.get === 'function' ? row.get({ plain: true }) : row;
+
+  // Use the email actually stored so role/scope resolution matches login.
+  const email = String(plain.email || targetEmail || '').trim();
+
+  // Roles — a JSON string, exactly as findUserPermissions returns and login stores.
+  let userRoles = '[]';
+  try {
+    userRoles = await findUserPermissions([EMAIL, PERSONIDENTIFIER], [email, targetPersonIdentifier]);
+  } catch (err) {
+    console.error('[impersonation] effective roles resolution failed', err);
+    return null;
+  }
+
+  // Read-time guard: never build an effective session for a Superuser target.
+  if (isSuperuser(userRoles)) return null;
+
+  let permissions: string[] = [];
+  let permissionResources: any[] = [];
+  try {
+    const enriched = await findUserPermissionsEnriched([EMAIL, PERSONIDENTIFIER], [email, targetPersonIdentifier]);
+    permissions = enriched.permissions;
+    permissionResources = enriched.permissionResources;
+  } catch (err) {
+    console.error('[impersonation] effective permissions resolution failed', err);
+  }
+
+  let scopeData: { personTypes: string[] | null; orgUnits: string[] | null } = {
+    personTypes: null,
+    orgUnits: null,
+  };
+  try {
+    scopeData = await findUserScope([EMAIL, PERSONIDENTIFIER], [email, targetPersonIdentifier]);
+  } catch (err) {
+    console.error('[impersonation] effective scope resolution failed', err);
+  }
+
+  // Mirror the login databaseUser shape (status gates AppLayout NoAccess; userID
+  // is read by feedbacklog/resolveCurator; name drives the header/banner).
+  const databaseUser = {
+    userID: plain.userID,
+    personIdentifier: plain.personIdentifier || targetPersonIdentifier,
+    nameFirst: plain.nameFirst,
+    nameMiddle: plain.nameMiddle,
+    nameLast: plain.nameLast,
+    email,
+    status: plain.status,
+    createTimestamp: plain.createTimestamp,
+    modifyTimestamp: plain.modifyTimestamp,
+  };
+
+  return {
+    username: targetPersonIdentifier,
+    email,
+    databaseUser,
+    userRoles,
+    permissions: JSON.stringify(permissions),
+    permissionResources: JSON.stringify(permissionResources),
+    scopeData: JSON.stringify(scopeData),
+  };
+}
+
+/** Curation scope axes — non-empty string[] or null per axis (null = no restriction). */
+export interface EffectiveScopeData {
+  personTypes: string[] | null;
+  orgUnits: string[] | null;
+}
+
+/**
+ * Effective roles/scope/proxy for the current request, normalized to native
+ * shapes regardless of whether the source is the (impersonating) TARGET resolved
+ * from DB or the REAL user read from the next-auth token.
+ */
+export interface EffectiveRolesScope {
+  /** EFFECTIVE personIdentifier (target when impersonating, else real). */
+  personIdentifier: string;
+  /** Always the REAL signed-in superuser's personIdentifier. */
+  realPersonIdentifier: string;
+  /** True while a live overlay is in effect. */
+  impersonating: boolean;
+  /** Parsed array of role objects (never a JSON string). */
+  userRoles: Array<{ roleLabel?: string }>;
+  /** Curation scope as a native object (never a JSON string). */
+  scopeData: EffectiveScopeData;
+  /** Array of person identifiers the effective user is a proxy for. */
+  proxyPersonIds: string[];
+}
+
+/** Parse a JSON column / JWT value that may already be an array or be a string. */
+function parseArray(value: unknown): any[] {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+/**
+ * Resolve the EFFECTIVE roles, scope and proxy set for server-side authorization.
+ *
+ * Faithful act-as: while impersonating, authz reflects the TARGET — roles, scope
+ * and proxy are resolved from the DB for the effective (personIdentifier, email),
+ * NOT the real superuser's. When NOT impersonating, the values are read from the
+ * next-auth token exactly as today's consumers do, so behavior is byte-identical.
+ *
+ * Normalization contract (callers can rely on native shapes):
+ *  - userRoles  → array  (findUserPermissions returns a STRING; token.userRoles is a STRING — both JSON.parsed)
+ *  - scopeData  → object (findUserScope returns an OBJECT; token.scopeData is a STRING — parsed when a string)
+ *  - proxyPersonIds → array (admin_users.proxy_person_ids may be a STRING or array; token.proxyPersonIds is a STRING)
+ *
+ * Server-only (resolves identity + reads DB controllers) — never call from client code.
+ */
+export async function getEffectiveRolesScope(
+  token: any,
+  req: any,
+): Promise<EffectiveRolesScope> {
+  const identity = getEffectiveIdentity(token, req);
+
+  if (identity.impersonating) {
+    // TARGET path: resolve roles/scope/proxy from the DB for the effective user.
+    const pid = identity.personIdentifier;
+    const email = identity.email || '';
+
+    // Roles — findUserPermissions returns a JSON STRING; parse to an array.
+    let userRoles: Array<{ roleLabel?: string }> = [];
+    try {
+      const rolesStr = await findUserPermissions([EMAIL, PERSONIDENTIFIER], [email, pid]);
+      userRoles = parseArray(rolesStr) as Array<{ roleLabel?: string }>;
+    } catch (err) {
+      console.error('[impersonation] effective roles (authz) resolution failed', err);
+      userRoles = [];
+    }
+
+    // Scope — findUserScope returns an OBJECT already; use as-is.
+    let scopeData: EffectiveScopeData = { personTypes: null, orgUnits: null };
+    try {
+      scopeData = await findUserScope([EMAIL, PERSONIDENTIFIER], [email, pid]);
+    } catch (err) {
+      console.error('[impersonation] effective scope (authz) resolution failed', err);
+      scopeData = { personTypes: null, orgUnits: null };
+    }
+
+    // Proxy — from the admin_users row's proxy_person_ids (STRING or array), else [].
+    let proxyPersonIds: string[] = [];
+    try {
+      const row: any = await findAdminUser([PERSONIDENTIFIER, EMAIL], [pid, email]);
+      const plain: any = row && typeof row.get === 'function' ? row.get({ plain: true }) : row;
+      proxyPersonIds = parseArray(plain?.proxy_person_ids).map(String);
+    } catch (err) {
+      console.error('[impersonation] effective proxy (authz) resolution failed', err);
+      proxyPersonIds = [];
+    }
+
+    return {
+      personIdentifier: pid,
+      realPersonIdentifier: identity.realPersonIdentifier,
+      impersonating: true,
+      userRoles,
+      scopeData,
+      proxyPersonIds,
+    };
+  }
+
+  // REAL path: read from the token exactly as the existing consumers do today.
+  // token.userRoles is a JSON STRING; token.scopeData is a JSON STRING;
+  // token.proxyPersonIds is a JSON STRING (today commonly absent → []).
+  const userRoles = parseArray(token?.userRoles) as Array<{ roleLabel?: string }>;
+
+  let scopeData: EffectiveScopeData = { personTypes: null, orgUnits: null };
+  const rawScope = token?.scopeData;
+  if (rawScope) {
+    if (typeof rawScope === 'string') {
+      try {
+        const parsed = JSON.parse(rawScope);
+        if (parsed && typeof parsed === 'object') scopeData = parsed;
+      } catch {
+        scopeData = { personTypes: null, orgUnits: null };
+      }
+    } else if (typeof rawScope === 'object') {
+      scopeData = rawScope as EffectiveScopeData;
+    }
+  }
+
+  const proxyPersonIds = parseArray(token?.proxyPersonIds).map(String);
+
+  return {
+    personIdentifier: identity.personIdentifier,
+    realPersonIdentifier: identity.realPersonIdentifier,
+    impersonating: false,
+    userRoles,
+    scopeData,
+    proxyPersonIds,
+  };
+}

--- a/src/utils/effectiveSession.ts
+++ b/src/utils/effectiveSession.ts
@@ -17,10 +17,98 @@ import {
   findUserPermissionsEnriched,
   findUserScope,
 } from '../../controllers/db/userroles.controller';
+import { findOnePerson } from '../../controllers/db/person.controller';
+import { findOneAdminSettings } from '../../controllers/db/admin.settings.controller';
+import sequelize from '../db/db';
 import { getEffectiveIdentity, isSuperuser } from './impersonation';
 
 const EMAIL = 'email';
 const PERSONIDENTIFIER = 'personIdentifier';
+
+/** Curate roles that mean "already provisioned" — if the target has any, we don't add Curator_Self. */
+const CURATE_ROLE_LABELS = ['Curator_All', 'Curator_Self', 'Curator_Scoped'];
+const CURATOR_SELF_ROLE_ID = 4;
+const CURATOR_ALL_ROLE_ID = 2;
+
+/**
+ * Compute the default roles a target WOULD receive at their own login
+ * (configured defaults from admin settings + Curator_Self for anyone in the
+ * person table), WITHOUT writing anything — a read-only, ephemeral mirror of the
+ * login-time `grantDefaultRolesToAdminUser`. Used so "View as" reflects the
+ * target's real post-login experience even if they've never signed in, while
+ * never mutating their account.
+ *
+ * Returns only the roles/permission keys NOT already present on the target.
+ */
+async function defaultRolesForTarget(
+  targetPersonIdentifier: string,
+  existingRoles: Array<{ roleLabel?: string; roleID?: number }>,
+): Promise<{ roles: Array<{ roleLabel: string; roleID: number; personIdentifier: string }>; permissionKeys: string[] }> {
+  const empty = { roles: [], permissionKeys: [] };
+  const existingLabels = new Set(existingRoles.map((r) => r?.roleLabel).filter(Boolean));
+  const existingIds = new Set(existingRoles.map((r) => r?.roleID).filter((v) => v != null));
+
+  // Configured default roleIds (admin_settings 'userRoles' → checked roles).
+  const candidateIds = new Set<number>();
+  try {
+    const settings: any = await findOneAdminSettings('userRoles');
+    if (settings && settings.viewAttributes) {
+      const va = JSON.parse(settings.viewAttributes);
+      (Array.isArray(va) ? va : []).forEach((attr: any) => {
+        (attr?.roles || []).forEach((role: any) => {
+          if (role?.isChecked && role?.roleId != null) candidateIds.add(Number(role.roleId));
+        });
+      });
+    }
+  } catch (err) {
+    console.error('[impersonation] default-role settings read failed', err);
+  }
+
+  // Curator_Self if the target is a person and has no curate role yet
+  // (and the configured defaults don't already include Curator_All).
+  let isPerson = false;
+  try {
+    const person: any = await findOnePerson([PERSONIDENTIFIER], [targetPersonIdentifier]);
+    isPerson = !!(person && person.personIdentifier);
+  } catch (err) {
+    console.error('[impersonation] default-role person check failed', err);
+  }
+  const hasCurateRole = [...existingLabels].some((l) => CURATE_ROLE_LABELS.includes(l as string));
+  if (isPerson && !hasCurateRole && !candidateIds.has(CURATOR_ALL_ROLE_ID)) {
+    candidateIds.add(CURATOR_SELF_ROLE_ID);
+  }
+
+  const newIds = [...candidateIds].filter((id) => !existingIds.has(id));
+  if (!newIds.length) return empty;
+
+  // Fetch labels + permission keys for the net-new roles (read-only).
+  let rows: any[] = [];
+  try {
+    rows = await sequelize.query(
+      `SELECT ar.roleID, ar.roleLabel, p.permissionKey
+       FROM admin_roles ar
+       LEFT JOIN admin_role_permissions arp ON ar.roleID = arp.roleID
+       LEFT JOIN admin_permissions p ON arp.permissionID = p.permissionID
+       WHERE ar.roleID IN (:ids)`,
+      { replacements: { ids: newIds }, raw: true, nest: true },
+    );
+  } catch (err) {
+    console.error('[impersonation] default-role label/permission lookup failed', err);
+    return empty;
+  }
+
+  const roleMap = new Map<number, { roleLabel: string; roleID: number; personIdentifier: string }>();
+  const permKeys = new Set<string>();
+  for (const r of rows) {
+    if (r.roleLabel && !roleMap.has(r.roleID)) {
+      roleMap.set(r.roleID, { roleLabel: r.roleLabel, roleID: r.roleID, personIdentifier: targetPersonIdentifier });
+    }
+    if (r.permissionKey) permKeys.add(r.permissionKey);
+  }
+  // Don't duplicate a roleLabel the target already has.
+  const roles = [...roleMap.values()].filter((r) => !existingLabels.has(r.roleLabel));
+  return { roles, permissionKeys: [...permKeys] };
+}
 
 /** A login-shaped `session.data` slice for the impersonation target. */
 export interface EffectiveSessionData {
@@ -96,6 +184,22 @@ export async function resolveEffectiveSessionData(
     console.error('[impersonation] effective scope resolution failed', err);
   }
 
+  // Ephemeral default roles: reflect what the target would have AFTER their own
+  // login (Curator_Self for a person + configured defaults), WITHOUT writing to
+  // the DB. This function only runs under an active overlay, so this only ever
+  // augments the impersonation target — never the real user.
+  let rolesArr: Array<{ roleLabel?: string; roleID?: number }> = [];
+  try {
+    const parsed = JSON.parse(userRoles);
+    rolesArr = Array.isArray(parsed) ? parsed : [];
+  } catch {
+    rolesArr = [];
+  }
+  const def = await defaultRolesForTarget(targetPersonIdentifier, rolesArr);
+  if (def.roles.length) rolesArr = [...rolesArr, ...def.roles];
+  if (def.permissionKeys.length) permissions = [...new Set([...permissions, ...def.permissionKeys])];
+  const userRolesOut = JSON.stringify(rolesArr);
+
   // Mirror the login databaseUser shape (status gates AppLayout NoAccess; userID
   // is read by feedbacklog/resolveCurator; name drives the header/banner).
   const databaseUser = {
@@ -114,7 +218,7 @@ export async function resolveEffectiveSessionData(
     username: targetPersonIdentifier,
     email,
     databaseUser,
-    userRoles,
+    userRoles: userRolesOut,
     permissions: JSON.stringify(permissions),
     permissionResources: JSON.stringify(permissionResources),
     scopeData: JSON.stringify(scopeData),
@@ -196,6 +300,15 @@ export async function getEffectiveRolesScope(
     } catch (err) {
       console.error('[impersonation] effective roles (authz) resolution failed', err);
       userRoles = [];
+    }
+
+    // Ephemeral default roles (same read-only logic as the session overlay) so
+    // server-side authorization matches what the target would have after login.
+    try {
+      const def = await defaultRolesForTarget(pid, userRoles as Array<{ roleLabel?: string; roleID?: number }>);
+      if (def.roles.length) userRoles = [...userRoles, ...def.roles];
+    } catch (err) {
+      console.error('[impersonation] effective default-roles (authz) failed', err);
     }
 
     // Scope — findUserScope returns an OBJECT already; use as-is.

--- a/src/utils/impersonation.ts
+++ b/src/utils/impersonation.ts
@@ -1,0 +1,137 @@
+/**
+ * "View as" (impersonation) — the effective-identity seam.
+ *
+ * A Superuser can temporarily act as another PM user. The overlay lives in a
+ * signed, HTTP-only `pm_impersonation` cookie, kept SEPARATE from the next-auth
+ * JWT (next-auth v3 can't mutate the session token mid-request). This module is
+ * the ONE place "who am I acting as" is decided: render, role/scope resolution,
+ * and data fetching read `getEffectiveIdentity`. Only audit attribution, the
+ * banner, and the start/stop guard read the *real* identity.
+ *
+ * The whole feature is gated by IMPERSONATION_ENABLED (default off): when off,
+ * any overlay cookie is ignored entirely, so the feature lands dark.
+ *
+ * Server-only (imports jsonwebtoken) — do not import into client components.
+ */
+import jwt from 'jsonwebtoken';
+
+export const IMPERSONATION_COOKIE = 'pm_impersonation';
+
+/** Read-time TTL (seconds). Default 30 min. The overlay is ignored once expired, regardless of the cookie's own Max-Age. */
+export const IMPERSONATION_TTL_SECONDS = Number(process.env.IMPERSONATION_TTL_SECONDS ?? 1800);
+
+export const SUPERUSER_ROLE = 'Superuser';
+
+export interface ImpersonationOverlay {
+  /** CWID being acted as. */
+  targetPersonIdentifier: string;
+  /** Target's email — needed downstream to resolve the target's roles/scope (keyed on pid + email). */
+  targetEmail: string;
+  /** The real superuser who started this. Binds the overlay to its owner and attributes actions ("logged to you"). */
+  realPersonIdentifier: string;
+  /** Epoch seconds when impersonation started. */
+  startedAt: number;
+}
+
+export interface EffectiveIdentity {
+  personIdentifier: string;
+  email: string;
+  /** True while a live overlay is in effect. */
+  impersonating: boolean;
+  /** The real signed-in superuser (=== personIdentifier when not impersonating). */
+  realPersonIdentifier: string;
+}
+
+type ReqLike = { cookies?: Record<string, string | undefined> };
+/** A next-auth JWT is an index type; accept it loosely. */
+type TokenLike = Record<string, unknown> | null | undefined;
+
+/** Current time in epoch seconds. */
+export function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/** Whether the feature is enabled at all (default off). */
+export function impersonationEnabled(): boolean {
+  return process.env.IMPERSONATION_ENABLED === 'true';
+}
+
+function secret(): string {
+  return process.env.NEXTAUTH_SECRET || '';
+}
+
+/** Sign an overlay into the cookie value (HS256, sharing the next-auth secret). */
+export function signOverlay(overlay: ImpersonationOverlay): string {
+  return jwt.sign(overlay, secret(), { algorithm: 'HS256' });
+}
+
+/** Verify + decode a cookie value into an overlay, or null if invalid/forged. */
+export function verifyOverlay(value: string | undefined | null): ImpersonationOverlay | null {
+  if (!value) return null;
+  try {
+    const decoded = jwt.verify(value, secret(), { algorithms: ['HS256'] }) as ImpersonationOverlay;
+    if (!decoded || !decoded.targetPersonIdentifier || !decoded.realPersonIdentifier) return null;
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether an overlay is live: flag on AND present AND within TTL. Strict `>` → expires exactly at startedAt + TTL. */
+export function overlayActive(overlay: ImpersonationOverlay | null, now: number = nowSeconds()): boolean {
+  return impersonationEnabled() && !!overlay && overlay.startedAt + IMPERSONATION_TTL_SECONDS > now;
+}
+
+/** Read + verify the overlay from a request's cookies. Null when flag-off, absent, malformed, or expired. */
+export function readOverlay(req: ReqLike, now: number = nowSeconds()): ImpersonationOverlay | null {
+  if (!impersonationEnabled()) return null;
+  const overlay = verifyOverlay(req?.cookies?.[IMPERSONATION_COOKIE]);
+  return overlayActive(overlay, now) ? overlay : null;
+}
+
+/**
+ * The single source of truth for "who am I acting as".
+ * Returns the impersonation target when a live overlay exists AND it belongs to
+ * this signed-in user (binding check); otherwise the real signed-in identity.
+ */
+export function getEffectiveIdentity(token: TokenLike, req: ReqLike, now: number = nowSeconds()): EffectiveIdentity {
+  const realPersonIdentifier = token?.username ? String(token.username) : '';
+  const realEmail = token?.email ? String(token.email) : '';
+  const overlay = readOverlay(req, now);
+  if (overlay && realPersonIdentifier && overlay.realPersonIdentifier === realPersonIdentifier) {
+    return {
+      personIdentifier: overlay.targetPersonIdentifier,
+      email: overlay.targetEmail || '',
+      impersonating: true,
+      realPersonIdentifier,
+    };
+  }
+  return {
+    personIdentifier: realPersonIdentifier,
+    email: realEmail,
+    impersonating: false,
+    realPersonIdentifier,
+  };
+}
+
+/** Parse a next-auth token's `userRoles` (a JSON string) into role objects. Tolerates arrays/strings/empty. */
+export function parseRoles(userRoles: unknown): Array<{ roleLabel?: string }> {
+  if (!userRoles) return [];
+  if (Array.isArray(userRoles)) return userRoles as Array<{ roleLabel?: string }>;
+  try {
+    const parsed = JSON.parse(String(userRoles));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Whether a roles value (array or JSON string) includes Superuser. */
+export function isSuperuser(userRoles: unknown): boolean {
+  return parseRoles(userRoles).some((r) => r?.roleLabel === SUPERUSER_ROLE);
+}
+
+/** Whether the real signed-in user may use "View as" (feature on AND superuser). */
+export function canViewAs(token: TokenLike): boolean {
+  return impersonationEnabled() && isSuperuser(token?.userRoles);
+}


### PR DESCRIPTION
## Summary

Superuser **"View as"** (full act-as) for Publication Manager, modeled on Scholars-Profile-System #637. Entirely behind `IMPERSONATION_ENABLED` (default **off** → the feature is dark and the app is unchanged when the flag is unset).

A Superuser can temporarily act as another (non-Superuser) PM user: the whole UI — menus, role gating, scope filtering, which person's data loads — resolves to the target, while actions remain **logged to the real Superuser**.

## How it works

- **Transparent seam (the crux):** identity lives in the next-auth v3 JWT, read client-side via `useSession()` across ~35 files. v3 can't mutate the JWT mid-session, so the overlay is a separate signed `pm_impersonation` cookie. When a live overlay exists, the custom `authHandler` rewrites the `GET /api/auth/session` response body to the **target's** resolved identity/roles/scope (owner-binding + Superuser re-checked) — so every client read reflects the target with **zero per-component changes**.
- **Server authorization** (`checkCurationScope`, authorships `resolveCurator`) resolves the **target's** roles/scope/proxy via `getEffectiveRolesScope` (faithful act-as); the audit identity (`curatedBy` / reviewer) stays the real Superuser.
- **Attribution:** new nullable `impersonatedByUserID` on `admin_feedback_log` (the real Superuser), resolved server-side from the overlay; `userID` stays the effective target → honest "logged to you".
- **UI:** `ViewAsControls` mounted in `AppLayout` — Superuser-gated "View as…" entry → people picker (reusing the existing `search-users` endpoint) → confirm dialog → amber banner with a live countdown and "Return to my view".

## Runtime verification (done)

Verified against a local dev server → dev RDS:
- ✅ Overlay fires: `POST /api/impersonation {did2005}` → `GET /api/auth/session` returns the **target** (`username:did2005`, `impersonating:true`, `realUser:paa2013`, `realUserName:"Paul Albert"`, `expiresAt` set); `DELETE` restores the real Superuser session.
- ✅ Superuser-target guard: `POST {drw2004}` → `403 "You cannot view as another superuser"`.
- ✅ Empty-email fail-closed guard: `POST {elc2013}` → `422 "Target has no email on record"`.

## ⚠️ Required before merge / deploy — schema in 3 places

The Sequelize model now references `impersonatedByUserID`, so the column must exist wherever this branch runs:
- ✅ **dev reciterDB (RDS)** — applied.
- ⬜ **prod reciterDB (RDS)** — apply `scripts/migrations/add-impersonated-by-feedbacklog.sql`.
- ⬜ **ReCiterDB repo schema** — add the column on **both** relevant branches.

(`ADD COLUMN ... INT DEFAULT NULL` is nullable and backward-compatible: the currently-deployed app's older model ignores it.)

## Notes / residual

- **Dup-data caveat:** some impersonated targets resolve `userRoles: []` due to the pre-existing duplicate-`admin_users`/email issue (role rows live on a row whose email ≠ the resolved one). This is **not** this PR's code — the resolver mirrors login's `findUserPermissions` exactly, and affected users also fail their own login role resolution.
- **Incidental fix included:** local `direct_login` now resolves roles from the matched `admin_users` row's email (fixes the local-dev `/noaccess` trap). Prod-safe — production uses SAML, not this provider.
- **Deferred (option-2 follow-up):** Edge `middleware.ts` route-gating still uses the real Superuser (direct-URL redirects aren't mirrored to the target); a faithful version needs an Edge-safe (jose) overlay verify.
- **Not yet done:** a roled-target flip demo (needs a clean-data curator CWID), a UI visual click-through, and unit tests (the project's node `__tests__/` aren't wired to a runnable jest config in this branch).

**Draft — do not merge** until the prod RDS + ReCiterDB schema steps land.

---

## Update — review fixes (redirect + ephemeral default roles)

Two follow-ups from testing, now included:

1. **Redirect to the target's landing.** Starting (and ending) "View as" now navigates to `/`, so the effective user lands on their own page via `getLandingPageFromPermissions` — e.g. a Curator_Self lands on `/curate/{pid}` instead of being stranded on an admin page that renders NoAccess.
2. **Ephemeral default roles (read-only).** A target who has no roles yet but exists in the `person` table now resolves with their configured defaults + Curator_Self (and matching permissions) for the impersonation **session only** — a read-only mirror of login's `grantDefaultRolesToAdminUser`, **never written to the DB**. Applied in both the session overlay and server-side authorization, so viewing-as a never-signed-in Curator_Self shows their tabs and lets them curate their own profile without mutating their account.

Verified: `POST /api/impersonation {ccole}` (a user with zero stored roles) → session resolves `['Reporter_All','Curator_Self']` with `canCurate`; `GET /` → redirect `/curate/ccole`; ccole's stored roles remain `[]` (no write). This also demonstrates the roled-target flip noted as "not yet done" above.
