### PR TITLE
fix(rbac): role-derived permission fallback + ungate profile/notifications

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -4,7 +4,7 @@
  * Tests verify:
  * - ROUTE_PERMISSIONS map completeness (MW-02)
  * - Permission-based route access via hasPermission (MW-01, MW-02)
- * - Baseline fallback for empty permissions (MW-03)
+ * - Role-derived fallback for empty permissions (MW-03)
  * - Self-only curator enforcement via role labels (MW-04)
  * - Landing page redirect via getLandingPageFromPermissions (MW-05)
  * - .git path blocking (403)
@@ -81,24 +81,27 @@ function createDecodedToken(
   }
 }
 
-// Role presets for readability
+// Role presets for readability.
+// Permission sets mirror the canonical RBAC seed (admin_role_permissions) in
+// docs/superpowers/plans/2026-04-14-data-driven-rbac.md — do NOT add keys a role
+// is not actually granted, or tests stop reflecting real route gating.
 const SUPERUSER_ROLES = [{ personIdentifier: 'su001', roleLabel: 'Superuser', roleID: 1 }]
 const SUPERUSER_PERMISSIONS = ['canManageUsers', 'canConfigure', 'canCurate', 'canReport', 'canSearch', 'canManageNotifications', 'canManageProfile']
 
 const CURATOR_ALL_ROLES = [{ personIdentifier: 'ca001', roleLabel: 'Curator_All', roleID: 2 }]
-const CURATOR_ALL_PERMISSIONS = ['canCurate', 'canSearch', 'canManageNotifications', 'canManageProfile']
+const CURATOR_ALL_PERMISSIONS = ['canCurate', 'canSearch']
 
 const REPORTER_ALL_ROLES = [{ personIdentifier: 'ra001', roleLabel: 'Reporter_All', roleID: 3 }]
-const REPORTER_ALL_PERMISSIONS = ['canReport', 'canSearch', 'canManageProfile']
+const REPORTER_ALL_PERMISSIONS = ['canReport', 'canSearch']
 
 const CURATOR_SELF_ROLES = [{ personIdentifier: 'cs001', roleLabel: 'Curator_Self', roleID: 4 }]
-const CURATOR_SELF_PERMISSIONS = ['canCurate', 'canManageNotifications', 'canManageProfile']
+const CURATOR_SELF_PERMISSIONS = ['canCurate']
 
 const CURATOR_SELF_REPORTER_ROLES = [
   { personIdentifier: 'cs001', roleLabel: 'Curator_Self', roleID: 4 },
   { personIdentifier: 'cs001', roleLabel: 'Reporter_All', roleID: 3 },
 ]
-const CURATOR_SELF_REPORTER_PERMISSIONS = ['canCurate', 'canSearch', 'canReport', 'canManageNotifications', 'canManageProfile']
+const CURATOR_SELF_REPORTER_PERMISSIONS = ['canCurate', 'canSearch', 'canReport']
 
 // -- Tests --
 
@@ -109,11 +112,11 @@ beforeEach(() => {
 })
 
 describe('ROUTE_PERMISSIONS map', () => {
-  test('Test 1: has exactly 7 entries matching the 7 matcher routes', () => {
-    const expectedRoutes = ['/manageusers', '/configuration', '/curate', '/report', '/search', '/notifications', '/manageprofile']
+  test('Test 1: has exactly the 5 permission-gated routes', () => {
+    const expectedRoutes = ['/manageusers', '/configuration', '/curate', '/report', '/search']
     const mapKeys = Object.keys(ROUTE_PERMISSIONS)
 
-    expect(mapKeys).toHaveLength(7)
+    expect(mapKeys).toHaveLength(5)
     expectedRoutes.forEach((route) => {
       expect(ROUTE_PERMISSIONS).toHaveProperty(route)
     })
@@ -123,8 +126,12 @@ describe('ROUTE_PERMISSIONS map', () => {
     expect(ROUTE_PERMISSIONS['/curate']).toBe('canCurate')
     expect(ROUTE_PERMISSIONS['/report']).toBe('canReport')
     expect(ROUTE_PERMISSIONS['/search']).toBe('canSearch')
-    expect(ROUTE_PERMISSIONS['/notifications']).toBe('canManageNotifications')
-    expect(ROUTE_PERMISSIONS['/manageprofile']).toBe('canManageProfile')
+    // /notifications and /manageprofile are intentionally NOT permission-gated
+    // (H1): the seed grants their keys to Superuser only, but the pages are
+    // exposed to Curator/Department roles, so they are gated by the self-only
+    // redirect block instead. Gating them here would lock those roles out.
+    expect(ROUTE_PERMISSIONS).not.toHaveProperty('/notifications')
+    expect(ROUTE_PERMISSIONS).not.toHaveProperty('/manageprofile')
   })
 })
 
@@ -280,6 +287,65 @@ describe('Baseline fallback (no permissions)', () => {
     const req = createMockRequest('/manageusers')
     const result = await middleware(req)
     expect(result.type).toBe('redirect')
+  })
+})
+
+describe('Empty permission set falls back to role matrix, not lockout (C1 regression)', () => {
+  // Simulates an environment where the RBAC permission tables are not seeded
+  // (or the login-time lookup failed): token.permissions is "[]". Privileged
+  // roles must still reach their routes via the role-derived fallback (MW-03),
+  // never get locked out.
+  test('Test 25: Superuser with empty permissions reaches /curate', async () => {
+    jwtDecode.mockReturnValue(createDecodedToken([], SUPERUSER_ROLES))
+    expect((await middleware(createMockRequest('/curate/anyone'))).type).toBe('next')
+  })
+
+  test('Test 26: Superuser with empty permissions reaches /manageusers', async () => {
+    jwtDecode.mockReturnValue(createDecodedToken([], SUPERUSER_ROLES))
+    expect((await middleware(createMockRequest('/manageusers'))).type).toBe('next')
+  })
+
+  test('Test 27: Superuser with empty permissions reaches /configuration', async () => {
+    jwtDecode.mockReturnValue(createDecodedToken([], SUPERUSER_ROLES))
+    expect((await middleware(createMockRequest('/configuration'))).type).toBe('next')
+  })
+
+  test('Test 28: Curator_All with empty permissions reaches /curate but not /manageusers', async () => {
+    jwtDecode.mockReturnValue(createDecodedToken([], CURATOR_ALL_ROLES))
+    expect((await middleware(createMockRequest('/curate/x'))).type).toBe('next')
+    expect((await middleware(createMockRequest('/manageusers'))).type).toBe('redirect')
+  })
+
+  test('Test 29: unknown role with empty permissions still gets baseline search/report', async () => {
+    jwtDecode.mockReturnValue(createDecodedToken([], [{ personIdentifier: 'u1', roleLabel: 'Unknown', roleID: 99 }]))
+    expect((await middleware(createMockRequest('/search'))).type).toBe('next')
+    expect((await middleware(createMockRequest('/report'))).type).toBe('next')
+    expect((await middleware(createMockRequest('/manageusers'))).type).toBe('redirect')
+  })
+})
+
+describe('Profile / notifications routes are not permission-gated (H1 regression)', () => {
+  // The canonical seed grants canManageNotifications/canManageProfile to
+  // Superuser only, but these routes are exposed to Curator roles. They must be
+  // gated only by the self-only-redirect block, not by ROUTE_PERMISSIONS.
+  test('Test 30: Curator_All reaches /manageprofile (not redirected)', async () => {
+    jwtDecode.mockReturnValue(createDecodedToken(CURATOR_ALL_PERMISSIONS, CURATOR_ALL_ROLES))
+    expect((await middleware(createMockRequest('/manageprofile'))).type).toBe('next')
+  })
+
+  test('Test 31: Curator_All reaches /notifications (not redirected)', async () => {
+    jwtDecode.mockReturnValue(createDecodedToken(CURATOR_ALL_PERMISSIONS, CURATOR_ALL_ROLES))
+    expect((await middleware(createMockRequest('/notifications'))).type).toBe('next')
+  })
+
+  test('Test 32: Curator_Self on own /manageprofile/cs001 is allowed', async () => {
+    jwtDecode.mockReturnValue(createDecodedToken(CURATOR_SELF_PERMISSIONS, CURATOR_SELF_ROLES))
+    expect((await middleware(createMockRequest('/manageprofile/cs001'))).type).toBe('next')
+  })
+
+  test('Test 33: Curator_Self on another user /manageprofile/other is redirected (self-only)', async () => {
+    jwtDecode.mockReturnValue(createDecodedToken(CURATOR_SELF_PERMISSIONS, CURATOR_SELF_ROLES))
+    expect((await middleware(createMockRequest('/manageprofile/other'))).type).toBe('redirect')
   })
 })
 

--- a/__tests__/permissionUtils.test.ts
+++ b/__tests__/permissionUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   hasPermission,
   getPermissionsFromRaw,
+  getPermissionsFromRoles,
   getLandingPageFromPermissions,
 } from '../src/utils/permissionUtils'
 
@@ -52,6 +53,46 @@ describe('getPermissionsFromRaw', () => {
 
   it('returns empty array for JSON string of non-array value', () => {
     expect(getPermissionsFromRaw('"just-a-string"')).toEqual([])
+  })
+})
+
+describe('getPermissionsFromRoles (role-derived fallback matrix)', () => {
+  it('maps Superuser to all seven permissions', () => {
+    const result = getPermissionsFromRoles([{ roleLabel: 'Superuser' }])
+    expect(result.sort()).toEqual(
+      ['canConfigure', 'canCurate', 'canManageNotifications', 'canManageProfile', 'canManageUsers', 'canReport', 'canSearch'].sort()
+    )
+  })
+
+  it('maps Curator_All to canCurate + canSearch', () => {
+    expect(getPermissionsFromRoles([{ roleLabel: 'Curator_All' }]).sort()).toEqual(['canCurate', 'canSearch'])
+  })
+
+  it('maps Curator_Self to canCurate only', () => {
+    expect(getPermissionsFromRoles([{ roleLabel: 'Curator_Self' }])).toEqual(['canCurate'])
+  })
+
+  it('maps Reporter_All to canReport + canSearch', () => {
+    expect(getPermissionsFromRoles([{ roleLabel: 'Reporter_All' }]).sort()).toEqual(['canReport', 'canSearch'])
+  })
+
+  it('unions and de-duplicates permissions across multiple roles', () => {
+    const result = getPermissionsFromRoles([{ roleLabel: 'Curator_Self' }, { roleLabel: 'Reporter_All' }])
+    expect(result.sort()).toEqual(['canCurate', 'canReport', 'canSearch'])
+  })
+
+  it('ignores unknown role labels', () => {
+    expect(getPermissionsFromRoles([{ roleLabel: 'Unknown' }])).toEqual([])
+  })
+
+  it('returns empty array for null / undefined / non-array input (defensive)', () => {
+    expect(getPermissionsFromRoles(null as any)).toEqual([])
+    expect(getPermissionsFromRoles(undefined as any)).toEqual([])
+    expect(getPermissionsFromRoles('nope' as any)).toEqual([])
+  })
+
+  it('skips role entries with no roleLabel', () => {
+    expect(getPermissionsFromRoles([{} as any, { roleLabel: 'Curator_All' }]).sort()).toEqual(['canCurate', 'canSearch'])
   })
 })
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,32 @@
+/**
+ * Node-environment Jest config for the root-level unit tests
+ * (middleware, permission/scope/capability helpers — no DOM).
+ *
+ * Component tests under __tests__/components/** require the jsdom
+ * environment and React Testing Library; they use jest.config.dom.js
+ * and are run separately (npm run test:dom).
+ *
+ * ts-jest runs in isolatedModules (transpile-only) mode: this repo is not
+ * tsc-clean, so per-file transpilation keeps the suite runnable without
+ * gating on unrelated pre-existing type errors.
+ */
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[jt]sx?$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  testMatch: ['<rootDir>/__tests__/*.test.ts'],
+  // Two pre-existing suites are excluded from the default green run (tracked on #735):
+  //   - capabilities.test.ts: legacy getCapabilities() (constants.js, phased out per D-08)
+  //     asserts scoped curation for Curator_Department_Delegate that the impl doesn't grant.
+  //   - checkCurationScope.test.ts: fails to load because person.controller.ts calls
+  //     models.Person.hasMany() at import time with no sequelize init — needs model mocking.
+  // Neither is related to the RBAC middleware fix in this PR. Run them explicitly to work on them.
+  testPathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/__tests__/capabilities.test.ts',
+    '<rootDir>/__tests__/checkCurationScope.test.ts',
+  ],
+  maxWorkers: '50%',
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "generate-models": "node ./src/db/scripts/generateModels.js"
+    "generate-models": "node ./src/db/scripts/generateModels.js",
+    "test": "jest --config jest.config.js",
+    "test:dom": "jest --config jest.config.dom.js"
   },
   "dependencies": {
     "@babel/runtime": "^7.17.8",
@@ -26,6 +28,8 @@
     "exceljs": "^4.3.0",
     "fs": "0.0.1-security",
     "handlebars": "^4.7.8",
+    "http-build-query": "^0.7.0",
+    "jsonwebtoken": "^8.5.1",
     "jwt-decode": "^3.1.2",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.45",
@@ -54,8 +58,6 @@
     "redux-devtools-extension": "^2.13.9",
     "redux-thunk": "^2.3.0",
     "reflect-metadata": "^0.1.13",
-    "http-build-query": "^0.7.0",
-    "jsonwebtoken": "^8.5.1",
     "saml2-js": "^3.0.1",
     "sequelize": "^6.9.0",
     "slick-carousel": "^1.8.1",
@@ -64,6 +66,7 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/http-build-query": "^0.7.3",
+    "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^8.5.5",
     "@types/next-redux-wrapper": "^3.0.0",
     "@types/node": "^16.11.6",
@@ -75,7 +78,9 @@
     "@types/validator": "^13.6.6",
     "eslint": "7.32.0",
     "eslint-config-next": "11.1.2",
+    "jest": "^29.7.0",
     "sequelize-auto": "^0.8.5",
+    "ts-jest": "^29.4.11",
     "typescript": "4.9.5"
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,17 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server'
 import jwt_decode from "jwt-decode"
-import { getPermissionsFromRaw, hasPermission, getLandingPageFromPermissions } from './utils/permissionUtils'
+import { getPermissionsFromRaw, getPermissionsFromRoles, hasPermission, getLandingPageFromPermissions } from './utils/permissionUtils'
 
-// MW-02: Route-to-permission lookup map
-// Every route in config.matcher must have a corresponding entry here.
+// MW-02: Route-to-permission lookup map.
+// Routes gated purely by a single permission key. NOTE: some matcher routes are
+// intentionally ABSENT here and gated by role instead, lower down:
+//   - /authorships              -> role-gated (Superuser / Curator_All)
+//   - /notifications, /manageprofile -> gated only by the self-only-redirect
+//       block. The canonical seed grants canManageNotifications/canManageProfile
+//       to Superuser only, but these pages are exposed to Curator/Department
+//       roles too (see SideNavbar), so gating them on a permission key here
+//       would lock those roles out — a regression vs. the prior role-based gate.
 export const ROUTE_PERMISSIONS: Record<string, string> = {
   '/manageusers': 'canManageUsers',
   '/configuration': 'canConfigure',
   '/curate': 'canCurate',
   '/report': 'canReport',
   '/search': 'canSearch',
-  '/notifications': 'canManageNotifications',
-  '/manageprofile': 'canManageProfile',
 }
 
 // Middleware matcher — UNCHANGED from original
@@ -51,9 +56,16 @@ export async function middleware(request: NextRequest) {
     // MW-01: Parse permissions from JWT
     let permissions = getPermissionsFromRaw(decoded.permissions)
 
-    // MW-03: Baseline fallback — every authenticated user can search and report
+    // MW-03: Fallback when the data-driven permission set is empty.
+    // An empty set means the permission tables were not seeded in this
+    // environment (or the login-time lookup failed) — NOT that the user is
+    // unprivileged. Derive permissions from role labels via the canonical seed
+    // matrix so privileged roles (Superuser, Curator_*, Reporter_All) are never
+    // locked out of /curate, /manageusers, /configuration, etc. Only if no
+    // known role matches do we fall back to the baseline search/report set.
     if (permissions.length === 0) {
-      permissions = ['canSearch', 'canReport']
+      const roleDerived = getPermissionsFromRoles(userRoles)
+      permissions = roleDerived.length > 0 ? roleDerived : ['canSearch', 'canReport']
     }
 
     const personIdentifier = userRoles[0]?.personIdentifier || null

--- a/src/utils/permissionUtils.ts
+++ b/src/utils/permissionUtils.ts
@@ -46,6 +46,55 @@ export function getPermissionsFromRaw(
 }
 
 /**
+ * Canonical role-label → permission-key matrix.
+ *
+ * This MUST stay in exact sync with the RBAC seed in
+ * docs/superpowers/plans/2026-04-14-data-driven-rbac.md (admin_role_permissions).
+ * It is used ONLY as a safety fallback by getPermissionsFromRoles() when the
+ * data-driven permission set is empty — e.g. the permission tables have not
+ * been seeded in this environment, or the login-time permission lookup failed —
+ * so that privileged roles are never locked out of routes they are entitled to.
+ */
+const ROLE_PERMISSION_FALLBACK: Record<string, string[]> = {
+  Superuser: [
+    'canCurate', 'canSearch', 'canReport',
+    'canManageUsers', 'canConfigure',
+    'canManageNotifications', 'canManageProfile',
+  ],
+  Curator_All: ['canCurate', 'canSearch'],
+  Curator_Self: ['canCurate'],
+  Curator_Scoped: ['canCurate', 'canSearch'],
+  Curator_Department: ['canCurate', 'canSearch'],
+  Curator_Department_Delegate: ['canCurate', 'canSearch'],
+  Reporter_All: ['canReport', 'canSearch'],
+}
+
+/**
+ * Derive a permission-key array from a user's role labels using the canonical
+ * seed matrix (ROLE_PERMISSION_FALLBACK).
+ *
+ * Safety fallback only — see the MW-03 fallback in src/middleware.ts. Returns
+ * the de-duplicated union of every matched role's permissions, or an empty
+ * array if no role matches (the caller then applies the baseline set).
+ *
+ * @param roles - User's roles array with { roleLabel }
+ * @returns De-duplicated permission key array
+ */
+export function getPermissionsFromRoles(
+  roles: Array<{ roleLabel?: string | null }> | null | undefined
+): string[] {
+  if (!roles || !Array.isArray(roles)) return []
+  const set = new Set<string>()
+  for (const role of roles) {
+    const keys = role && role.roleLabel ? ROLE_PERMISSION_FALLBACK[role.roleLabel] : undefined
+    if (keys) {
+      for (const key of keys) set.add(key)
+    }
+  }
+  return Array.from(set)
+}
+
+/**
  * Broader curate roles that override self-only detection.
  * A user with any of these roles is NOT a self-only curator,
  * even if they also have Curator_Self.

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}


### PR DESCRIPTION
## Why

Two **production-regression** fixes in the data-driven RBAC middleware (`src/middleware.ts`), surfaced by the review of this branch. Both bite when `dev_Upd_NextJS14SNode18` replaces the currently-live app — not the new feature code, but what the rewritten middleware does to existing users.

### C1 (was Critical) — empty permission set → privileged-user lockout
Route authorization now reads `decoded.permissions` (a JWT claim populated at login by a 4-table JOIN over `admin_permissions` / `admin_role_permissions` / `admin_permission_resources`). If those tables are **not seeded** in an environment — a fresh/DR stand-up, an un-run migration, or a transient DB error during login (`[...nextauth].jsx` sets `permissions = []` on throw) — the claim is `"[]"`. The old fallback then granted only `['canSearch','canReport']`, so **Superusers and Curators were redirected away from `/curate`, `/manageusers`, and `/configuration`.** Strictly worse than today's app, which gates the same routes on role labels always present in the JWT.

**Fix:** add `getPermissionsFromRoles()` — a role-label → permission-key fallback mirroring the canonical seed (`docs/superpowers/plans/2026-04-14-data-driven-rbac.md`) — applied when the data-driven set is empty. Privileged roles can never be locked out, and **seeded environments are unaffected**: a non-empty set bypasses the fallback, so intentional DB grants/revocations still win.

### H1 (was High) — `/manageprofile` + `/notifications` unreachable for Curator/Department roles
Gated on `canManageProfile` / `canManageNotifications`, which the seed grants to **Superuser only** — yet `SideNavbar` renders the links for `Department_user`, `Curator_Self`, `Curator_All`. Those users clicked a visible link and got bounced. **Fix:** remove both from `ROUTE_PERMISSIONS`; they stay gated by the existing self-only-redirect block (so `Curator_Self` is still confined to their own page), matching prior behavior.

## Fallback matrix (kept in sync with the seed)

| Role | Permissions |
|---|---|
| Superuser | all 7 |
| Curator_All / Curator_Scoped / Curator_Department / Curator_Department_Delegate | canCurate, canSearch |
| Curator_Self | canCurate |
| Reporter_All | canReport, canSearch |

## Tests
- Aligned the middleware fixtures with the **real seed** (they previously granted non-superusers `canManage*` keys the seed never gives, masking H1).
- Updated the `ROUTE_PERMISSIONS` map test (now 5 permission-gated routes; asserts `/notifications` + `/manageprofile` are intentionally absent).
- Added **C1 regression** (empty permissions + Superuser/Curator_All reach their routes; unknown role still gets baseline) and **H1 regression** (Curator_All reaches profile/notifications; Curator_Self self-redirect preserved).
- Added `getPermissionsFromRoles` unit tests.
- **Wired a runnable node jest config** (`jest.config.js` + `tsconfig.jest.json`, `npm test`) so these actually execute — addresses #735.

## Verification status
- ✅ **Unit tests pass:** `npm test` → **5 suites / 97 tests green**, including the new C1/H1 middleware regression cases and the `getPermissionsFromRoles` matrix. (jest/ts-jest now wired — previously there was no runner; see #735.)
- ✅ **Typecheck:** `tsc --noEmit` introduces no new errors on the changed source (the repo has pre-existing errors unrelated to this PR).
- ⚠️ **Not runtime-tested** against a live unseeded vs. seeded DB.
- ℹ️ Two pre-existing root suites (`capabilities.test.ts`, `checkCurationScope.test.ts`) are excluded from the default run and tracked on #735 — neither relates to this change.

## Relationship to the RBAC seeding work
This PR is the **fail-safe** so an unseeded environment can never lock users out. The complementary ops task — provisioning/seeding the permission tables in **prod reciterDB** and mirroring them into the **ReCiterDB repo** (the 3-places rule), plus confirming the intended `/manageprofile`+`/notifications` gating — is tracked in #739. Parallels the impersonation-column rollout in #733.

Scope: middleware authorization + the test runner. Does not touch the impersonation feature.