### PR TITLE
feat(ui): calm redesign — Inter typeface + navy button system

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,0 +1,353 @@
+# Publication Manager — Visual Style Guide
+
+The design source of truth for the ReCiter Publication Manager UI, describing the **"calm" redesign** as it actually ships on `/curate/[cwid]` and `/authorships`. A new contributor should be able to build `/search` (Find People) and `/report` from this document without reading the curate source.
+
+**Authoritative token source:** `styles/globals.css` `:root`. Where a value below is a CSS custom property (`--name`), that file wins. Where a value is a bare hex with no token, it is a component-level hardcode (the curator / authorship CSS Modules) that is the de-facto design language but *not* yet tokenized — see [Known drift](#known-drift--reconcile-before-next-ui-work) before relying on it.
+
+This guide is **descriptive of what ships today, not aspirational.** All numbers below were verified against `styles/globals.css`, `src/pages/_document.tsx`, `src/pages/_app.tsx`, and the shipped `*.module.css` files.
+
+---
+
+## Tech stack & styling architecture
+
+| Layer | Choice |
+|-------|--------|
+| Framework | Next.js (Pages Router), React 16, Redux + redux-thunk. package.json pins **Next ^12.2.5** (node_modules currently resolves 14.x). |
+| Styling | Global CSS + design tokens (`styles/globals.css`) + per-component CSS Modules. **No Tailwind, no shadcn.** |
+| Component libraries | **MUI 5** for complex inputs (Autocomplete, TextField, Popper, Paper, Tooltip, `styled`) · **react-bootstrap** for structural UI (Modal, Badge, Form.Check, Spinner, Dropdown) |
+| Icons | Inline SVG (custom `NavIcon` wrappers). `react-icons` is installed but not the preferred pattern. |
+| MUI theme | `src/pages/_app.tsx` — `palette.primary` = WCM red (`#b31b1b` / `#8c1515` / `#f5e6e6`), `shape.borderRadius` = **6**, `typography.fontFamily` = **Inter** stack (matches `--font-sans`). |
+
+Styling lives in three places, in priority order: (1) `globals.css` tokens + element/Bootstrap overrides, (2) the MUI theme in `_app.tsx`, (3) component `*.module.css` and inline `sx`/`style`. New work should prefer tokens; reach for a hardcode only to match an existing un-tokenized calm pattern.
+
+> **Library-leakage warning.** react-bootstrap `.btn-primary` and MUI defaults both surface **WCM red** unless overridden. New buttons must be re-skinned to the system — see [Buttons](#buttons) and [Known drift](#known-drift--reconcile-before-next-ui-work). The `/report` export buttons already do this (an `.exportBtn` class forcing navy `#1a2133`).
+
+---
+
+## Typography
+
+### Fonts — Inter, loaded via Google Fonts `<link>`
+
+**Inter is the single typeface** for both body and display. It is loaded with a plain Google Fonts `<link>` in `src/pages/_document.tsx`:
+
+```
+https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap
+```
+
+This is **not** `next/font`: package.json pins Next ^12 while node_modules resolves 14.x, so a `<link>` is used because it survives either resolution. Do not migrate to `next/font` without re-pinning Next.
+
+| Token | Value | Reality |
+|-------|-------|---------|
+| `--font-sans` | `'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif` | Body, UI, inputs, headings. |
+| `--font-display` | `'Inter', sans-serif` | Display headings (`h1`, `h3 strong`, person name). |
+| `--font-serif` | `var(--font-display)` | **Legacy alias** of `--font-display`, kept so old references resolve. Not a serif — it is Inter. |
+
+> **The Bootstrap reboot trap.** `bootstrap/dist/css/bootstrap.min.css` is imported in `_app.tsx` *after* `globals.css`, so its reboot would otherwise reset `body` to the Bootstrap default. `globals.css` defends against this two ways: it sets `--bs-body-font-family: var(--font-sans)` **and** `body { font-family: var(--font-sans) !important }`. Keep both — dropping either lets Bootstrap's font win on body text. (Verified: `getComputedStyle(body).fontFamily` resolves to Inter.)
+
+### Type roles in practice
+
+| Role | Size | Weight | Line height | Notes |
+|------|------|--------|-------------|-------|
+| Body / UI / inputs | 13px | 400 | 1.6 | `--font-sans` |
+| Label | 11px | 600 | 1.4 | |
+| Section title | 11px | 600 | 1.0 | UPPERCASE, letter-spacing **0.1em**, color `#8a94a6`, **no gray fill** |
+| `h1` (page) | 28px | 500 | — | `--font-display`, letter-spacing −0.02em, color `#1a2133`, `padding-bottom: 10px` |
+| `h3` (results-count line) | 14px | 600 | — | `--font-sans`, color `#1a2133` |
+| `h3 strong` (the number) | 22px | 600 | — | `--font-display`, color `#c0392b`, `margin-right: 4px` |
+| Person name (curate) | 20px | 600 | — | `--font-display`, color `--gray-900` |
+| Article title (card) | 14px | 600 | 1.45 | color `#1a2133` |
+
+**Weight policy:** for new work use only **400** (default) and **600** (emphasis). Inherited exceptions in existing code: **500** (the `h1` rule, navbar selected item, some MUI/feedback-value text) and **700** (legacy `UsersTable` headers — new headers use 11px / 600 / uppercase). Do not introduce new 500/700 usages.
+
+The `--font-size-*` token scale (`xs 12 · sm 14 · base 16 · lg 18 · xl 20 · 2xl 24`) exists but is **largely bypassed**; real components use literal `11 / 13 / 14 / 22 / 26 / 28px`. See [Known drift](#known-drift--reconcile-before-next-ui-work).
+
+---
+
+## Color
+
+### Warm content surfaces (tokens — the calm foundation)
+
+| Token | Hex | Use |
+|-------|-----|-----|
+| `--color-warm-bg` | `#f5f2ee` | Page background (`body`, set `!important`) |
+| `--color-warm-surface` | `#ffffff` | Cards, forms |
+| `--color-warm-border` | `#e8e2d9` | Card borders, section dividers |
+
+Additional warm values used pervasively in the curator/authorship CSS (not yet tokenized):
+
+| Role | Hex | Where |
+|------|-----|-------|
+| Muted fill | `#eeeae4` | `.form-control` bg, light tokens, photo placeholder, inactive surfaces |
+| Border (input) | `#ddd7ce` | `.form-control` border, MUI fieldset, card-action outlines |
+| Border (input, focus/hover) | `#bbb5aa` | `.form-control:focus`, hover outlines |
+| Subtle surface | `#faf8f5` | Controls bar, form footer, button hover bg |
+| Hairline divider | `#f0ece5` | Keyword-chip hover bg, faint internal rules |
+
+### Ink & text (curator hardcodes — the de-facto text scale)
+
+| Role | Hex | Use |
+|------|-----|-----|
+| Ink | `#1a2133` | Headings, body emphasis, CTAs, dark chrome, dark tokens, sidebar |
+| Body muted | `#5a6478` | Field labels, secondary text, authors line |
+| Hint / placeholder | `#8a94a6` | Field hints, input placeholders, section-title rule, meta dots |
+
+### One navy — chrome (tokens, authoritative)
+
+There is **one navy across the app**, `#1a2133`. (This resolves the old "two navies" drift — `--color-chrome` was previously `#1e2d3d`.)
+
+| Token | Hex | Use |
+|-------|-----|-----|
+| `--color-chrome` | `#1a2133` | Sidebar/header, CTAs, dark tokens, ink |
+| `--color-chrome-hover` | `#252d42` | Chrome hover |
+| `--color-chrome-border` | `#2a3350` | Chrome borders |
+| `--color-chrome-text` | `#a0aec0` | Chrome muted text |
+| `--color-chrome-text-bright` | `#e2e8f0` | Chrome bright text |
+
+### Accent blue (tokens, authoritative)
+
+| Token | Hex / value | Use |
+|-------|-------------|-----|
+| `--color-accent` | `#2563a8` | **Content links**, input focus ring, selected/target author, ProxyBadge, focused-card border |
+| `--color-accent-soft` | `rgba(37,99,168,0.1)` | `box-shadow: 0 0 0 3px …` focus rings, soft hover backgrounds |
+
+### Brand / primary (tokens)
+
+| Token | Hex | Use |
+|-------|-----|-----|
+| `--wcm-red` / `--color-primary` | `#b31b1b` | **Brand chrome only** — favicon, date-picker selection, legacy `.btn-primary.primary`/`.btn-danger`/`.wcm-primary-lg`. Reserved for true brand; **not** the content-link or CTA color. |
+| `--wcm-red-dark` / `--color-primary-dark` | `#8c1515` | Hover/active of the above |
+| `--wcm-red-light` / `--color-primary-light` | `#f5e6e6` | Tinted hover backgrounds, selected date span |
+
+### Semantic soft tints (the calm decision palette)
+
+The calm system uses **soft tint at rest → solid fill on hover/commit**. Used by the decision buttons, status chips, and tab counts.
+
+| State | Rest bg | Rest text | Solid (hover/commit) |
+|-------|---------|-----------|----------------------|
+| Success / Accept | `#dcfce7` | `#166534` | `#16a34a` (token `--color-success`) |
+| Danger / Reject | `#fee2e2` | `#991b1b` | `#dc2626` (token `--color-danger`) |
+| Warning | `#fef3c7` | `#92400e` | — |
+
+Token semantics also exist: `--color-success #16a34a` / `--color-success-light #dcfce7`; `--color-danger #dc2626` / `--color-danger-light #fef2f2`; `--color-warning #f59e0b` / `--color-warning-light #fef3c7`.
+
+### Badge colors (tokens)
+
+| | Background | Text |
+|---|---|---|
+| Blue | `--color-badge-blue-bg #eff6ff` | `--color-badge-blue-text #1d4ed8` |
+| Yellow | `--color-badge-yellow-bg #fefce8` | `--color-badge-yellow-text #a16207` |
+| Red | `--color-badge-red-bg #fef2f2` | `--color-badge-red-text #b91c1c` |
+
+### Gray scale (tokens, Tailwind-derived)
+
+`--gray-50 #f9fafb` · `100 #f3f4f6` · `200 #e5e7eb` · `300 #d1d5db` · `400 #9ca3af` · `500 #6b7280` · `600 #4b5563` · `700 #374151` · `800 #1f2937` · `900 #111827`. The grays survive mostly in legacy and Bootstrap-override contexts; new calm work prefers the warm palette and ink scale above.
+
+### Color-role budget (60 / 30 / 10)
+
+- **Dominant ~60%** — `#f5f2ee` warm bg / `#ffffff` surfaces.
+- **Secondary ~30%** — `#1a2133` chrome / `#eeeae4` muted / `#faf8f5` subtle.
+- **Accent ~10%** — `#2563a8` for links, focus rings, selected/target state, ProxyBadge.
+- **Semantic** — success/danger/warning soft tints for decisions and status only.
+
+---
+
+## Spacing
+
+8-point grid. All new spacing must be a multiple of 4.
+
+| Step | Value | Use |
+|------|-------|-----|
+| xs | 4px | Icon gaps, inline label padding, micro-gaps |
+| sm | 8px | Compact spacing, field-grid gap, controls-bar gap |
+| md | 16px | Default spacing, table-cell padding, evidence column gap |
+| lg | 24px | Section padding, page margins |
+| xl | 32px | Article-list horizontal padding |
+| 2xl | 48px | (reserved) |
+| 3xl | 64px | Empty-state vertical padding |
+
+Locked exceptions (do not "fix" to a pure multiple): **28px** horizontal padding on `formSection` / `searchFormContainer`; **20px** on `personHeader` and SideNavbar menu items; the **16px** dead-zone gap between the big Accept/Reject buttons.
+
+---
+
+## Radius & elevation
+
+### Radius standard (settled)
+
+- **6px** (`--radius-md`) for **cards and controls** — the default.
+- **8px** (`--radius-lg`) allowed **only** for large outer wrapper containers (e.g. a page-level filter shell, the person-photo frame).
+- **Pills** (`--radius-pill`, 999px) where intentional — multi-select tokens, dropdown trigger buttons, danger/outline buttons.
+- **5px** survives on `.form-control` and the MUI input `baseSx` (a near-6 legacy value; treat as control radius).
+
+| Token | Value | | Token | Value |
+|-------|-------|--|-------|-------|
+| `--radius-sm` | 4px | | `--shadow-sm` | `0 1px 2px 0 rgb(0 0 0 / .05)` |
+| `--radius-md` | 6px | | `--shadow-md` | `0 4px 6px -1px …, 0 2px 4px -2px …` |
+| `--radius-lg` | 8px | | `--shadow-lg` | `0 10px 15px -3px …, 0 4px 6px -4px …` |
+| `--radius-pill` | 999px | | `--shadow-xl` | `0 20px 25px -5px …, 0 8px 10px -6px …` |
+
+Calm cards are intentionally **flat** — `box-shadow: none` at rest, with a `0.5px solid #e8e2d9` hairline doing the elevation work. Shadows are reserved for floating layers (dropdown menus `--shadow-lg`, modals, popovers).
+
+---
+
+## Layout
+
+- `--header-height: 52px`
+- `--sidebar-width-expanded: 220px`
+- App shell is a full-height flex column (`#__next`, `100vh`, `overflow-y: scroll`); the content area scrolls. The dark navy sidebar is the brand chrome; there is no separate top header bar (brand lives in the sidebar, user info in the content area).
+
+---
+
+## Navigation model
+
+The **group curation surface has been retired.** Previously `/curate` was a multi-person queue (People / Org / Institution / Person-Type multi-select). Now:
+
+- **`/curate` redirects to `/search` (Find People).** `src/pages/curate/index.*` returns a `getServerSideProps` redirect (`destination: "/search"`, `permanent: false`). Curate an individual by going Find People → person → `/curate/[cwid]`, or via the Authorships review queue.
+- **The sidebar "Curate" item is a context indicator, not a destination queue.** It links to `/curate` (which bounces to Find People) and **highlights while you are on `/curate/[cwid]`** via a `startsWith('/curate')` active match in the sidebar. Treat it as "you are curating someone," not "open the curation queue."
+
+When building `/search`, this is the entry point into per-person curation — its row actions (Curate · Reports · Profile) lead to `/curate/[cwid]` and friends.
+
+---
+
+## Components
+
+### Buttons
+
+The calm button idiom is **soft tint at rest → solid fill on hover**, 6px or pill radius, compact, weights 400/600 only.
+
+| Class / pattern | Look |
+|-----------------|------|
+| **Navy CTA** (Create / Update / Save / Search / Export) | `#1a2133` bg, white text, 13px/600 — the canonical primary action. On `/report`, `.exportBtn` forces this navy (overriding Bootstrap's red `.btn-primary`). |
+| `.btn-warning` (secondary) | White bg, `#5a6478` text, `#ddd7ce` border, `--radius-md`, 14px; hover → `#faf8f5` bg / `#bbb5aa` border / `#1a2133` text |
+| `.btn-outline-secondary` | Warm border, `#5a6478` text, **pill**, 13px; hover → `#faf8f5` / `#bbb5aa` / `#1a2133` |
+| `.transparent-btn` | White, warm border, **pill**; hover → `--wcm-red-light` bg / red border + text (legacy brand hover) |
+| `.btn-danger` | WCM-red bg, **pill**, 13px/600, padding `6px 20px` (legacy brand button) |
+| `.btn-primary.primary`, `.wcm-primary-lg` | WCM red → `#8c1515` hover, `--radius-md` (legacy brand) |
+| `.text-btn`, `.transparent-button` | WCM red, underlined, transparent — text-only action |
+
+> When you need a primary action button, **use the navy CTA**, not raw `.btn-primary` (which is brand red). Brand-red buttons are legacy/brand-chrome only.
+
+### Decision buttons (Accept / Reject)
+
+The signature calm component, in the publication card.
+
+**Pending state — large, spaced, with a Fitts's-law dead zone** (`.bigActions`):
+- Two full-width buttons (`flex: 1`), `padding: 11px 24px`, 14px/500, `--radius-md`.
+- **Accept** (`.btnAcceptBig`): rest `#dcfce7` bg / `#166534` text / `#b7e4c7` border → hover solid `#16a34a` bg / white text.
+- **Reject** (`.btnRejectBig`): rest `#fee2e2` bg / `#991b1b` text / `#f3c4c4` border → hover solid `#dc2626` bg / white text.
+- Between them sits a **16px `.deadZone`** with a faint dashed centerline (`.deadZoneLine`, `1px dashed #ddd7ce`): big targets, but a fast double-click can't accidentally flip Accept ↔ Reject.
+- `:active { transform: scale(0.985) }` for a confident press.
+
+**Decided state — compact mirrored opposite-action + Undo** (`.cardActions` / `.cardActionsActioned`):
+- Small neutral-chrome buttons (white bg, `0.5px solid #ddd7ce`, `#5a6478`), hover `#faf8f5` / `#bbb5aa`.
+- Colored text only: `.btnAccept #1a7a4a` · `.btnReject #c0392b` · `.btnUndo #5a6478`. A decided card shows the *opposite* action plus **Undo** — you never re-press the action you already took.
+
+Keyboard: **A** = Accept, **R** = Reject, **E** = toggle evidence on the focused card.
+
+### Score tile (tier-shaded)
+
+Left-rail tile on each publication card (`.scoreTile`): 44px wide, `--radius-md`, `0.5px` border, number 17px/600 over a 9px/400 uppercase-ish label (`letter-spacing 0.05em`). Background and text are shaded by score tier:
+
+| Tier | bg | border | number | label |
+|------|----|--------|--------|-------|
+| High (`.scoreTileHigh`) | `#eaf3ee` | `#cfe5da` | `#0f6e56` | `#5dcaa5` |
+| Medium (`.scoreTileMedium`) | `#faf2e6` | `#ecd9bb` | `#92600a` | `#c9a25f` |
+| Low (`.scoreTileLow`) | `#fbeeee` | `#ecd0d0` | `#a33030` | `#cf8f8f` |
+
+### Feedback evidence — ranked list (replaces the old diverging bar chart)
+
+The per-attribute feedback scores render as a **ranked list: label · value · thin bar** (`.feedbackList`, a 3-column grid `minmax(120px,max-content) 40px minmax(0,1fr)`, gap `8px 16px`, 13px).
+
+- **Label** `.feedbackLabel` `#5a6478`; **value** `.feedbackValue` `#1a2133`/500, right-aligned; negative value `.feedbackValueNeg` `#c0392b`.
+- **Bar** `.feedbackBarTrack` is a 4px `#eeeae4` rail; `.feedbackBarFill` is `#1a2133` at 0.75 opacity; negative `.feedbackBarFillNeg` is `#c0392b`.
+- **Critical contract — fixed ±100 scale.** Bar width is computed against a constant `FEEDBACK_SCALE = 100` (`Publication.tsx`): `barPct = min(abs(value)/100 * 100, 100)`. Bars are **not** normalized per-card, so a bar of the same length means the same magnitude on every publication. Values beyond ±100 cap at full width. (Tooltip: a score of 100 = strong evidence *for* authorship, −100 = strong evidence *against*, near 0 = inconclusive.)
+
+This replaced the earlier diverging bar chart — do not reintroduce per-card normalization or a centered/diverging axis.
+
+### Article card
+
+`.articleCard`: white, **`0.5px solid #e8e2d9`**, **6px** radius, `box-shadow: none`, flex row. Focused (`.focused`): border `#2563a8` + `box-shadow 0 0 0 3px rgba(37,99,168,0.15)`. A 3px left **status strip** marks decided cards: accepted `#1D9E75`, rejected `#c0392b`. Highlighted/target author in the authors line: `#2563a8`/600.
+
+### Keyword chips (subtle, weight-tiered)
+
+Inferred-keyword chips (`.kwTag`): **transparent** background at rest, 6px radius, `padding 2px 7px`, 13px, `#2e3647`; hover fills `#f0ece5` / `#1a2133`. Tiered by salience: `.kwHigh` 600/`#1a2133`, `.kwMedium` 500, `.kwLow` `opacity 0.85` (→ 1 on hover). Quiet by design — no boxed fill at rest.
+
+### Form controls (`.form-control`)
+
+Warm style: bg `#eeeae4`, border `1px solid #ddd7ce`, radius **5px**, 13px, text `#1a2133`, padding `8px 12px`, `font-family: var(--font-sans)`. Focus → white bg, `#bbb5aa` border, **no box-shadow**. Placeholder `#8a94a6`.
+
+> Two focus treatments coexist by design: Bootstrap `.form-control` focuses to the warm `#bbb5aa` border (no ring); MUI inputs (via `baseSx`) focus to the **accent-blue** ring `#2563a8` + `rgba(37,99,168,0.1)` glow. Match whichever library the control uses.
+
+### MUI Autocomplete — mandatory `baseSx`
+
+Every new MUI Autocomplete/TextField uses this pattern (from `AddUser.tsx`) so inputs match:
+
+```ts
+const baseSx = {
+  '& .MuiOutlinedInput-root': {
+    padding: '4px 8px',
+    background: '#fff',
+    borderRadius: '5px',
+    fontSize: '13px',
+    fontFamily: 'inherit',
+    '& fieldset': { borderColor: '#ddd7ce', top: 0, '& legend': { display: 'none' } },
+    '&:hover fieldset': { borderColor: '#ddd7ce' },
+    '&.Mui-focused fieldset': {
+      borderColor: '#2563a8', borderWidth: '1px',
+      boxShadow: '0 0 0 3px rgba(37,99,168,0.1)',
+    },
+  },
+};
+```
+
+### Tokens / pills (multi-select chips)
+
+| Type | Background | Text | Border | Use |
+|------|-----------|------|--------|-----|
+| Dark token | `#1a2133` | `#fff` | none | Role pills, selected users |
+| Light token | `#eeeae4` | `#5a6478` | `1px solid #ddd7ce` | Department / scope / proxy-person pills |
+
+Both: pill radius, 13px/400, padding `4px 8px 4px 12px`, 16px circular-hover close button.
+
+### Dropdowns
+
+Trigger is a **pill button**: `#e8e4dc`/`#f3f1ed` bg, `#b0aca4`/`#d6d0c4` border, `#2c2a27` text, 14px, padding `6px 12px 6px 14px`. Open state darkens to `#e8e4dc`/`#b0aca4` and the chevron rotates 180° (0.15s). Menu: `--radius-lg`, `--shadow-lg`, `1px solid --color-warm-border`, `12px 0` padding (item padding lives on the items).
+
+### Modals (react-bootstrap)
+
+`z-index: 2055` (backdrop + dialog), `.modal.fade` transition disabled. Curator modals (e.g. GrantProxyModal) are centered, size `lg`, header 13px/600/`#1a2133`, footer navy "Save Changes" + transparent "Discard Changes".
+
+### Toasts (react-toastify)
+
+The accept/reject confirmation is an **undo toast** (`.undoToast`): a verb in semantic color — accepted `#166534`, rejected `#991b1b`, both 600 — followed by an Undo button (`.undoToastBtn`, navy `#1a2133` / white, hover `#2a3450`) on a navy chrome. Standard copy elsewhere: success "… Changes take effect on the user's next login."; error "Failed to … Please try again." Full copy deck lives in the UI-SPEC "Copywriting Contract."
+
+### Links
+
+`globals.css` styles content `<a>` as **accent blue** (`var(--color-accent)` `#2563a8`) → `--color-accent-dark`/hover treatment. WCM red is reserved for **true brand chrome only** (favicon, date-picker, legacy brand buttons), not content links. Curator hyperlinks (person names, breadcrumbs, row actions) are accent blue and now match the global `<a>`.
+
+### Date pickers
+
+`react-dates` (DateRangePicker) and `react-datepicker` (year picker) are themed to WCM red as brand chrome: selected day `#b31b1b`, selected/hovered span `#f5e6e6` bg / `#8c1515` text, `--radius-md` inputs. (On `/report`, the DatePicker "Clear" affordance is moving to `--color-accent` to stay on the content palette.)
+
+---
+
+## Known drift — reconcile before / during next UI work
+
+These are the genuinely-open inconsistencies remaining after the calm reconciliation. None are blocking, but each is a trap for new work. (The old "no webfont loaded," "two navies," and "accent untokenized" items are **resolved** and intentionally omitted.)
+
+1. **Ink-tone drift — in progress.** `#2c2a27` (near-black) appears in the shared dropdown/filter CSS (`.search-summary-buttons .btn-primary`, `.dropdown .btn-white`, and Report's `ChecboxSelect` `.ddItem`/`.ptLabel`/`.posLabel`) vs the `#1a2133` ink elsewhere. Being collapsed to `#1a2133` in this reconciliation pass.
+2. **Three+ reds — keep straight, don't consolidate blindly.** `--wcm-red #b31b1b` (brand chrome), `--color-danger #dc2626` (semantic danger / Reject-on-commit), `#c0392b` (heading number `h3 strong`, destructive text, required asterisks, negative feedback bars, rejected status strip), `--color-badge-red-text #b91c1c` (badge text). Each has a distinct job; document which is which rather than merging.
+3. **Type-scale tokens bypassed.** `--font-size-*` (12/14/16/18/20/24) is mostly unused; components use literal `11/13/14/22/26/28px`. Reconcile the token scale with the real set or stop publishing the unused tokens.
+4. **Library leakage.** react-bootstrap `.btn-primary` and MUI defaults default to **WCM red**. Any new primary button must be overridden to the system (navy CTA), the way `/report`'s `.exportBtn` is. Audit new buttons for un-skinned brand red.
+5. **Two control radii.** `.form-control` and the MUI `baseSx` ship at **5px** while the standard is 6px. Harmless, but unify when touching those files.
+
+---
+
+## Sources & how to extend
+
+- **Tokens (authoritative):** `styles/globals.css` `:root` + element/Bootstrap overrides.
+- **Webfont load:** `src/pages/_document.tsx` (Google Fonts `<link>` for Inter).
+- **MUI theme:** `src/pages/_app.tsx` (`createTheme`).
+- **Calm components:** `src/components/elements/Publication/Publication.module.css` (article card, score tile, feedback bars, decision buttons), `src/components/elements/CurateIndividual/CurateIndividual.module.css` (keyword chips, undo toast, tabs), `src/components/elements/Authorships/` (review queue), `src/components/elements/Navbar/SideNavbar.tsx` (chrome + Curate indicator).
+- **Design contract:** `.planning/phases/09-scoped-roles-and-proxy-ui/09-UI-SPEC.md` (copywriting deck, conditional-render logic, per-component specs).
+
+To add a value: define a `--token` in `globals.css` first, then reference it. Only hardcode to match an existing un-tokenized calm pattern, and prefer fixing the drift above over adding a new one. Verify visual changes with Playwright MCP (`browser_snapshot`) rather than screenshots.

--- a/src/components/elements/Common/PageHeader.module.css
+++ b/src/components/elements/Common/PageHeader.module.css
@@ -1,6 +1,6 @@
 .header {
   font-weight: 600;
-  color: var(--gray-900);
+  color: #1a2133;
   font-size: var(--font-size-2xl);
   font-family: var(--font-sans);
   padding-bottom: 10px;

--- a/src/components/elements/Common/Skeleton.module.css
+++ b/src/components/elements/Common/Skeleton.module.css
@@ -2,8 +2,8 @@
 /* Phase 1: UIBUG-03 -- replaces Loader spinner with content-shaped placeholders */
 
 .skeleton {
-  background-color: #e0e0e0;
-  background-image: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
+  background-color: #eeeae4;
+  background-image: linear-gradient(90deg, #eeeae4 25%, #faf8f5 50%, #eeeae4 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
   border-radius: 4px;
@@ -21,8 +21,8 @@
 
 .skeletonTableHeader {
   height: 40px;
-  background-color: rgba(46, 65, 79, 0.3);
-  background-image: linear-gradient(90deg, rgba(46, 65, 79, 0.3) 25%, rgba(46, 65, 79, 0.15) 50%, rgba(46, 65, 79, 0.3) 75%);
+  background-color: #eeeae4;
+  background-image: linear-gradient(90deg, #eeeae4 25%, #faf8f5 50%, #eeeae4 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
   border-radius: 4px;

--- a/src/components/elements/Common/Styles.module.css
+++ b/src/components/elements/Common/Styles.module.css
@@ -1,4 +1,4 @@
 .divider {
   opacity: 1;
-  background-color: var(--gray-200);
+  background-color: #e8e2d9;
 }

--- a/src/components/elements/CurateIndividual/CurateIndividual.module.css
+++ b/src/components/elements/CurateIndividual/CurateIndividual.module.css
@@ -233,26 +233,59 @@
 .kwTag {
   position: relative;
   display: inline-block;
-  background: rgb(245, 245, 245);
-  border-radius: 10px;
-  padding: 2px 14px;
-  font-size: 12px;
-  color: #5a6478;
+  background: transparent;
+  border-radius: 6px;
+  padding: 2px 7px;
+  font-size: 13px;
+  color: #2e3647;
   white-space: nowrap;
   cursor: default;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background 0.12s, color 0.12s;
 }
 
 .kwTag:hover {
-  background: #e8e8e8;
+  background: #f0ece5;
   color: #1a2133;
 }
 
 /* weight tiers */
 .kwHigh   { font-weight: 600; color: #1a2133; border-color: #ccc6bc; }
 .kwMedium { font-weight: 500; }
-.kwLow    { opacity: 0.7; }
+.kwLow    { opacity: 0.85; }
 .kwTag:hover { opacity: 1; }
+
+/* Undo toast (fired on accept/reject) */
+.undoToast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+}
+.undoToastVerbAccept { color: #166534; font-weight: 600; flex-shrink: 0; }
+.undoToastVerbReject { color: #991b1b; font-weight: 600; flex-shrink: 0; }
+.undoToastTitle {
+  color: #5a6478;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.undoToastBtn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: #1a2133;
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 5px 14px;
+  cursor: pointer;
+}
+.undoToastBtn:hover { background: #2a3450; }
 
 /* tooltip */
 .kwTip {
@@ -640,19 +673,61 @@
   font-weight: 600;
 }
 
-/* ── Keyboard hint bar ── */
+/* ── Keyboard shortcuts ("?" popover) ── */
 
-.kbdHint {
-  background: #f0f5fc;
-  border: 1px solid #c5d7f0;
-  border-left: none;
-  border-right: none;
-  padding: 7px 24px;
+.kbdHintRow {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 32px 0;
+}
+
+.kbdHintWrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.kbdHintBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  padding: 4px 0;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 400;
+  color: #8a94a6;
+  cursor: pointer;
+  transition: color 0.12s;
+}
+
+.kbdHintBtn:hover,
+.kbdHintBtn[aria-expanded="true"] {
+  color: #5a6478;
+}
+
+.kbdHintPopover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 180px;
+  padding: 12px 16px;
+  background: #fff;
+  border: 0.5px solid #e8e2d9;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(26, 33, 51, 0.12), 0 2px 8px rgba(26, 33, 51, 0.06);
+  font-size: 12px;
+  color: #5a6478;
+}
+
+.kbdHintPopover > span {
   display: flex;
   align-items: center;
-  gap: 16px;
-  font-size: 11.5px;
-  color: #3b6fb5;
+  gap: 4px;
 }
 
 .kbd {
@@ -662,12 +737,12 @@
   min-width: 20px;
   height: 18px;
   padding: 0 5px;
-  background: #fff;
-  border: 1px solid #a8c4e0;
-  border-radius: 3px;
+  background: #faf8f5;
+  border: 0.5px solid #ddd7ce;
+  border-radius: 4px;
   font-size: 10.5px;
   font-weight: 600;
-  color: #3b6fb5;
+  color: #5a6478;
   margin-right: 4px;
 }
 

--- a/src/components/elements/CurateIndividual/ReciterTabContent.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabContent.tsx
@@ -7,6 +7,7 @@ import Pagination from '../Pagination/Pagination';
 import { useSession } from "next-auth/client";
 import { curateSearchtextAction, reciterUpdatePublication, reciterFetchData } from "../../../redux/actions/actions";
 import { useDispatch, useSelector } from "react-redux";
+import { toast } from "react-toastify";
 import { RootStateOrAny } from "../../../types/redux";
 import styles from "./CurateIndividual.module.css";
 import CheckIcon from '@mui/icons-material/Check';
@@ -32,6 +33,8 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
   const [sort, setSort] = useState<string>("0")
   const [publications, setPublications] = useState<any>(props.publications);
   const [searchtextCarier, setSearchtextCarier] = useState<any>("");
+  const [showShortcuts, setShowShortcuts] = useState<boolean>(false);
+  const shortcutsRef = useRef<HTMLDivElement>(null);
 
   const [page, setPage] = useState(1)
   const [count, setCount] = useState(20)
@@ -110,7 +113,7 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
 
 
 
-  const handleUpdatePublication = (uid: string, pmid: number, userAssertion: string) => {
+  const handleUpdatePublication = (uid: string, pmid: number, userAssertion: string, articleOverride?: any) => {
     const userId = session?.data?.databaseUser?.userID;
     const request = {
       publications: [pmid],
@@ -129,14 +132,20 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
     // Always call the API
     dispatch(reciterUpdatePublication(uid, request));
 
-    // update user assertion of the publication
-    let updatedPublication = {};
-    let index = publications.findIndex(publication => publication.pmid === pmid);
-    if (index > -1) {
-      updatedPublication = {
-        ...publications[index],
-        userAssertion: userAssertion
-      };
+    // update user assertion of the publication. Prefer an explicitly-passed article
+    // (e.g. undo, where the card was already removed from the local list) so the parent
+    // always gets a full record to file into the destination queue — never an empty {}.
+    let updatedPublication: any = {};
+    if (articleOverride) {
+      updatedPublication = { ...articleOverride, userAssertion };
+    } else {
+      let index = publications.findIndex(publication => publication.pmid === pmid);
+      if (index > -1) {
+        updatedPublication = {
+          ...publications[index],
+          userAssertion: userAssertion
+        };
+      }
     }
 
     // Suggested tab: immediately remove actioned card and track for undo
@@ -144,12 +153,42 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
       const article = publications.find((p: any) => p.pmid === pmid);
       setPublications(prev => prev.filter((p: any) => p.pmid !== pmid));
       lastActioned.current = { pmid, prevState: 'NULL', article };
+      fireUndoToast(pmid, userAssertion, article);
     }
 
     // Update parent filteredData so clearing a filter reflects the change
     props.updatePublicationAssertion(updatedPublication, userAssertion, props.tabType);
     props.onAssertionChange?.(pmid, userAssertion);
   }
+
+  // Toast with an Undo affordance — the rolling queue removes the card on decision,
+  // so this is the catchable "you just did X — undo?" line. Reverts via the same path.
+  const fireUndoToast = (pmid: number, userAssertion: string, article: any) => {
+    const accepted = userAssertion === 'ACCEPTED';
+    const title = article?.articleTitle || article?.title || `PMID ${pmid}`;
+    const shortTitle = title.length > 60 ? title.slice(0, 60).trim() + '…' : title;
+    const toastId = `undo-${pmid}`;
+    const doUndo = () => {
+      if (isSuggested && article) {
+        setPublications((prev: any) =>
+          prev.some((p: any) => p.pmid === pmid) ? prev : [...prev, { ...article, userAssertion: 'NULL' }]
+        );
+      }
+      handleUpdatePublication(props.personIdentifier, pmid, 'NULL', article);
+      if (lastActioned.current?.pmid === pmid) lastActioned.current = null;
+      toast.dismiss(toastId);
+    };
+    toast(
+      <div className={styles.undoToast}>
+        <span className={accepted ? styles.undoToastVerbAccept : styles.undoToastVerbReject}>
+          {accepted ? 'Accepted' : 'Rejected'}
+        </span>
+        <span className={styles.undoToastTitle}>{shortTitle}</span>
+        <button type="button" className={styles.undoToastBtn} onClick={doUndo}>Undo</button>
+      </div>,
+      { toastId, autoClose: 6000 }
+    );
+  };
 
   const handleUpdatePublicationAll = (userAssertion: string) => {
     const userId = session?.data?.databaseUser?.userID;
@@ -242,7 +281,7 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
               : [...prev, { ...article, userAssertion: prevState }]
           );
         }
-        handleUpdatePublication(props.personIdentifier, undoPmid, prevState);
+        handleUpdatePublication(props.personIdentifier, undoPmid, prevState, article);
         lastActioned.current = null;
       } else if (key === 'e' && focusedPub) {
         e.preventDefault();
@@ -272,6 +311,25 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
     const el = document.querySelector(`[data-pmid="${focusedPub.pmid}"]`);
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }, [focusedIndex, isArticleTab]);
+
+  // Close the keyboard-shortcuts popover on click outside or Escape
+  useEffect(() => {
+    if (!showShortcuts) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (shortcutsRef.current && !shortcutsRef.current.contains(e.target as Node)) {
+        setShowShortcuts(false);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowShortcuts(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [showShortcuts]);
 
   if (!props.publications.length) {
     if (props.tabType === 'NULL') {
@@ -349,14 +407,30 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
         handleCountUpdate={handleCountUpdate}
       />
 
-      {/* Keyboard hint bar — Suggested tab only */}
+      {/* Keyboard shortcuts — behind a quiet "?" popover (handlers stay active regardless) */}
       {isArticleTab && (
-        <div className={styles.kbdHint}>
-          <span><span className={styles.kbd}>A</span> Accept</span>
-          <span><span className={styles.kbd}>R</span> Reject</span>
-          <span><span className={styles.kbd}>U</span> Undo last</span>
-          <span><span className={styles.kbd}>E</span> Toggle Evidence</span>
-          <span><span className={styles.kbd}>&uarr;</span><span className={styles.kbd}>&darr;</span> Navigate</span>
+        <div className={styles.kbdHintRow}>
+          <div className={styles.kbdHintWrap} ref={shortcutsRef}>
+            <button
+              type="button"
+              className={styles.kbdHintBtn}
+              aria-label="Keyboard shortcuts"
+              aria-expanded={showShortcuts}
+              onClick={() => setShowShortcuts((v) => !v)}
+            >
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" width="13" height="13"><circle cx="8" cy="8" r="6.5"/><path d="M6.3 6.2a1.7 1.7 0 113 .9c-.7.5-1.3.8-1.3 1.6M8 11.4v.05" strokeLinecap="round"/></svg>
+              Keyboard shortcuts
+            </button>
+            {showShortcuts && (
+              <div className={styles.kbdHintPopover}>
+                <span><span className={styles.kbd}>A</span> Accept</span>
+                <span><span className={styles.kbd}>R</span> Reject</span>
+                <span><span className={styles.kbd}>U</span> Undo last</span>
+                <span><span className={styles.kbd}>E</span> Toggle evidence</span>
+                <span><span className={styles.kbd}>&uarr;</span><span className={styles.kbd}>&darr;</span> Navigate</span>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/src/components/elements/CurateIndividual/ReciterTabs.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabs.tsx
@@ -61,29 +61,26 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
 
   const updatePublicationAssertion = (reciterArticle: any, userAssertion: string, prevUserAssertion: string) => {
     setFilteredData(prev => prev.map((tabData: any) => {
+      // Remove this pmid from every bucket, then add it once to the destination tab.
+      // Robust even when prevUserAssertion is stale (e.g. an undo fired from the Suggested
+      // tab for a card that already moved to Accepted): accept/reject/undo always land in
+      // the right queue, with accurate counts and no duplicates.
+      const without = tabData.data.filter((i: any) => i.pmid !== reciterArticle.pmid);
       if (tabData.value === userAssertion) {
-        return { ...tabData, data: [...tabData.data, reciterArticle], count: tabData.count + 1 };
+        return { ...tabData, data: [...without, reciterArticle], count: without.length + 1 };
       }
-      if (tabData.value === prevUserAssertion) {
-        const newData = tabData.data.filter((i: any) => i.pmid !== reciterArticle.pmid);
-        return { ...tabData, data: newData, count: Math.max(0, tabData.count - 1) };
-      }
-      return tabData;
+      return { ...tabData, data: without, count: without.length };
     }));
   }
 
   const updatePublicationAssertionBulk = (reciterArticles: any, userAssertion: string, prevUserAssertion: string) => {
     const pmids = new Set(reciterArticles.map((a: any) => a.pmid));
     setFilteredData(prev => prev.map((tabData: any) => {
+      const without = tabData.data.filter((i: any) => !pmids.has(i.pmid));
       if (tabData.value === userAssertion) {
-        return { ...tabData, data: [...tabData.data, ...reciterArticles], count: tabData.count + reciterArticles.length };
+        return { ...tabData, data: [...without, ...reciterArticles], count: without.length + reciterArticles.length };
       }
-      if (tabData.value === prevUserAssertion) {
-        const newData = tabData.data.filter((i: any) => !pmids.has(i.pmid));
-        const removed = tabData.data.length - newData.length;
-        return { ...tabData, data: newData, count: Math.max(0, tabData.count - removed) };
-      }
-      return tabData;
+      return { ...tabData, data: without, count: without.length };
     }));
   }
   const handleUpdateSearchFilters = (pubFilters : any)=>{

--- a/src/components/elements/Dropdown/Dropdown.module.css
+++ b/src/components/elements/Dropdown/Dropdown.module.css
@@ -86,7 +86,7 @@
 .actionsItemPrimary {
   composes: actionsItem;
   font-weight: 500 !important;
-  color: #1e2d3d !important;
+  color: #1a2133 !important;
 }
 
 .actionsItem svg {
@@ -106,7 +106,7 @@
 .secondaryDropdownButton :global(.dropdown-menu) {
   background: #fff !important;
   border: 1px solid #d6d0c4 !important;
-  border-radius: 12px !important;
+  border-radius: 8px !important;
   box-shadow: 0 4px 20px rgba(26,33,51,0.14), 0 1px 4px rgba(26,33,51,0.07) !important;
   padding: 0 !important;
   overflow: hidden;
@@ -119,47 +119,47 @@
 
 /* Action buttons in table rows — dark style matching target */
 .secondaryDropdownButton button {
-  background-color: #1e2d3d !important;
+  background-color: #1a2133 !important;
   color: #ffffff !important;
-  border-color: #1e2d3d !important;
+  border-color: #1a2133 !important;
   font-size: 12px !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   font-family: var(--font-sans) !important;
   padding: 6px 12px !important;
   white-space: nowrap;
 }
 
 .secondaryDropdownButton button:first-child {
-  border-radius: 5px 0 0 5px !important;
+  border-radius: 6px 0 0 6px !important;
 }
 
 .secondaryDropdownButton button:hover {
-  background-color: #273848 !important;
-  border-color: #273848 !important;
+  background-color: #252d42 !important;
+  border-color: #252d42 !important;
   color: #ffffff !important;
 }
 
 .secondaryDropdownButton button:active {
-  background-color: #273848 !important;
-  border-color: #273848 !important;
+  background-color: #252d42 !important;
+  border-color: #252d42 !important;
   color: #ffffff !important;
 }
 
 .secondaryDropdownButton button:focus {
-  background-color: #1e2d3d !important;
-  border-color: #1e2d3d !important;
+  background-color: #1a2133 !important;
+  border-color: #1a2133 !important;
   color: #ffffff !important;
 }
 
 .secondaryDropdownButton a {
-  background-color: #273848 !important;
+  background-color: #252d42 !important;
   color: rgba(255,255,255,0.7) !important;
-  border-color: #1e2d3d !important;
+  border-color: #1a2133 !important;
   border-left: 1px solid rgba(255,255,255,0.12) !important;
 }
 
 .secondaryDropdownButton a:hover {
-  background-color: #2d3a52 !important;
+  background-color: #2a3350 !important;
   color: #ffffff !important;
 }
 

--- a/src/components/elements/Identity/Identity.module.css
+++ b/src/components/elements/Identity/Identity.module.css
@@ -14,7 +14,7 @@
 }
 
 .imgProps {
-    border: 0px solid var(--gray-300);
+    border: 0px solid #ddd7ce;
     max-height: 100%;
     max-width: 100%;
     border-radius: var(--radius-md);
@@ -44,6 +44,6 @@
 }
 
 .manageBtn {
-    border: 1px solid var(--gray-300);
+    border: 1px solid #ddd7ce;
     border-radius: var(--radius-md);
 }

--- a/src/components/elements/Manage/ManageUsers.module.css
+++ b/src/components/elements/Manage/ManageUsers.module.css
@@ -11,7 +11,7 @@
   font-weight: 600;
   font-size: 24px;
   letter-spacing: -0.02em;
-  color: #1a1a1a;
+  color: #1a2133;
 }
 
 .pageSubtitle {
@@ -25,7 +25,7 @@
   align-items: center;
   gap: 6px;
   padding: 8px 16px;
-  background: #1e2d3d;
+  background: #1a2133;
   color: #fff;
   border: none;
   border-radius: 8px;
@@ -39,7 +39,7 @@
 }
 
 .btnAdd:hover {
-  background: #273848;
+  background: #243050;
 }
 
 .btnAdd svg {

--- a/src/components/elements/Manage/ManageUsersTabs.tsx
+++ b/src/components/elements/Manage/ManageUsersTabs.tsx
@@ -25,11 +25,11 @@ const ManageUsersTabs: FunctionComponent = () => {
             fontFamily: '"Open Sans", sans-serif, Arial',
           },
           "& .Mui-selected": {
-            color: "#0d6efd !important",
+            color: "#2563a8 !important",
             fontWeight: 600,
           },
           "& .MuiTabs-indicator": {
-            backgroundColor: "#0d6efd",
+            backgroundColor: "#2563a8",
             height: "2px",
           },
         }}

--- a/src/components/elements/Manage/PermissionEditModal.tsx
+++ b/src/components/elements/Manage/PermissionEditModal.tsx
@@ -196,7 +196,7 @@ const PermissionEditModal: FunctionComponent<PermissionEditModalProps> = ({
               readOnly
               value={permissionKey}
               style={{
-                backgroundColor: "#e9ecef",
+                backgroundColor: "#eeeae4",
                 padding: "6px 12px",
               }}
             />
@@ -266,7 +266,7 @@ const PermissionEditModal: FunctionComponent<PermissionEditModalProps> = ({
             )}
           />
         </Form.Group>
-        <hr style={{ borderColor: "#ddd" }} />
+        <hr style={{ borderColor: "#ddd7ce" }} />
         <div
           style={{
             fontSize: "16px",
@@ -289,7 +289,7 @@ const PermissionEditModal: FunctionComponent<PermissionEditModalProps> = ({
           variant="link"
           onClick={handleAddResource}
           style={{
-            color: "#0d6efd",
+            color: "#2563a8",
             padding: 0,
             textDecoration: "none",
             fontSize: "14px",

--- a/src/components/elements/Manage/PermissionsTab.module.css
+++ b/src/components/elements/Manage/PermissionsTab.module.css
@@ -5,9 +5,11 @@
 }
 
 .categoryHeader td {
-    background-color: #f0f0f0;
+    background-color: transparent;
     font-weight: 600;
-    font-size: 14px;
-    color: #333333;
-    padding: 8px 16px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #8a94a6;
+    padding: 12px 16px 4px;
 }

--- a/src/components/elements/Manage/UsersTable.module.css
+++ b/src/components/elements/Manage/UsersTable.module.css
@@ -45,7 +45,7 @@
 .personName {
   font-size: 14px;
   font-weight: 500;
-  color: #2c4a7c;
+  color: #2563a8;
   margin-bottom: 1px;
   white-space: nowrap;
 }
@@ -101,7 +101,7 @@
   padding: 0;
   font-family: inherit;
   font-size: 12px;
-  color: #2c4a7c;
+  color: #2563a8;
   cursor: pointer;
   text-decoration: none;
 }

--- a/src/components/elements/Navbar/SideNavbar.tsx
+++ b/src/components/elements/Navbar/SideNavbar.tsx
@@ -223,12 +223,15 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
       isRequired:true
     },
     {
+      // The group curation surface is retired. This item highlights while you're on
+      // /curate/[cwid] (the startsWith('/curate') match in MenuListItem); clicking it
+      // routes to Find People to pick a person to curate.
       title: 'Curate Publications',
       to: '/curate',
       imgUrl: SettingsIconTools,
       imgUrlActive: settingsIconActive,
       muiIcon: <IconCurate />,
-      disabled: isSuperuser ? false : (Object.keys(filters).length === 0),
+      disabled: false,
       allowedRoleNames: ["Superuser", "Curator_All","Curator_Self","Curator_Scoped"],
       isRequired:true
     },

--- a/src/components/elements/Pagination/Pagination.module.css
+++ b/src/components/elements/Pagination/Pagination.module.css
@@ -16,8 +16,8 @@
   align-items: center;
   gap: 10px;
   font-family: var(--font-sans);
-  background: #eef3fb;
-  border: 1px solid #d6e4f5;
+  background: #faf8f5;
+  border: 1px solid #e8e2d9;
   border-radius: 6px;
   padding: 9px 16px;
 }

--- a/src/components/elements/Publication/Publication.module.css
+++ b/src/components/elements/Publication/Publication.module.css
@@ -159,44 +159,20 @@
   color: #2c4a7c;
 }
 
-/* Tag pill variants for evidence table */
-.evTagOrg {
+/* Unified provenance badge — one light pill for every source. Color is reserved
+   for match semantics, never for "where the data came from". */
+.evTag {
   display: inline-flex;
   align-items: center;
-  padding: 1px 6px;
-  border-radius: 3px;
-  font-size: 9.5px;
-  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 400;
   margin: 1px 2px 1px 4px;
-  background: #eef3fb;
-  color: #2563a8;
-  border: 1px solid #c9d9f0;
-}
-
-.evTagPub {
-  display: inline-flex;
-  align-items: center;
-  padding: 1px 6px;
-  border-radius: 3px;
-  font-size: 9.5px;
-  font-weight: 600;
-  margin: 1px 2px 1px 4px;
-  background: #f4edfb;
-  color: #6b3fa0;
-  border: 1px solid #d9c3f0;
-}
-
-.evTagDept {
-  display: inline-flex;
-  align-items: center;
-  padding: 1px 6px;
-  border-radius: 3px;
-  font-size: 9.5px;
-  font-weight: 600;
-  margin: 1px 2px 1px 4px;
+  white-space: nowrap;
   background: #eeeae4;
   color: #5a6478;
-  border: 1px solid #ddd7ce;
+  border: none;
 }
 
 .dataEmpty {
@@ -300,55 +276,52 @@
 }
 
 .highlightedAuthor {
-  color: #2563eb;
+  color: var(--color-accent, #2563a8);
   background-color: transparent;
   font-weight: 600;
 }
 .acceptedCheck > i{
   color : red;
 }
-/* ── Feedback bar chart ── */
+/* ── Evidence sections (quiet title text + white card) ── */
 
-.sectionPanel {
-  background: #fff;
-  border: 1px solid #d6d0c4;
-  border-radius: 10px;
-  overflow: hidden;
-  margin-bottom: 16px;
+.sectionBlock {
+  margin-bottom: 20px;
+}
+
+.sectionBlock:last-child {
+  margin-bottom: 0;
 }
 
 .sectionHeader {
-  padding: 10px 24px;
-  border-bottom: 1px solid #eae6df;
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 12px;
-  background: #faf8f5;
-  border-radius: 0;
+  margin-bottom: 6px;
 }
 
-.sectionTitleGroup {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-}
-
+/* Quiet uppercase section-title role on the warm background, no fill */
 .sectionTitle {
-  font-size: 15px;
+  font-size: 11px;
   font-weight: 600;
-  color: #1a1a1a;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #8a94a6;
 }
 
-.sectionSubtitle {
-  font-size: 12px;
-  color: #a09a92;
-  font-weight: 400;
+.sectionCard {
+  background: #fff;
+  border: 0.5px solid #e8e2d9;
+  border-radius: 6px;
+  padding: 14px 18px;
 }
 
-.sectionBody {
-  padding: 14px 24px;
-  border-radius: 0;
+.identityCard {
+  background: #fff;
+  border: 0.5px solid #e8e2d9;
+  border-radius: 6px;
+  overflow: hidden;
 }
 
 /* Learn more popover */
@@ -362,19 +335,19 @@
   align-items: center;
   gap: 5px;
   font-size: 12px;
-  font-weight: 500;
-  color: #2c4a7c;
+  font-weight: 400;
+  color: #8a94a6;
   background: none;
   border: none;
   cursor: pointer;
   font-family: inherit;
   padding: 0;
   text-decoration: none;
-  transition: opacity 0.12s;
+  transition: color 0.12s;
 }
 
 .learnMoreBtn:hover {
-  text-decoration: underline;
+  color: #5a6478;
 }
 
 .learnMorePopover {
@@ -424,6 +397,34 @@
   display: block;
 }
 
+/* Identity-scores legend popover (icon + label, compact) */
+.legendPopover {
+  width: auto;
+  min-width: 150px;
+  padding: 12px 16px;
+  font-size: 12px;
+}
+
+.learnMoreWrap:hover .legendPopover {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #5a6478;
+}
+
+.legendIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
 .feedbackHeaderLabel {
   font-size: 10px;
   font-weight: 700;
@@ -443,206 +444,58 @@
   text-decoration: underline;
 }
 
-.feedbackChart {
-  margin-bottom: 0;
-}
+/* ── Feedback-based scores — ranked list (label · value · thin bar) ── */
 
-.chartAxisHeader {
+.feedbackList {
   display: grid;
-  grid-template-columns: 200px 1fr 1px 1fr;
-  margin-bottom: 2px;
-  position: relative;
+  grid-template-columns: minmax(120px, max-content) 40px minmax(0, 1fr);
+  gap: 8px 16px;
+  align-items: center;
+  font-size: 13px;
 }
 
-.chartAxisNeg {
+.feedbackLabel {
+  color: #5a6478;
+  white-space: nowrap;
+}
+
+.feedbackValue {
+  color: #1a2133;
+  font-weight: 500;
   text-align: right;
-  padding-right: 6px;
-  font-size: 11px;
-  font-weight: 400;
-  color: #a09a92;
-}
-
-.chartAxisPos {
-  text-align: left;
-  padding-left: 6px;
-  font-size: 11px;
-  font-weight: 400;
-  color: #a09a92;
-}
-
-.chartScale {
-  position: absolute;
-  right: 0;
-  top: 0;
-  font-size: 11px;
-  font-weight: 400;
-  color: #a09a92;
-  letter-spacing: 0.02em;
-}
-
-.chartRow {
-  display: grid;
-  grid-template-columns: 200px 1fr 1px 1fr;
-  align-items: center;
-  height: 30px;
-}
-
-.chartRow:first-of-type {
-  border-top: none;
-}
-
-.chartRow:last-of-type {
-  border-bottom: none;
-}
-
-.chartRow:hover {
-  background: #faf8f5;
-}
-
-.chartLabel {
-  font-size: 13px;
-  color: #2c2a27;
-  padding: 2px 10px 2px 0;
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
   white-space: nowrap;
 }
 
-.chartLabelText {
-  flex-shrink: 0;
-}
-
-.chartVal {
-  font-size: 13px;
-  font-weight: 600;
-  font-family: inherit;
-  white-space: nowrap;
-}
-
-.chartValPos {
-  color: #2c2a27;
-}
-
-.chartValNeg {
-  color: #a33030;
-}
-
-.chartValDominant {
-  color: #2563a8;
-}
-
-.chartLabelDominant {
-  font-weight: 600;
-  color: #1a2133;
-}
-
-.chartBarNeg {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 2px 2px 2px 0;
-}
-
-.chartCenterLine {
-  background: #eae6df;
-  width: 1px;
-  align-self: stretch;
-}
-
-.chartBarPos {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 2px 0 2px 2px;
-}
-
-.barNeg {
-  height: 10px;
-  border-radius: 3px 0 0 3px;
-  min-width: 2px;
-  background: #d4706b;
-  opacity: 1;
-}
-
-.barPos {
-  height: 10px;
-  border-radius: 0 3px 3px 0;
-  min-width: 2px;
-  background: #2c4a7c;
-}
-
-.barDominant {
-  background: #2c4a7c;
-}
-
-.barNeg.barDominant {
-  background: #d4706b;
-  opacity: 1;
-}
-
-.barOverflow {
-  position: relative;
-  overflow: visible;
-}
-
-.barPos.barOverflow {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.barNeg.barOverflow {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-
-.barOverflow::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  width: 8px;
-  height: 100%;
-  background: repeating-linear-gradient(
-    90deg,
-    currentColor 0px,
-    currentColor 2px,
-    transparent 2px,
-    transparent 4px
-  );
-  opacity: 0.45;
-  border-radius: 0 2px 2px 0;
-}
-
-.barPos.barOverflow::after {
-  right: -8px;
-  color: #1a2133;
-}
-
-.barPos.barDominant.barOverflow::after {
-  color: #2563a8;
-}
-
-.barNeg.barOverflow::after {
-  left: -8px;
-  border-radius: 2px 0 0 2px;
+.feedbackValueNeg {
+  composes: feedbackValue;
   color: #c0392b;
 }
 
-.barNeg.barDominant.barOverflow::after {
-  color: #2563a8;
+.feedbackBarTrack {
+  height: 4px;
+  background: #eeeae4;
+  border-radius: 2px;
+  overflow: hidden;
 }
 
-.chartValOverflowMarker {
-  font-size: 10px;
-  opacity: 0.6;
+.feedbackBarFill {
+  height: 4px;
+  background: #1a2133;
+  opacity: 0.75;
+  border-radius: 2px;
+}
+
+.feedbackBarFillNeg {
+  composes: feedbackBarFill;
+  background: #c0392b;
 }
 
 /* ── New card layout ── */
 
 .articleCard {
   background: #fff;
-  border: 1px solid #d6d0c4;
-  border-radius: 14px;
+  border: 0.5px solid #e8e2d9;
+  border-radius: 6px;
   box-shadow: none;
   display: flex;
   flex-direction: row;
@@ -658,17 +511,17 @@
 .statusStrip {
   width: 3px;
   flex-shrink: 0;
-  border-radius: 10px 0 0 10px;
+  border-radius: 6px 0 0 6px;
 }
 
 .statusStripAccepted {
   composes: statusStrip;
-  background: #3b7a57;
+  background: #1D9E75;
 }
 
 .statusStripRejected {
   composes: statusStrip;
-  background: #a33030;
+  background: #c0392b;
 }
 
 .cardMain {
@@ -682,46 +535,6 @@
   display: flex;
   flex-direction: row;
 }
-
-/* ── Score column ── */
-
-.scoreCol {
-  position: relative;
-  width: auto;
-  min-width: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 14px 6px 14px 16px;
-  background: none;
-  border-right: none;
-  gap: 2px;
-  align-self: flex-start;
-}
-
-.focused .scoreCol {
-  background: none;
-}
-
-.scoreNumber {
-  font-size: 20px;
-  font-weight: 600;
-  line-height: 1;
-  color: #2a6b47;
-}
-
-.scoreLabel {
-  display: none;
-}
-
-.scorePip {
-  display: none;
-}
-
-.scoreHigh { background-color: #22c55e; }
-.scoreMedium { background-color: #f59e0b; }
-.scoreLow { background-color: #9ca3af; }
 
 /* ── Card content ── */
 
@@ -737,7 +550,7 @@
 
 .scoreArea {
   flex-shrink: 0;
-  padding: 16px 0 16px 20px;
+  padding: 16px 0 16px 18px;
   align-self: flex-start;
 }
 
@@ -756,28 +569,26 @@
 
 .cardDate {
   font-size: 12px;
-  color: #6b6560;
+  color: #8a94a6;
 }
 
 .cardMetaSep {
-  color: #d0cbc3;
+  color: #ddd7ce;
   margin: 0 2px;
 }
 
 .pmidLabel {
-  color: #a09a92;
+  color: #8a94a6;
 }
 
 .pmidLink {
-  color: #000;
-  text-decoration: underline;
-  text-decoration-color: #b8cce4;
-  text-underline-offset: 3px;
+  color: var(--color-accent, #2563a8);
+  text-decoration: none;
   margin-left: 2px;
 }
 
 .pmidLink:hover {
-  text-decoration-color: #2c4a7c;
+  text-decoration: underline;
 }
 
 .scoreTip {
@@ -863,53 +674,69 @@
   color: rgba(255, 255, 255, 0.4);
 }
 
-.scoreInline {
-  font-family: inherit;
-  font-weight: 600;
-  font-size: 16px;
-  letter-spacing: -0.01em;
-  line-height: 1;
+/* Score tile — left rail, ~44px, shaded by score tier */
+.scoreTile {
   flex-shrink: 0;
-  width: 40px;
-  height: 40px;
-  display: inline-flex;
+  width: 44px;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  border-radius: 10px;
-  border: none;
+  padding: 8px 0;
+  border-radius: 6px;
+  border: 0.5px solid transparent;
   cursor: default;
 }
 
-.scoreInlineHigh {
-  composes: scoreInline;
-  color: #2a6b47;
-  background: #e6f3ec;
-}
-
-.scoreInlineMedium {
-  composes: scoreInline;
-  color: #92600a;
-  background: #fdf4e7;
-}
-
-.scoreInlineLow {
-  composes: scoreInline;
-  color: #a33030;
-  background: #fdf5f5;
-}
-
-.articleTitle {
+.scoreTileNumber {
   font-size: 17px;
   font-weight: 600;
-  color: #1a1a1a;
-  line-height: 1.35;
+  line-height: 1;
+}
+
+.scoreTileLabel {
+  font-size: 9px;
+  font-weight: 400;
+  letter-spacing: 0.05em;
+  margin-top: 2px;
+}
+
+.scoreTileHigh {
+  composes: scoreTile;
+  background: #eaf3ee;
+  border-color: #cfe5da;
+}
+.scoreTileHigh .scoreTileNumber { color: #0f6e56; }
+.scoreTileHigh .scoreTileLabel { color: #5dcaa5; }
+
+.scoreTileMedium {
+  composes: scoreTile;
+  background: #faf2e6;
+  border-color: #ecd9bb;
+}
+.scoreTileMedium .scoreTileNumber { color: #92600a; }
+.scoreTileMedium .scoreTileLabel { color: #c9a25f; }
+
+.scoreTileLow {
+  composes: scoreTile;
+  background: #fbeeee;
+  border-color: #ecd0d0;
+}
+.scoreTileLow .scoreTileNumber { color: #a33030; }
+.scoreTileLow .scoreTileLabel { color: #cf8f8f; }
+
+.articleTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1a2133;
+  line-height: 1.45;
   margin-bottom: 4px;
   margin-top: 6px;
 }
 
 .articleAuthors {
-  font-size: 12px;
-  color: var(--gray-600);
+  font-size: 13px;
+  color: #5a6478;
   line-height: 1.4;
   margin-bottom: 4px;
 }
@@ -921,31 +748,50 @@
 
 .articleMeta {
   font-size: 12px;
-  color: var(--gray-500);
+  color: #8a94a6;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 0;
-  margin-bottom: 6px;
+  margin-bottom: 0;
 }
 
 .articleMeta > span:not(:first-child)::before {
   content: "\2022";
   padding: 0 6px;
-  color: var(--gray-300);
+  color: #ddd7ce;
 }
 
 .typeBadge {
   display: inline-block;
-  background: #e6eef7;
+  background: #eeeae4;
   border: none;
-  border-radius: 20px;
-  padding: 3px 10px;
+  border-radius: 999px;
+  padding: 2px 10px;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 400;
   text-transform: none;
-  letter-spacing: 0.03em;
-  color: #2c4a7c;
+  letter-spacing: 0;
+  color: #5a6478;
+}
+
+/* Status chip for actioned cards (meta row) */
+.statusChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.statusChipAccepted {
+  composes: statusChip;
+  color: #1D9E75;
+}
+
+.statusChipRejected {
+  composes: statusChip;
+  color: #c0392b;
 }
 
 .articleLinks {
@@ -997,10 +843,10 @@
 .evidenceBtnPrimary {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
   font-size: 12px;
-  font-weight: 500;
-  color: #2c4a7c;
+  font-weight: 400;
+  color: var(--color-accent, #2563a8);
   background: none;
   border: none;
   border-radius: 0;
@@ -1159,14 +1005,23 @@
   border-color: var(--gray-400);
 }
 
-/* ── Card actions footer ── */
+/* ── Card footer row — evidence link left, action cluster right ── */
 
+.cardFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 20px;
+  padding: 12px 0 14px;
+  border-top: 0.5px solid #f0ece5;
+}
+
+/* Decided-state action cluster — compact (left-aligned; evidence sits right) */
 .cardActions {
   display: flex;
+  align-items: center;
   gap: 8px;
-  margin-top: 0;
-  padding: 5px 20px 14px;
-  border-top: none;
 }
 
 /* Evidence container spans full card width */
@@ -1175,54 +1030,103 @@
 }
 
 .cardActions button {
-  flex: 1;
-  padding: 6px;
+  padding: 7px 15px;
   font-size: 13px;
   font-weight: 500;
   font-family: inherit;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
-  transition: background 0.12s, color 0.12s;
+  white-space: nowrap;
+  background: #ffffff;
+  border: 0.5px solid #ddd7ce;
+  color: #5a6478;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 
-.btnAccept {
-  background: #f0f8f4;
-  color: #2a6b47;
-  border: 1px solid #b8d4c4;
+.cardActions button:hover {
+  background: #faf8f5;
+  border-color: #bbb5aa;
 }
 
-.btnAccept:hover {
-  background: #e2f0e8;
-}
+/* Decided opposite-action: colored text on neutral chrome */
+.btnAccept { color: #1a7a4a; }
+.btnReject { color: #c0392b; }
+.btnUndo   { color: #5a6478; }
 
-.btnReject {
-  background: #fdf5f5;
-  color: #a33030;
-  border: 1px solid #e8c4c4;
-}
-
-.btnReject:hover {
-  background: #fae8e8;
-}
-
-/* Actioned state (undo + opposite action) */
 .cardActionsActioned {
-  /* no special grid override needed with flex */
+  /* compact cluster — no override needed */
 }
 
-.btnUndo {
-  background: #fff;
-  color: #6b6560;
-  border: 1px solid #d6d0c4;
+/* ── Pending decision buttons — large + spaced, with a dead-zone gap.
+   Big targets (Fitts's law) but a fast click can't flip Accept <-> Reject.
+   Soft tint at rest, solid fill on hover: calm normally, confident on commit. ── */
+.bigActions {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: stretch;
+  gap: 0;
 }
 
-.btnUndo:hover {
-  background: #f7f5f1;
-  color: #2c2a27;
+.bigActions button {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 11px 24px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  border-radius: var(--radius-md);
+  border: 0.5px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease, transform 0.05s ease;
+}
+
+.bigActions button:active { transform: scale(0.985); }
+.bigActions button svg { flex-shrink: 0; }
+
+/* dead-zone gap with a faint dashed centerline */
+.deadZone {
+  flex: 0 0 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.deadZoneLine {
+  height: 58%;
+  border-left: 1px dashed #ddd7ce;
+}
+
+.btnAcceptBig {
+  background: #dcfce7;
+  color: #166534;
+  border-color: #b7e4c7;
+}
+
+.btnAcceptBig:hover {
+  background: #16a34a;
+  color: #ffffff;
+  border-color: #16a34a;
+}
+
+.btnRejectBig {
+  background: #fee2e2;
+  color: #991b1b;
+  border-color: #f3c4c4;
+}
+
+.btnRejectBig:hover {
+  background: #dc2626;
+  color: #ffffff;
+  border-color: #dc2626;
 }
 
 /* Actioned card in Suggested tab */
@@ -1234,92 +1138,48 @@
   color: var(--gray-500);
 }
 
-/* ── Identity table ── */
-
-.identityScoresHeader {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--gray-500);
-  margin-bottom: 8px;
-}
+/* ── Identity-based scores (single status icon, no rails/bars) ── */
 
 .identityTable {
   margin-bottom: 0;
-}
-
-.legendBar {
-  padding: 10px 24px;
-  border-bottom: 1px solid #eae6df;
-  background: #fff;
-}
-
-.evidenceLegend {
-  display: flex;
-  gap: 16px;
-  margin: 0;
-}
-
-.legendItem {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 11px;
-  color: var(--gray-500);
-}
-
-.legendDot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
+  font-size: 13px;
 }
 
 .identityRow {
   display: grid;
-  grid-template-columns: 4px minmax(140px, 0.8fr) 1.1fr 1fr;
-  gap: 0;
-  align-items: center;
-  border-bottom: 1px solid #e8e2d9;
-  font-size: 12.5px;
-  color: var(--gray-700);
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0 16px;
+  align-items: baseline;
+  padding: 12px 18px;
+  border-bottom: 0.5px solid #f0ece5;
+  color: #1a2133;
 }
 
-.identityRow:hover {
-  background: #faf8f5;
-}
-
-.identityHeaderRow {
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #fff;
-  background: rgb(150, 150, 150);
+.identityRow:last-of-type {
   border-bottom: none;
-  border-radius: 0;
 }
 
-.identityHeaderRow div {
-  color: #fff;
-  padding-top: 8px;
-  padding-bottom: 8px;
+/* Quiet uppercase column header on a subtle surface */
+.identityHeaderRow {
+  align-items: center;
+  padding: 8px 18px;
+  background: #faf8f5;
+  border-bottom: 0.5px solid #e8e2d9;
 }
 
-.identityHeaderRow:hover {
-  background: rgb(150, 150, 150);
-}
-
-.identityStrip {
-  width: 4px;
-  border-radius: 2px;
-  min-height: 100%;
-  align-self: stretch;
+.identityHeaderRow > div {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8a94a6;
 }
 
 .identityEvidence {
-  padding: 11px 14px 11px 8px;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0 6px;
   min-width: 0;
 }
 
@@ -1327,33 +1187,21 @@
   margin: 2px 0;
 }
 
-.evNameRow {
-  display: flex;
+.matchIcon {
+  display: inline-flex;
   align-items: center;
-  gap: 4px;
-  margin-bottom: 4px;
+  align-self: center;
+  flex-shrink: 0;
+  margin-right: 2px;
 }
 
 .evName {
-  font-size: 12.5px;
-  font-weight: 600;
-  color: var(--gray-900);
-}
-
-.matchIconCircle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  font-size: 9px;
-  flex-shrink: 0;
+  color: #1a2133;
 }
 
 .sourceLink {
   font-size: 10px;
-  color: var(--gray-400);
+  color: #8a94a6;
   text-decoration: none;
   margin-left: 2px;
 }
@@ -1362,52 +1210,25 @@
   text-decoration: underline;
 }
 
-.evPointsRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 3px;
-}
-
-.pointsValue {
-  font-family: 'Space Grotesk', sans-serif;
-  font-weight: 500;
-  font-size: 12px;
-  color: var(--gray-600);
+.evPoints {
+  color: #8a94a6;
   white-space: nowrap;
-  min-width: 32px;
 }
 
-.pointsValueZero {
-  composes: pointsValue;
-  color: var(--gray-400);
-}
-
-.miniBar {
-  flex: 1;
-  max-width: 80px;
-  height: 4px;
-  background: var(--gray-100);
-  border-radius: 2px;
-  overflow: hidden;
-}
-
-.miniBarFill {
-  height: 100%;
-  border-radius: 2px;
-  transition: width 0.3s ease;
+.evPointsNeg {
+  composes: evPoints;
+  color: #c0392b;
 }
 
 .identityData {
-  padding: 11px 14px;
-  font-size: 12px;
-  color: var(--gray-600);
+  font-size: 13px;
+  color: #1a2133;
   min-width: 0;
 }
 
 .identityDataSpan {
   composes: identityData;
-  grid-column: 3 / 5;
+  grid-column: 2 / 4;
 }
 
 .identityData p {
@@ -1415,26 +1236,24 @@
 }
 
 .zeroToggle {
-  background: #eeeae4;
-  border-top: 1px solid #e8e2d9;
+  background: #faf8f5;
   border: none;
-  padding: 8px 14px;
-  font-size: 11.5px;
-  color: var(--gray-500);
-  font-weight: 500;
+  border-top: 0.5px solid #e8e2d9;
+  padding: 8px 18px;
+  font-size: 12px;
+  color: #8a94a6;
+  font-weight: 400;
   cursor: pointer;
   width: 100%;
   text-align: left;
   display: flex;
   align-items: center;
   gap: 6px;
-  transition: background 0.12s, color 0.12s;
-  border-radius: 0 0 8px 8px;
+  transition: color 0.12s;
 }
 
 .zeroToggle:hover {
-  background: var(--gray-50);
-  color: var(--gray-700);
+  color: #5a6478;
 }
 
 .keyHint {
@@ -1452,64 +1271,3 @@
   opacity: 0.45;
 }
 
-/* ── Score tooltip ── */
-
-.scoreTooltip {
-  position: absolute;
-  left: calc(100% + 12px);
-  top: 50%;
-  transform: translateY(-50%) translateX(-4px);
-  width: 210px;
-  background: #1a2133;
-  border-radius: 8px;
-  padding: 12px 14px;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.15s, transform 0.15s;
-  z-index: 200;
-  box-shadow: 0 6px 24px rgba(26, 33, 51, 0.2);
-}
-
-.scoreTooltip::before {
-  content: '';
-  position: absolute;
-  right: 100%;
-  top: 50%;
-  transform: translateY(-50%);
-  border: 6px solid transparent;
-  border-right-color: #1a2133;
-}
-
-.scoreCol:hover .scoreTooltip {
-  opacity: 1;
-  pointer-events: auto;
-  transform: translateY(-50%) translateX(0);
-}
-
-.stRow {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  padding: 4px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
-}
-
-.stRowLast {
-  border-bottom: none;
-}
-
-.stLabel {
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.45);
-}
-
-.stVal {
-  font-family: 'Space Grotesk', sans-serif;
-  font-size: 13px;
-  font-weight: 500;
-  color: #fff;
-}
-
-.stValGreen { color: #5de0a0; }
-.stValAmber { color: #f0b84a; }
-.stValMuted { color: rgba(255, 255, 255, 0.4); }

--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -1,9 +1,5 @@
 import React, { useState, useEffect, useRef, FunctionComponent } from "react"
 import styles from './Publication.module.css';
-import {} from "react-bootstrap";
-import CheckIcon from '@mui/icons-material/Check';
-import ClearIcon from '@mui/icons-material/Clear';
-import UndoIcon from '@mui/icons-material/Undo';
 import { Container, Row, Col, Button, Accordion, Card } from "react-bootstrap";
 import type { Author } from '../../../../types/Author';
 import { useSelector, useDispatch } from "react-redux";
@@ -179,19 +175,25 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
       userAssertion: string
     }) => {
       const evDefault = expandedPubIndex ? expandedPubIndex : props.showEvidenceDefault;
+      // Compact right-aligned action cluster (not full-width). Wiring/dispatch unchanged.
       switch (userAssertion) {
         case "NULL" :
           return (
-            <div className={styles.cardActions}>
+            <div className={styles.bigActions}>
               <button
-                className={styles.btnAccept}
+                className={styles.btnAcceptBig}
                 onClick={() => { props.updatePublication(props.personIdentifier, pmid, 'ACCEPTED'); dispatch(showEvidenceByDefault(evDefault))}}
-              ><CheckIcon style={{fontSize:16}}/> Accept <span className={styles.keyHint}>A</span>
+              >
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" width="15" height="15"><path d="M13.5 4.5L6.3 11.7 3 8.4"/></svg>
+                Accept
               </button>
+              <span className={styles.deadZone}><span className={styles.deadZoneLine} /></span>
               <button
-                className={styles.btnReject}
+                className={styles.btnRejectBig}
                 onClick={() =>{ props.updatePublication(props.personIdentifier, pmid, 'REJECTED'); dispatch(showEvidenceByDefault(evDefault))}}
-              ><ClearIcon style={{fontSize:16}}/> Reject <span className={styles.keyHint}>R</span>
+              >
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" width="15" height="15"><path d="M4.5 4.5l7 7M11.5 4.5l-7 7"/></svg>
+                Reject
               </button>
             </div>
           )
@@ -204,7 +206,7 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
                   onClick={() => { props.updatePublication(props.personIdentifier, pmid, 'NULL'); dispatch(showEvidenceByDefault(evDefault)); }}
                 >
                   <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" width="13" height="13"><path d="M3 8a5 5 0 105-5H5M3 8V4m0 4H7"/></svg>
-                  Accepted — Undo
+                  Undo
                 </button>
               </div>
             );
@@ -212,16 +214,18 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
           return (
             <div className={styles.cardActions}>
               <button
+                className={styles.btnReject}
+                onClick={() => { props.updatePublication(props.personIdentifier, pmid, 'REJECTED'); dispatch(showEvidenceByDefault(evDefault)); }}
+              >
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" width="13" height="13"><path d="M4.5 4.5l7 7M11.5 4.5l-7 7"/></svg>
+                Reject
+              </button>
+              <button
                 className={styles.btnUndo}
                 onClick={() => { props.updatePublication(props.personIdentifier, pmid, 'NULL'); dispatch(showEvidenceByDefault(evDefault)); }}
               >
                 <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" width="13" height="13"><path d="M3 8a5 5 0 105-5H5M3 8V4m0 4H7"/></svg>
                 Undo
-              </button>
-              <button
-                className={styles.btnReject}
-                onClick={() => { props.updatePublication(props.personIdentifier, pmid, 'REJECTED'); dispatch(showEvidenceByDefault(evDefault)); }}
-              ><ClearIcon style={{fontSize:16}}/> Reject
               </button>
             </div>
           );
@@ -234,7 +238,7 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
                   onClick={() => { props.updatePublication(props.personIdentifier, pmid, 'NULL'); dispatch(showEvidenceByDefault(evDefault)); }}
                 >
                   <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" width="13" height="13"><path d="M3 8a5 5 0 105-5H5M3 8V4m0 4H7"/></svg>
-                  Rejected — Undo
+                  Undo
                 </button>
               </div>
             );
@@ -242,16 +246,18 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
           return (
             <div className={styles.cardActions}>
               <button
-                className={styles.btnAccept}
-                onClick={() => { props.updatePublication(props.personIdentifier, pmid, 'ACCEPTED'); dispatch(showEvidenceByDefault(evDefault)); }}
-              ><CheckIcon style={{fontSize:16}}/> Accept
-              </button>
-              <button
                 className={styles.btnUndo}
                 onClick={() => { props.updatePublication(props.personIdentifier, pmid, 'NULL'); dispatch(showEvidenceByDefault(evDefault)); }}
               >
                 <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" width="13" height="13"><path d="M3 8a5 5 0 105-5H5M3 8V4m0 4H7"/></svg>
                 Undo
+              </button>
+              <button
+                className={styles.btnAccept}
+                onClick={() => { props.updatePublication(props.personIdentifier, pmid, 'ACCEPTED'); dispatch(showEvidenceByDefault(evDefault)); }}
+              >
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" width="13" height="13"><path d="M13 4.5L6.2 11.5 3 8.3"/></svg>
+                Accept
               </button>
             </div>
           );
@@ -276,15 +282,10 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
       return userName; 
     }
 
-    const getTagClass = (tag: string): string => {
-      const lower = tag.toLowerCase();
-      if (['scopus', 'affiliation', 'co-investigator', 'org unit'].includes(lower)) {
-        return styles.evTagOrg;
-      }
-      if (['pubmed', 'journal category'].includes(lower)) {
-        return styles.evTagPub;
-      }
-      return styles.evTagDept;
+    // Provenance badges (Affiliation / Scopus / PubMed / Journal Category, etc.) all read
+    // as one light pill. Color is reserved strictly for match semantics, not source.
+    const getTagClass = (_tag: string): string => {
+      return styles.evTag;
     };
 
     const TableCellWithTypes = (props: any) => {
@@ -369,18 +370,19 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
       return 'mismatch';
     };
 
-    const matchColors: Record<string, { bg: string; border: string; label: string }> = {
-      match: { bg: '#dcfce7', border: '#22c55e', label: 'Strong match' },
-      partial: { bg: '#fef3c7', border: '#f59e0b', label: 'Partial / weak' },
-      mismatch: { bg: '#fee2e2', border: '#ef4444', label: 'Mismatch' },
-      nodata: { bg: '#f3f4f6', border: '#9ca3af', label: 'No data' },
+    // Status lives in exactly one place — the icon color. No fills, no rails, no bars.
+    const matchColors: Record<string, { color: string; label: string }> = {
+      match: { color: '#1D9E75', label: 'Strong' },
+      partial: { color: '#BA7517', label: 'Partial' },
+      mismatch: { color: '#c0392b', label: 'Mismatch' },
+      nodata: { color: '#8a94a6', label: 'No data' },
     };
 
     const matchIcons: Record<string, JSX.Element> = {
-      match: <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" width="9" height="9"><path d="M1.5 5l2.5 2.5 4.5-4.5"/></svg>,
-      partial: <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" width="9" height="9"><path d="M5 2v4M5 7.5v.5"/></svg>,
-      mismatch: <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" width="9" height="9"><path d="M2.5 2.5l5 5M7.5 2.5l-5 5"/></svg>,
-      nodata: <svg viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="2" width="9" height="9"><path d="M2 5h6"/></svg>,
+      match: <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" width="14" height="14"><circle cx="8" cy="8" r="6.5"/><path d="M5.3 8.2l1.8 1.8 3.6-3.8"/></svg>,
+      partial: <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" width="14" height="14"><circle cx="8" cy="8" r="6.5"/><path d="M8 4.8v3.6M8 10.7v.05"/></svg>,
+      mismatch: <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" width="14" height="14"><circle cx="8" cy="8" r="6.5"/><path d="M5.8 5.8l4.4 4.4M10.2 5.8l-4.4 4.4"/></svg>,
+      nodata: <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" width="14" height="14"><circle cx="8" cy="8" r="6.5"/><path d="M5 8h6"/></svg>,
     };
 
     const formatEvidenceTable = (evidence: any) => {
@@ -652,31 +654,24 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
         const visibleRows = evidenceTableRows.filter((r: any) => Number(r.points) !== 0);
         const zeroRows = evidenceTableRows.filter((r: any) => Number(r.points) === 0);
         const rowsToRender = showZeroWeight ? evidenceTableRows : visibleRows;
-        const maxAbsPoints = Math.max(...evidenceTableRows.map((r: any) => Math.abs(Number(r.points) || 0)), 1);
 
         const IdentityRow = ({ evidenceRow, idx }: { evidenceRow: any; idx: number }) => {
           const mt = determineMatchType(evidenceRow.name, evidenceRow.points, evidence);
           const mc = matchColors[mt];
           const ptsNum = Number(evidenceRow.points) || 0;
-          const barPct = Math.min((Math.abs(ptsNum) / maxAbsPoints) * 100, 100);
+          const ptsIsNeg = ptsNum < 0;
           return (
             <div className={styles.identityRow} key={idx}>
-              <div className={styles.identityStrip} style={{ background: mc.border }} />
               <div className={styles.identityEvidence}>
-                <div className={styles.evNameRow}>
-                  <span className={styles.matchIconCircle} style={{ background: mc.bg, color: mc.border }}>{matchIcons[mt]}</span>
-                  <span className={styles.evName}>{evidenceRow.title}</span>
-                  {evidenceRow.source && <a href={evidenceRow.source} target="_blank" rel="noreferrer" className={styles.sourceLink}>(source)</a>}
-                </div>
+                <span className={styles.matchIcon} style={{ color: mc.color }}>{matchIcons[mt]}</span>
+                <span className={styles.evName}>{evidenceRow.title}</span>
+                {evidenceRow.source && <a href={evidenceRow.source} target="_blank" rel="noreferrer" className={styles.sourceLink}>(source)</a>}
                 {evidenceRow.pointsText ? (
-                  <div style={{ fontSize: '10.5px', color: 'var(--gray-400)', marginTop: 2 }}>{evidenceRow.pointsText}</div>
+                  <span className={styles.evPoints}>{evidenceRow.pointsText}</span>
                 ) : (
-                  <div className={styles.evPointsRow}>
-                    <span className={ptsNum === 0 ? styles.pointsValueZero : styles.pointsValue}>
-                      {ptsNum !== 0 ? ptsNum.toFixed(2) : '0.00'} pts
-                    </span>
-                    <div className={styles.miniBar}><div className={styles.miniBarFill} style={{ width: `${barPct}%`, background: mc.border }} /></div>
-                  </div>
+                  <span className={ptsIsNeg ? styles.evPointsNeg : styles.evPoints}>
+                    {ptsNum !== 0 ? ptsNum.toFixed(2) : '0.00'} pts
+                  </span>
                 )}
               </div>
               {evidenceRow.spanData ? (
@@ -699,23 +694,11 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
 
         return (
           <>
-            {/* Color legend bar */}
-            <div className={styles.legendBar}>
-              <div className={styles.evidenceLegend}>
-                {Object.entries(matchColors).map(([key, mc]) => (
-                  <span className={styles.legendItem} key={key}>
-                    <span className={styles.legendDot} style={{ background: mc.border }} />
-                    {mc.label}
-                  </span>
-                ))}
-              </div>
-            </div>
-            {/* Table header */}
+            {/* Quiet column header */}
             <div className={`${styles.identityRow} ${styles.identityHeaderRow}`}>
-              <div style={{ padding: 0 }} />
               <div className={styles.identityEvidence}>Evidence</div>
-              <div className={styles.identityData}>Institutional Data</div>
-              <div className={styles.identityData}>Article Data</div>
+              <div className={styles.identityData}>Institutional</div>
+              <div className={styles.identityData}>Article</div>
             </div>
             {/* Rows */}
             {rowsToRender.map((evidenceRow: any, idx: number) => (
@@ -746,59 +729,49 @@ const formatFeedbackLabel = (key: string): string => {
 };
 
 const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.Element => {
-  const sortedFeedback = feedbackEvidence && Object.entries(feedbackEvidence)
+  const sortedFeedback = (feedbackEvidence ? Object.entries(feedbackEvidence) : [])
     .map(([key, value]) => [formatFeedbackLabel(key), Math.round(value as number)] as [string, number])
     .filter(([, v]) => v !== 0)
-    .sort((a, b) => Math.abs(b[1]) - Math.abs(a[1]));
+    .sort((a, b) => b[1] - a[1]);
+
+  // Scale every bar against the documented ±100 feedback range (not the per-card
+  // max), so the same value renders at the same width on every card — bars stay
+  // comparable across publications. Values beyond 100 cap at full width.
+  const FEEDBACK_SCALE = 100;
 
   return (
-    <div className={styles.feedbackChart}>
-      <div className={styles.chartAxisHeader}>
-        <div />
-        <span className={styles.chartAxisNeg}>&larr; Negative</span>
-        <div />
-        <span className={styles.chartAxisPos}>Positive &rarr;</span>
-        <span className={styles.chartScale}>Scale: &plusmn;100</span>
-      </div>
-      {sortedFeedback?.map(([label, value], i) => {
-        const absVal = Math.abs(value);
-        const isOverflow = absVal > 100;
-        const isDominant = isOverflow;
-        const barWidth = Math.min(absVal, 100);
+    <div className={styles.feedbackList}>
+      {sortedFeedback.map(([label, value], i) => {
+        const isNeg = value < 0;
+        const barPct = Math.min((Math.abs(value) / FEEDBACK_SCALE) * 100, 100);
         return (
-          <div className={`${styles.chartRow} ${isDominant ? styles.chartRowDominant : ''}`} key={i}>
-            <div className={`${styles.chartLabel} ${isDominant ? styles.chartLabelDominant : ''}`}>
-              <span className={styles.chartLabelText}>{label}</span>
-              <span className={`${styles.chartVal} ${isDominant ? styles.chartValDominant : value < 0 ? styles.chartValNeg : styles.chartValPos}`}>
-                {value < 0 ? `\u2212${absVal}` : value}{isOverflow && <span className={styles.chartValOverflowMarker}> »</span>}
-              </span>
+          <React.Fragment key={i}>
+            <span className={styles.feedbackLabel}>{label}</span>
+            <span className={isNeg ? styles.feedbackValueNeg : styles.feedbackValue}>
+              {isNeg ? `−${Math.abs(value)}` : value}
+            </span>
+            <div className={styles.feedbackBarTrack}>
+              <div
+                className={isNeg ? styles.feedbackBarFillNeg : styles.feedbackBarFill}
+                style={{ width: `${barPct}%` }}
+              />
             </div>
-            <div className={styles.chartBarNeg}>
-              {value < 0 && <div className={`${styles.barNeg} ${isDominant ? styles.barDominant : ''} ${isOverflow ? styles.barOverflow : ''}`} style={{ width: `${barWidth}%` }} />}
-            </div>
-            <div className={styles.chartCenterLine} />
-            <div className={styles.chartBarPos}>
-              {value > 0 && <div className={`${styles.barPos} ${isDominant ? styles.barDominant : ''} ${isOverflow ? styles.barOverflow : ''}`} style={{ width: `${barWidth}%` }} />}
-            </div>
-          </div>
+          </React.Fragment>
         );
       })}
     </div>
   );
 };
-
     const rawScore = reciterArticle.authorshipLikelihoodScore ?? null;
     const score = rawScore !== null ? Math.round(rawScore) : null;
     const scoreNum = typeof score === 'number' ? score : 0;
-    const pipClass = scoreNum >= 70 ? styles.scoreHigh : scoreNum >= 40 ? styles.scoreMedium : styles.scoreLow;
     const userAssertion = reciterArticle.userAssertion;
     const isActioned = userAssertion === 'ACCEPTED' || userAssertion === 'REJECTED';
-    const isActionedInSuggested = props.activekey === 'NULL' && isActioned;
     const evDefault = expandedPubIndex ? expandedPubIndex : props.showEvidenceDefault;
 
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      <div className={`${styles.articleCard}${props.isFocused ? ` ${styles.focused}` : ''}${isActionedInSuggested ? ` ${styles.actionedCard}` : ''}`} data-pmid={reciterArticle.pmid} onMouseDown={props.onCardMouseDown}>
+      <div className={`${styles.articleCard}${props.isFocused ? ` ${styles.focused}` : ''}`} data-pmid={reciterArticle.pmid} onMouseDown={props.onCardMouseDown}>
         {/* Status strip for accepted/rejected */}
         {userAssertion === 'ACCEPTED' && <div className={styles.statusStripAccepted} />}
         {userAssertion === 'REJECTED' && <div className={styles.statusStripRejected} />}
@@ -806,11 +779,12 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
         {/* Main content column */}
         <div className={styles.cardMain}>
           <div className={styles.cardTop}>
-            {/* Score at top-left */}
+            {/* Score tile — left rail */}
             <div className={styles.scoreArea}>
               <span className={styles.scoreTip}>
-                <span className={scoreNum >= 70 ? styles.scoreInlineHigh : scoreNum >= 40 ? styles.scoreInlineMedium : styles.scoreInlineLow}>
-                  {score !== null ? score : "N/A"}
+                <span className={scoreNum >= 70 ? styles.scoreTileHigh : scoreNum >= 40 ? styles.scoreTileMedium : styles.scoreTileLow}>
+                  <span className={styles.scoreTileNumber}>{score !== null ? score : "N/A"}</span>
+                  <span className={styles.scoreTileLabel}>SCORE</span>
                 </span>
                 {score !== null && (
                   <span className={styles.scoreTooltip}>
@@ -830,21 +804,27 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
             </div>
             {/* Content area */}
             <div className={styles.cardContent}>
-              {/* Row 1: Badge + Date + PMID + DOI + Supporting Evidence */}
+              {/* Row 1: Type chip · date · PMID link */}
               <div className={styles.cardMetaRow}>
                 <div className={styles.cardMetaLeft}>
                   {reciterArticle.publicationType?.publicationTypeCanonical &&
                     <span className={styles.typeBadge}>{reciterArticle.publicationType.publicationTypeCanonical}</span>
                   }
                   {reciterArticle.publicationDateDisplay && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>{reciterArticle.publicationDateDisplay}</span></>}
-                  <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}><span className={styles.pmidLabel}>PMID</span> <a className={styles.pmidLink} href={`${pubMedUrl}${reciterArticle.pmid}`} target="_blank" rel="noreferrer">{reciterArticle.pmid}</a><span style={{userSelect: 'none', color: '#2c4a7c'}}> ↗</span></span></>
+                  <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}><span className={styles.pmidLabel}>PMID</span> <a className={styles.pmidLink} href={`${pubMedUrl}${reciterArticle.pmid}`} target="_blank" rel="noreferrer">{reciterArticle.pmid}</a><span style={{userSelect: 'none', color: '#2563a8'}}> ↗</span></span></>
+                  {userAssertion === 'ACCEPTED' && (
+                    <span className={styles.statusChipAccepted}>
+                      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" width="12" height="12"><path d="M13 4.5L6.2 11.5 3 8.3"/></svg>
+                      Accepted
+                    </span>
+                  )}
+                  {userAssertion === 'REJECTED' && (
+                    <span className={styles.statusChipRejected}>
+                      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" width="12" height="12"><path d="M4.5 4.5l7 7M11.5 4.5l-7 7"/></svg>
+                      Rejected
+                    </span>
+                  )}
                 </div>
-                {reciterArticle.evidence !== undefined && (
-                  <button className={styles.evidenceBtnPrimary} data-evidence-toggle onClick={() => toogleEvidence(props.index)}>
-                    <svg width="13" height="13" viewBox="0 0 13 13" fill="none"><circle cx="5.5" cy="5.5" r="4" stroke="currentColor" strokeWidth="1.3"/><path d="M8.5 8.5L11.5 11.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
-                    Supporting evidence
-                  </button>
-                )}
               </div>
               {/* Row 2: Title */}
               <div className={styles.articleTitle}>{reciterArticle.articleTitle}</div>
@@ -891,22 +871,27 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
 
             </div>
           </div>
-          {/* Action buttons — above evidence panel */}
-          <CardFooter pmid={reciterArticle.pmid} userAssertion={userAssertion} />
+          {/* Footer row — action cluster left, evidence link right */}
+          <div className={styles.cardFooter}>
+            <CardFooter pmid={reciterArticle.pmid} userAssertion={userAssertion} />
+            {reciterArticle.evidence !== undefined ? (
+              <button className={styles.evidenceBtnPrimary} data-evidence-toggle onClick={() => toogleEvidence(props.index)}>
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none"><circle cx="5.5" cy="5.5" r="4" stroke="currentColor" strokeWidth="1.3"/><path d="M8.5 8.5L11.5 11.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/></svg>
+                Supporting evidence
+              </button>
+            ) : <span />}
+          </div>
           {/* Evidence panel — full card width */}
           {reciterArticle.evidence !== undefined && (
             <div className={`${styles.publicationShowEvidenceContainer} ${(props.index === props.showEvidenceDefault || showEvidence) ? styles.publicationShowEvidenceContainerOpen : ""}`}>
 
-              {/* Feedback-based scores panel */}
-              <div className={styles.sectionPanel}>
+              {/* Feedback-based scores */}
+              <div className={styles.sectionBlock}>
                 <div className={styles.sectionHeader}>
-                  <div className={styles.sectionTitleGroup}>
-                    <span className={styles.sectionTitle}>Feedback-based scores</span>
-                    <span className={styles.sectionSubtitle}>Scores learned from curation history</span>
-                  </div>
+                  <span className={styles.sectionTitle}>Feedback-based scores</span>
                   <div className={styles.learnMoreWrap}>
                     <div className={styles.learnMoreBtn}>
-                      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" width="13" height="13"><circle cx="8" cy="8" r="6"/><path d="M8 7v4M8 5.5v.5" strokeLinecap="round"/></svg>
+                      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" width="13" height="13"><circle cx="8" cy="8" r="6.5"/><path d="M8 7v4M8 5.5v.5" strokeLinecap="round"/></svg>
                       Learn more
                     </div>
                     <div className={styles.learnMorePopover}>
@@ -915,23 +900,34 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
                     </div>
                   </div>
                 </div>
-                <div className={styles.sectionBody}>
+                <div className={styles.sectionCard}>
                   {reciterArticle.evidence.feedbackEvidence && Object.keys(reciterArticle.evidence.feedbackEvidence).length > 0
                     ? displayFeedbackEvidence(reciterArticle.evidence.feedbackEvidence)
-                    : <p style={{color:'var(--gray-400)', fontStyle:'italic', margin:'0'}}>No feedback available.</p>
+                    : <p style={{color:'#8a94a6', fontStyle:'italic', margin:'0'}}>No feedback available.</p>
                   }
                 </div>
               </div>
 
-              {/* Identity-based scores panel */}
-              <div className={styles.sectionPanel}>
-                <div className={styles.sectionHeader} style={{borderBottom: 'none'}}>
-                  <div className={styles.sectionTitleGroup}>
-                    <span className={styles.sectionTitle}>Identity-based scores</span>
-                    <span className={styles.sectionSubtitle}>Comparison of institutional profile data against article metadata</span>
+              {/* Identity-based scores */}
+              <div className={styles.sectionBlock}>
+                <div className={styles.sectionHeader}>
+                  <span className={styles.sectionTitle}>Identity-based scores</span>
+                  <div className={styles.learnMoreWrap}>
+                    <div className={styles.learnMoreBtn}>
+                      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" width="13" height="13"><circle cx="8" cy="8" r="6.5"/><path d="M8 7v4M8 5.5v.5" strokeLinecap="round"/></svg>
+                      Legend
+                    </div>
+                    <div className={`${styles.learnMorePopover} ${styles.legendPopover}`}>
+                      {Object.entries(matchColors).map(([key, mc]) => (
+                        <span className={styles.legendItem} key={key}>
+                          <span className={styles.legendIcon} style={{ color: mc.color }}>{matchIcons[key]}</span>
+                          {mc.label}
+                        </span>
+                      ))}
+                    </div>
                   </div>
                 </div>
-                <div className={styles.identityTable}>
+                <div className={styles.identityCard}>
                   {formatEvidenceTable(reciterArticle.evidence)}
                 </div>
               </div>

--- a/src/components/elements/Report/ChecboxSelect.module.css
+++ b/src/components/elements/Report/ChecboxSelect.module.css
@@ -19,7 +19,7 @@
   background: transparent;
   font-size: 15px;
   font-family: inherit;
-  color: #2c2a27;
+  color: #1a2133;
   outline: none;
 }
 
@@ -71,7 +71,7 @@
   padding: 8px 16px;
   font-size: 15px;
   font-weight: 500;
-  color: #2c2a27;
+  color: #1a2133;
   cursor: pointer;
   transition: background 0.1s;
   white-space: nowrap;
@@ -89,12 +89,12 @@
 
 .ddItem:hover {
   background: #faf8f5;
-  color: #2c2a27;
+  color: #1a2133;
 }
 
 .ddItemChecked {
   composes: ddItem;
-  color: #2c2a27;
+  color: #1a2133;
   font-weight: 500;
 }
 
@@ -114,8 +114,8 @@
 
 .cbOn {
   composes: cb;
-  background: #2c4a7c;
-  border-color: #2c4a7c;
+  background: #2563a8;
+  border-color: #2563a8;
 }
 
 .cbOn::after {
@@ -157,7 +157,7 @@
 
 .ddClear {
   font-size: 14px;
-  color: #2c4a7c;
+  color: #2563a8;
   cursor: pointer;
   background: none;
   border: none;
@@ -213,7 +213,7 @@
 
 .ptLabel {
   font-size: 14px;
-  color: #2c2a27;
+  color: #1a2133;
   font-weight: 500;
   line-height: 1;
   flex-shrink: 0;
@@ -239,7 +239,7 @@
   cursor: pointer;
   transition: background 0.1s;
   font-size: 14px;
-  color: #2c2a27;
+  color: #1a2133;
   background: none;
   border: none;
   border-bottom: 1px solid #eae6df;
@@ -250,12 +250,12 @@
 
 .posItem:hover {
   background: #f7f5f1;
-  color: #2c2a27;
+  color: #1a2133;
 }
 
 .posLabel {
   font-size: 14px;
-  color: #2c2a27;
+  color: #1a2133;
   font-weight: 500;
 }
 

--- a/src/components/elements/Report/DatePicker.module.css
+++ b/src/components/elements/Report/DatePicker.module.css
@@ -1,7 +1,7 @@
 /* ── HEADER ── */
 .ddHeader {
   padding: 8px 12px;
-  background: #f3f1ed;
+  background: transparent;
   border-bottom: 1px solid #eae6df;
   display: flex;
   align-items: center;
@@ -10,7 +10,7 @@
 
 .ddHeaderLabel {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: #5a5650;
@@ -18,7 +18,7 @@
 
 .ddClear {
   font-size: 13px;
-  color: #8B1A1A;
+  color: var(--color-accent);
   background: none;
   border: none;
   font-family: inherit;
@@ -28,7 +28,7 @@
 }
 
 .ddClear:hover {
-  color: #c0392b;
+  text-decoration: underline;
 }
 
 /* ── DATE INPUTS ── */

--- a/src/components/elements/Report/ExportModal.module.css
+++ b/src/components/elements/Report/ExportModal.module.css
@@ -63,10 +63,10 @@
 
 .title {
   font-family: inherit;
-  font-weight: 500;
+  font-weight: 600;
   font-size: 16px;
   letter-spacing: 0;
-  color: #1a1a1a;
+  color: #1a2133;
 }
 
 .closeBtn {
@@ -122,7 +122,7 @@
   font-weight: 600;
   font-size: 28px;
   letter-spacing: -0.02em;
-  color: #1a1a1a;
+  color: #1a2133;
   line-height: 1;
 }
 
@@ -131,7 +131,7 @@
   color: #8a847c;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-weight: 500;
+  font-weight: 600;
   margin-top: 2px;
 }
 
@@ -157,13 +157,13 @@
 }
 
 .badgeRtf {
-  background: #e6eef7;
-  color: #2c4a7c;
+  background: #eeeae4;
+  color: #5a6478;
 }
 
 .badgeCsv {
   background: #e6f3ec;
-  color: #2a6b47;
+  color: #166534;
 }
 
 /* ── DESCRIPTION ── */
@@ -293,14 +293,14 @@
   width: 22px;
   height: 22px;
   border: 2.5px solid #ddd8d0;
-  border-top-color: #8a95a3;
+  border-top-color: #8a94a6;
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
 }
 
 .loadingText {
   font-size: 12.5px;
-  color: #8a95a3;
+  color: #8a94a6;
 }
 
 /* ── ERROR ── */

--- a/src/components/elements/Report/FilterSection.module.css
+++ b/src/components/elements/Report/FilterSection.module.css
@@ -2,7 +2,7 @@
   background-color: var(--color-warm-surface);
   border: 1px solid var(--color-warm-border);
   box-shadow: var(--shadow-sm);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   padding: 16px 20px;
 }
 
@@ -17,10 +17,10 @@
 .filterName {
   margin-bottom: 8px;
   font-size: 10.5px;
-  font-weight: 700;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.09em;
-  color: var(--gray-500);
+  color: #8a94a6;
 }
 
 .filtersContainer {

--- a/src/components/elements/Report/FilterSection.tsx
+++ b/src/components/elements/Report/FilterSection.tsx
@@ -25,7 +25,7 @@ const filterNameToState = {
 const Buttons = ({ clearFilters, searchResults }) => {
   return (
     <div className="d-flex align-items-center">
-      <Button variant="danger" onClick={searchResults}>Search</Button>
+      <Button className="primary" onClick={searchResults} style={{ padding: '6px 20px', background: '#1a2133', borderColor: '#1a2133', borderRadius: '6px', fontSize: '14px', fontWeight: 600, fontFamily: 'inherit', whiteSpace: 'nowrap' }}>Search</Button>
       <Button variant="outline-secondary" size="sm" className="ms-3" onClick={clearFilters}>Reset</Button>
     </div>
   )

--- a/src/components/elements/Report/Report.module.css
+++ b/src/components/elements/Report/Report.module.css
@@ -1,6 +1,6 @@
 .header {
-  font-weight: 500;
-  color: var(--gray-900);
+  font-weight: 600;
+  color: #1a2133;
   font-size: 28px;
   font-family: var(--font-serif);
   padding-bottom: 10px;
@@ -22,7 +22,7 @@
   display: flex;
   align-items: center;
   gap: 9px;
-  color: #8a95a3;
+  color: #8a94a6;
   font-size: 12.5px;
   padding: 24px 0 8px;
 }
@@ -32,7 +32,7 @@
   height: 18px;
   flex-shrink: 0;
   border: 2px solid #ddd8d0;
-  border-top-color: #8a95a3;
+  border-top-color: #8a94a6;
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
 }

--- a/src/components/elements/Report/ReportsResultPane.module.css
+++ b/src/components/elements/Report/ReportsResultPane.module.css
@@ -17,7 +17,7 @@
 
 .cardDate {
   font-size: 12px;
-  color: rgb(100, 100, 100);
+  color: #5a6478;
 }
 
 .metaSep {
@@ -28,7 +28,7 @@
 .articleTitle {
   font-size: 16px;
   font-weight: 600;
-  color: #1a1a1a;
+  color: #1a2133;
   line-height: 1.4;
   margin-bottom: 8px;
 }
@@ -40,9 +40,9 @@
   letter-spacing: 0.03em;
   padding: 3px 10px;
   border-radius: 20px;
-  background: #e6eef7;
+  background: #eeeae4;
   border: none;
-  color: #2c4a7c;
+  color: #5a6478;
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -89,14 +89,14 @@
 }
 
 .idLink {
-  color: #2c4a7c;
+  color: #2563a8;
   text-decoration: underline;
-  text-decoration-color: #b8cce4;
+  text-decoration-color: #c9d9f0;
   text-underline-offset: 2px;
 }
 
 .idLink:hover {
-  text-decoration-color: #2c4a7c;
+  text-decoration-color: #2563a8;
 }
 
 .dot {
@@ -129,7 +129,7 @@
 .metricLabel {
   position: relative;
   cursor: help;
-  border-bottom: 1px dashed #b8c4d0;
+  border-bottom: 1px dashed #ddd7ce;
   white-space: nowrap;
   display: inline-block;
 }
@@ -145,8 +145,8 @@
   left: 50%;
   transform: translateX(-50%);
   width: 230px;
-  background: #1e2a3a;
-  color: #f0f4fa;
+  background: #1a2133;
+  color: #f5f2ee;
   font-size: 11.5px;
   line-height: 1.55;
   font-weight: 400;
@@ -166,7 +166,7 @@
   left: 50%;
   transform: translateX(-50%);
   border: 6px solid transparent;
-  border-top-color: #1e2a3a;
+  border-top-color: #1a2133;
 }
 
 .metricValue {

--- a/src/components/elements/Report/ReportsResultPane.tsx
+++ b/src/components/elements/Report/ReportsResultPane.tsx
@@ -115,7 +115,7 @@ export const ReportsResultPane: React.FC<ReportsResultPaneProps> = ({
         <span className={styles.metaSep}>·</span>
         <span className={styles.cardDate}>{publicationDateDisplay}</span>
         <span className={styles.metaSep}>·</span>
-        <span className={styles.cardDate}><span className={styles.idLabel}>PMID</span> <a className={styles.idLink} href={`${pubMedUrl}${pmid}`} target="_blank" rel="noreferrer">{pmid}</a><span style={{userSelect: 'none', color: '#2c4a7c'}}> ↗</span></span>
+        <span className={styles.cardDate}><span className={styles.idLabel}>PMID</span> <a className={styles.idLink} href={`${pubMedUrl}${pmid}`} target="_blank" rel="noreferrer">{pmid}</a><span style={{userSelect: 'none', color: '#2563a8'}}> ↗</span></span>
       </div>
 
       {/* Row 2: Title */}

--- a/src/components/elements/Report/SearchSummary.module.css
+++ b/src/components/elements/Report/SearchSummary.module.css
@@ -13,8 +13,8 @@
 .articlesCount {
   font-family: var(--font-serif);
   font-size: 28px;
-  font-weight: 500;
-  color: var(--gray-900);
+  font-weight: 600;
+  color: #1a2133;
 }
 
 .controlsRow {
@@ -64,6 +64,19 @@
   font-size: 14px !important;
   padding: 6px 14px !important;
   margin: 0 !important;
+  background-color: #1a2133 !important;
+  border: 1px solid #1a2133 !important;
+  color: #fff !important;
+  font-weight: 600 !important;
+  border-radius: var(--radius-md) !important;
+}
+
+.exportBtn:hover,
+.exportBtn:focus,
+.exportBtn:active {
+  background-color: #11172a !important;
+  border-color: #11172a !important;
+  color: #fff !important;
 }
 
 /* ── SORT BY ── */
@@ -87,14 +100,14 @@
 .sortItem:hover {
   background: #f7f5f1;
   color: #2c2a27;
-  border-left-color: #2c4a7c;
+  border-left-color: #2563a8;
 }
 
 .sortItemActive {
   color: #2c2a27;
   font-weight: 500;
   background: #f7f5f1;
-  border-left-color: #2c4a7c;
+  border-left-color: #2563a8;
 }
 
 .sortLabel {
@@ -135,7 +148,7 @@
 }
 
 .sortToggleBtnActive {
-  background: #2c4a7c;
+  background: #2563a8;
   color: #fff;
 }
 
@@ -159,18 +172,18 @@
 .showItem:hover {
   background: #f7f5f1 !important;
   color: #2c2a27 !important;
-  border-left-color: #2c4a7c;
+  border-left-color: #2563a8;
 }
 
 .showItemActive {
   color: #2c2a27 !important;
   font-weight: 500;
   background: #f7f5f1 !important;
-  border-left-color: #2c4a7c;
+  border-left-color: #2563a8;
 }
 
 .showCheck {
-  color: #2c4a7c;
+  color: #2563a8;
   font-size: 11px;
 }
 

--- a/src/components/elements/Report/SearchSummary.tsx
+++ b/src/components/elements/Report/SearchSummary.tsx
@@ -464,9 +464,9 @@ const SearchSummary = ({
                   {isActive && <span className={styles.sortDirection}>{isDesc ? 'High → Low' : 'Low → High'}</span>}
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style={{ opacity: isActive ? 1 : 0.3, flexShrink: 0 }}>
                     {(isActive && !isDesc) ? (
-                      <path d="M7 11V3M7 3L4 6M7 3l3 3" stroke={isActive ? '#2c4a7c' : '#6b6560'} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M7 11V3M7 3L4 6M7 3l3 3" stroke={isActive ? '#2563a8' : '#6b6560'} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                     ) : (
-                      <path d="M7 3v8M7 11L4 8M7 11l3-3" stroke={isActive ? '#2c4a7c' : '#6b6560'} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M7 3v8M7 11L4 8M7 11l3-3" stroke={isActive ? '#2563a8' : '#6b6560'} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                     )}
                   </svg>
                 </button>

--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -13,7 +13,7 @@ import { updatePubFiltersFromSearch } from "../../../redux/actions/actions";
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { styled } from '@mui/material/styles';
-import { Table,Button} from "react-bootstrap";
+import { Table,Button,Dropdown} from "react-bootstrap";
 import SplitDropdown from "../Dropdown/SplitDropdown";
 import Loader from "../Common/Loader";
 import { reciterConfig } from "../../../../config/local";
@@ -640,7 +640,7 @@ const Search = () => {
     // setCurateIds(paginatedIdentities);
     tableBody = paginatedIdentities.map(function (identity, identityIndex) {
       return <tr key={identityIndex}>
-        <td key={`${identityIndex}__name`} width="30%">
+        <td key={`${identityIndex}__name`} width="34%">
         {
 
           isCuratorSelf ?
@@ -649,11 +649,9 @@ const Search = () => {
           <Name identity={identity} nameOrcwidLabel={nameOrcwidLabel?.labelUserView} onClickProfile={ dropdownTitle && dropdownTitle === 'Curate Publications' ? () => onClickProfile(identity.personIdentifier) :() => redirectToCurate("report", identity)} proxyPersonIds={proxyPersonIds}></Name>
         }
         </td>
-        <td key={`${identityIndex}__orgUnit`} width="20%" className={styles.colOrg}>
-          {identity.primaryOrganizationalUnit && <div>{identity.primaryOrganizationalUnit}</div>}
-        </td>
-        <td key={`${identityIndex}__institution`} width="20%" className={styles.colInst}>
-          {identity.primaryInstitution && <div>{identity.primaryInstitution}</div>}
+        <td key={`${identityIndex}__affiliation`} width="32%" className={styles.colAffiliation}>
+          {identity.primaryOrganizationalUnit && <div className={styles.affilOrg}>{identity.primaryOrganizationalUnit}</div>}
+          {identity.primaryInstitution && <div className={styles.affilInst}>{identity.primaryInstitution}</div>}
         </td>
         {isCuratorAll || isSuperUser  ?
         <td key={`${identityIndex}__pending`} width="10%" className={styles.colPending}>
@@ -662,20 +660,25 @@ const Search = () => {
             <span className={styles.pendingBadgeNone}>0</span>
           }
         </td>
-         : ""}
-        <td key={`${identityIndex}__dropdown`} width="20%" className={styles.actionsCell}>
-          <button type="button" className={styles.actionLink} style={{fontWeight:500}} onClick={() => onClickProfile(identity.personIdentifier)}>Curate</button>
-          <span className={styles.actionDot}>·</span>
-          <button type="button" className={styles.actionLink} onClick={() => redirectToCurate("report", identity)}>Reports</button>
-          <span className={styles.actionDot}>·</span>
-          <button type="button" className={styles.actionLink} onClick={() => { setShowprofileID(identity.personIdentifier); handleShow(); }}>Profile</button>
+         : null}
+        <td key={`${identityIndex}__actions`} width="24%" className={styles.actionsCell}>
+          <Dropdown className="d-inline-block">
+            <Dropdown.Toggle variant="primary" id={`actions_${identity.personIdentifier}`}>
+              Curate Publications
+            </Dropdown.Toggle>
+            <Dropdown.Menu className={styles.actionMenu}>
+              <Dropdown.Item className={styles.actionMenuItem} onClick={() => onClickProfile(identity.personIdentifier)}>Curate Publications</Dropdown.Item>
+              <Dropdown.Item className={styles.actionMenuItem} onClick={() => redirectToCurate("report", identity)}>Create Reports</Dropdown.Item>
+              <Dropdown.Item className={styles.actionMenuItem} onClick={() => { setShowprofileID(identity.personIdentifier); handleShow(); }}>View Profile</Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
         </td>
       </tr>;
     })
   } else {
     tableBody = (
       <tr>
-        <td colSpan="5">
+        <td colSpan={(isCuratorAll || isSuperUser) ? 4 : 3}>
           <p className={styles.noitemsList}>
             {showScopeFilter && scopeFilterChecked
               ? 'No people found matching your scope. Try unchecking the scope filter to see all results.'
@@ -760,9 +763,8 @@ const Search = () => {
                         <thead>
                           <tr>
                             <th key="0">Name</th>
-                            <th key="1">Organization</th>
-                            <th key="2">Institution</th>
-                            {isCuratorAll || isSuperUser  ? <th key="3">Pending</th> : ""}
+                            <th key="1">Affiliation</th>
+                            {isCuratorAll || isSuperUser  ? <th key="3">Pending</th> : null}
                             <th key="4">Actions</th>
                           </tr>
                         </thead>
@@ -803,17 +805,21 @@ function Name(props) {
 
   if (props.identity.firstName !== undefined) {
     const nameString = `${firstName} ${middleName} ${lastName}`.replace(/\s+/g, ' ').trim()
+    const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase() || '?'
     return (
-      <div>
-        <div className={styles.nameRow}>
-          <button className={styles.btnLink} onClick={props.onClickProfile}>
-            {nameString}
-          </button>
-          {isProxyFor(props.proxyPersonIds, props.identity.personIdentifier) && <ProxyBadge />}
-        </div>
-        {props.identity.title && <div className={styles.personRole}>{props.identity.title}</div>}
-        <div className={styles.personCwid}>
-          <span className={styles.cwidLabel}>{props.nameOrcwidLabel}:</span> {props.identity.personIdentifier}
+      <div className={styles.nameCell}>
+        <div className={styles.monogram} aria-hidden="true">{initials}</div>
+        <div className={styles.nameBlock}>
+          <div className={styles.nameRow}>
+            <button className={styles.btnLink} onClick={props.onClickProfile}>
+              {nameString}
+            </button>
+            {isProxyFor(props.proxyPersonIds, props.identity.personIdentifier) && <ProxyBadge />}
+          </div>
+          {props.identity.title && <div className={styles.personRole}>{props.identity.title}</div>}
+          <div className={styles.personCwid}>
+            <span className={styles.cwidLabel}>{props.nameOrcwidLabel}:</span> {props.identity.personIdentifier}
+          </div>
         </div>
       </div>
     )

--- a/src/components/elements/Search/Search.module.css
+++ b/src/components/elements/Search/Search.module.css
@@ -32,7 +32,7 @@
 .resultsBar {
   background: #ffffff;
   border: 1px solid #e8e2d9;
-  border-radius: 8px 8px 0 0;
+  border-radius: 6px 6px 0 0;
   padding: 12px 16px;
   display: flex;
   align-items: center;
@@ -214,7 +214,7 @@
 /* ── TABLE ── */
 .table {
   border: 1px solid #eae6df;
-  border-radius: 10px;
+  border-radius: 6px;
   overflow: hidden;
   font-family: var(--font-sans);
 }
@@ -226,7 +226,7 @@
 
 .table > thead th {
   font-size: 11px !important;
-  font-weight: 500 !important;
+  font-weight: 600 !important;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: #8a847c !important;
@@ -256,7 +256,7 @@
 }
 
 .table tbody td {
-  padding: 10px 14px;
+  padding: 12px 14px;
   vertical-align: middle;
   font-size: 13px;
   color: #6b6560;
@@ -270,7 +270,7 @@
 
 .table tr a {
   text-decoration: none;
-  color: #2c4a7c;
+  color: #2563a8;
   font-weight: 500;
   font-size: 14px;
 }
@@ -291,12 +291,11 @@
 /* Person name button link in table */
 .btnLink {
   text-decoration: none;
-  color: #2c4a7c;
+  color: #1a2133;
   background: none;
   border: none;
   padding: 0px;
-  font-weight: 500;
-  font-size: 14px;
+  font-weight: 600;
   font-size: 14px;
   font-family: var(--font-sans);
   cursor: pointer;
@@ -306,7 +305,7 @@
 
 .btnLink:hover {
   text-decoration: underline;
-  color: #2c4a7c;
+  color: #2563a8;
 }
 
 /* Person role / title */
@@ -319,9 +318,10 @@
 
 /* CWID line */
 .personCwid {
-  font-size: 11.5px;
+  font-size: 11px;
   color: #8a94a6;
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
 }
 
 .cwidLabel {
@@ -329,24 +329,98 @@
   color: #5a6478;
 }
 
+/* Name cell: monogram + text block */
+.nameCell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.monogram {
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #eeeae4;
+  color: #1a2133;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.nameBlock {
+  min-width: 0;
+}
+
+/* Affiliation cell: organization over institution */
+.colAffiliation {
+  vertical-align: middle;
+}
+
+.affilOrg {
+  font-size: 13px;
+  color: #1a2133;
+  line-height: 1.4;
+}
+
+.affilInst {
+  font-size: 12px;
+  color: #8a94a6;
+  line-height: 1.4;
+  margin-top: 1px;
+}
+
 /* Column-specific styles */
 .actionsCell {
   text-align: left !important;
+  vertical-align: middle;
+}
+
+.actionsCell :global(.mt-2) {
+  margin-top: 0 !important;
+}
+
+/* Row action menu — matches the top filter pill dropdowns */
+.actionMenu {
+  min-width: 180px;
+  border-radius: 8px;
+  border: 1px solid #d6d0c4;
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.actionMenuItem {
+  padding: 8px 14px !important;
+  font-size: 13px !important;
+  color: #1a2133 !important;
+}
+
+.actionMenuItem:hover,
+.actionMenuItem:focus {
+  background: #f7f5f1 !important;
+  color: #1a2133 !important;
 }
 
 .actionLink {
   background: none;
   border: none;
-  padding: 0;
+  padding: 2px 6px;
+  border-radius: 4px;
   font-family: inherit;
   font-size: 12px;
-  color: #2c4a7c;
+  color: #2563a8;
   cursor: pointer;
   text-decoration: none;
 }
 
 .actionLink:hover {
   text-decoration: underline;
+  background: var(--color-accent-soft, rgba(37,99,168,0.1));
 }
 
 .actionDot {
@@ -379,14 +453,14 @@
   border-radius: 11px;
   font-size: 11px;
   font-weight: 600;
-  background: #e6eef7;
-  color: #2c4a7c;
+  background: #eeeae4;
+  color: #1a2133;
   border: none;
 }
 
 .pendingBadgeNone {
   font-size: 12px;
-  color: #a09a92;
+  color: #8a94a6;
 }
 
 .noitemsList {

--- a/src/components/elements/Search/SearchBar.tsx
+++ b/src/components/elements/Search/SearchBar.tsx
@@ -137,7 +137,7 @@ useEffect(() => {
                 value=""
               />
               <span style={{ flex: 1 }} />
-              <Button className="primary" type="submit" style={{ padding: '6px 20px', background: '#8B1A1A', borderColor: '#8B1A1A', borderRadius: '20px', fontSize: '14px', fontWeight: 500, fontFamily: 'inherit', whiteSpace: 'nowrap' }}>Search</Button>
+              <Button className="primary" type="submit" style={{ padding: '6px 20px', background: '#1a2133', borderColor: '#1a2133', borderRadius: '6px', fontSize: '14px', fontWeight: 600, fontFamily: 'inherit', whiteSpace: 'nowrap' }}>Search</Button>
               <button type="button" className={styles.textButton} onClick={clearFilters} style={{ background: 'none', border: 'none', padding: 0, fontFamily: 'inherit', fontSize: '13px', color: '#a09a92', cursor: 'pointer', whiteSpace: 'nowrap' }}>Reset</button>
             </div>
           </div>

--- a/src/components/elements/TabAddPublication/TabAddPublication.module.css
+++ b/src/components/elements/TabAddPublication/TabAddPublication.module.css
@@ -67,7 +67,7 @@
     padding: 7px 16px;
     font-size: 12.5px;
     font-weight: 600;
-    background: var(--wcm-red);
+    background: #1a2133;
     color: #fff;
     border: none;
     border-radius: 6px;
@@ -76,7 +76,7 @@
 }
 
 .searchBtn:hover {
-    background: var(--wcm-red-dark);
+    background: #11172a;
 }
 
 .resetBtn {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,13 +26,15 @@ const theme = createTheme({
     },
   },
   typography: {
+    // Matches --font-sans in globals.css (Inter loaded via Google Fonts <link> in _document.tsx).
     fontFamily: [
-      'Arial',
-      'Helvetica',
+      '"Inter"',
       '-apple-system',
       'BlinkMacSystemFont',
       '"Segoe UI"',
       'Roboto',
+      'Helvetica',
+      'Arial',
       'sans-serif',
     ].join(','),
   },

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,32 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+// Pages-Router custom Document.
+// Webfonts are loaded here via a plain Google Fonts <link> rather than next/font:
+// package.json pins Next ^12.2.5 while node_modules currently resolves Next 14.x,
+// so next/font would break on a clean reinstall to the pin. A <link> is stable
+// across both. Inter is used for both body (--font-sans) and display (--font-display).
+// Do not add <title> or meta charset here — those are owned by _app.tsx / per-page Head.
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}

--- a/src/pages/curate/index.js
+++ b/src/pages/curate/index.js
@@ -2,24 +2,17 @@ import CuratePublications from '../../components/elements/CuratePublications/Cur
 import { AppLayout } from "../../components/layouts/AppLayout"
 import { getSession } from "next-auth/client"
 
-/* export async function getServerSideProps(ctx) {
-    const session = await getSession(ctx);
-
-    if (!session || !session.data) {
-        return {
-            redirect: {
-                destination: "/login",
-                permanent: false,
-            },
-        };
-    }
-
+// The group curation surface (the multi-person People/Org/Institution/Person-Type queue)
+// has been retired. Curate individuals via Find People (/search -> person -> /curate/[cwid])
+// or use the Authorships review queue. Any visit to /curate redirects to Find People.
+export async function getServerSideProps() {
     return {
-        props: {
-            session: session,
+        redirect: {
+            destination: "/search",
+            permanent: false,
         },
     };
-} */
+}
 
 const PublicationsPage = () => {
     return (

--- a/src/redux/reducers/reducers.js
+++ b/src/redux/reducers/reducers.js
@@ -309,15 +309,28 @@ export const institutionsFetching = (state=false, action) => {
 
 }
 
+// Institutions that should always appear first in any Institution(s) dropdown,
+// in this order. Names must match the primaryInstitution values exactly.
+const PINNED_INSTITUTIONS = ['Weill Cornell Medicine', 'Weill Cornell Medical College in Qatar'];
+
+const sortPinnedInstitutions = (list) => {
+  if (!Array.isArray(list)) return list;
+  const pinned = PINNED_INSTITUTIONS
+    .map(name => list.find(item => item && item.primaryInstitution === name))
+    .filter(Boolean);
+  const rest = list.filter(item => !(item && PINNED_INSTITUTIONS.includes(item.primaryInstitution)));
+  return [...pinned, ...rest];
+};
+
 export const institutionsData = (state=[], action) => {
 
   switch(action.type) {
-      
+
       case methods.INSTITUTIONS_CLEAR_ALL_DATA :
           return []
 
       case methods.INSTITUTIONS_CHANGE_ALL_DATA :
-          return action.payload
+          return sortPinnedInstitutions(action.payload)
 
       default :
           return state

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -30,12 +30,20 @@
   --color-warning: #f59e0b;
   --color-warning-light: #fef3c7;
 
-  /* Chrome (dark sidebar/header) */
-  --color-chrome: #1e2d3d;
-  --color-chrome-hover: #273848;
-  --color-chrome-border: #2e4050;
-  --color-chrome-text: #8aa8c0;
+  /* Chrome (dark sidebar/header) — one navy across the app.
+     Aligned to the shipped hardcode #1a2133 used by headings, CTAs, dark tokens,
+     and the sidebar (reconciles STYLEGUIDE drift #2 and #3). */
+  --color-chrome: #1a2133;
+  --color-chrome-hover: #252d42;
+  --color-chrome-border: #2a3350;
+  --color-chrome-text: #a0aec0;
   --color-chrome-text-bright: #e2e8f0;
+
+  /* Accent blue — canonical accent token (reconciles STYLEGUIDE drift #4).
+     Use for content/curator links, focus rings, selected state, ProxyBadge.
+     The global <a> color uses this accent token; WCM red is reserved for brand chrome. */
+  --color-accent: #2563a8;
+  --color-accent-soft: rgba(37, 99, 168, 0.1);
 
   /* Warm content */
   --color-warm-bg: #f5f2ee;
@@ -63,8 +71,13 @@
   --radius-pill: 999px;
 
   /* Typography */
-  --font-sans: Arial, Helvetica, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --font-serif: 'Space Grotesk', sans-serif;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-display: 'Inter', sans-serif;
+  /* --font-serif is a legacy alias of --font-display (kept so existing references resolve). */
+  --font-serif: var(--font-display);
+  /* Bootstrap's reboot is imported after globals.css and sets body font from this var;
+     point it at our stack so DM Sans actually reaches body text app-wide. */
+  --bs-body-font-family: var(--font-sans);
   --font-size-xs: 12px;
   --font-size-sm: 14px;
   --font-size-base: 16px;
@@ -85,7 +98,7 @@ html,
 body {
   height: 100vh;
   background: var(--color-warm-bg) !important;
-  font-family: var(--font-sans);
+  font-family: var(--font-sans) !important;
   color: var(--gray-900);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
@@ -94,15 +107,15 @@ body {
 
 .btn-warning {
   background-color: #ffffff !important;
-  color: var(--gray-700) !important;
-  border: 1px solid var(--gray-300) !important;
+  color: #5a6478 !important;
+  border: 1px solid #ddd7ce !important;
   border-radius: var(--radius-md) !important;
   font-size: 14px !important;
 }
 .btn-warning:hover {
-  background-color: var(--gray-50) !important;
-  border-color: var(--gray-400) !important;
-  color: var(--gray-800) !important;
+  background-color: #faf8f5 !important;
+  border-color: #bbb5aa !important;
+  color: #1a2133 !important;
 }
 
 /* Form controls — warm input style */
@@ -145,13 +158,14 @@ h3 strong {
 }
 
 a {
-  color: var(--wcm-red);
+  color: var(--color-accent);
   text-decoration: none;
   transition: color 0.15s ease;
 }
 
 a:hover {
-  color: var(--wcm-red-dark);
+  color: var(--color-accent);
+  text-decoration: underline;
 }
 
 * {
@@ -237,7 +251,7 @@ h1 {
 .table {
   vertical-align: middle !important;
   border-radius: var(--radius-md);
-  border-color: var(--gray-200);
+  border-color: var(--color-warm-border);
 }
 
 .wcm-primary-lg.btn {
@@ -322,7 +336,7 @@ h1 {
 }
 
 .border-grey {
-  border: 1px solid #ced4da;
+  border: 1px solid #ddd7ce;
 }
 
 .rounded-right {
@@ -395,20 +409,20 @@ h1 {
 
 .btn-outline-secondary {
   border-color: var(--color-warm-border) !important;
-  color: var(--gray-600) !important;
+  color: #5a6478 !important;
   border-radius: var(--radius-pill) !important;
   font-size: 13px !important;
   padding: 6px 14px !important;
 }
 
 .btn-outline-secondary:hover {
-  background-color: var(--gray-100) !important;
-  border-color: var(--gray-400) !important;
-  color: var(--gray-800) !important;
+  background-color: #faf8f5 !important;
+  border-color: #bbb5aa !important;
+  color: #1a2133 !important;
 }
 
 .dropdown-menu {
-  border: 1px solid var(--gray-200);
+  border: 1px solid var(--color-warm-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   padding: 12px 0;


### PR DESCRIPTION
**Draft for visual review.** This is the "calm" UI redesign that had been sitting **uncommitted** in a local worktree (`~/worktrees/pm-calm-redesign`) — never committed, merged, or deployed, which is why reciter-dev still shows Space Grotesk + the red Search button. Now preserved and rebased onto current `dev_Upd`.

## What it changes (37 files, +1326/−921)
- **Typeface → Inter.** `--font-sans` / `--font-display` switch to Inter, loaded via a Google Fonts `<link>` in a new `src/pages/_document.tsx`. `--font-serif` is kept as a legacy alias of `--font-display` so existing references resolve (it is no longer a serif).
- **Buttons → navy system.** Re-skinned off the library-default WCM red (`#b31b1b`) to navy (`#1a2133` / `#243050`) to stop react-bootstrap `.btn-primary` / MUI red leakage (the Search PubMed button, export buttons, etc.).
- **Surface refit** across curate, authorships, search, reports, and manage-users (spacing, headers, tables, modals, pagination, skeletons), plus `STYLEGUIDE.md` as the design contract.

## Conflict reconciliation
The only file that also changed on `dev_Upd` since the redesign's base was `src/pages/api/auth/[...nextauth].jsx`. The redesign's change there was a local-login email fallback that `dev_Upd` **already contains a superset of** (plus the impersonation overlay), so the rebase took `dev_Upd`'s version verbatim — **this PR makes no auth changes** (`[...nextauth].jsx` is byte-identical to `dev_Upd`).

## Before merging — please verify
- ⚠️ **Visual review needed.** This repo has no per-PR preview env (it deploys from `dev_Upd` via CodeBuild), so visual verification means running the branch locally or merging to dev. I can run it on the local dev server and screenshot the key pages if you want eyes on it before merge.
- ⚠️ **Possible WIP.** Per the handoff notes, curate + authorships were "done" but search / reports / styleguide were a handoff — some surfaces may be incomplete. Worth a pass for half-finished screens.
- ℹ️ **Raw backup:** the pre-rebase commit is preserved on `origin/feature/calmer-pm-ui` if anything needs to be recovered.

Not for merge until you've signed off visually.