### PR TITLE
fix(rbac): role-derived permission fallback in login-landing paths (completes #738)

### DIFF
--- a/src/components/elements/Login/Login.js
+++ b/src/components/elements/Login/Login.js
@@ -7,7 +7,7 @@ import Router from "next/router"
 import Header from "../Header/Header"
 import { signIn,getSession } from "next-auth/client"
 import { toast } from "react-toastify"
-import { getPermissionsFromRaw, getLandingPageFromPermissions } from '../../../utils/permissionUtils';
+import { getPermissionsFromRaw, getPermissionsFromRoles, getLandingPageFromPermissions } from '../../../utils/permissionUtils';
 import { useRouter } from 'next/router'
 
 const Login = () => {
@@ -43,8 +43,17 @@ const Login = () => {
             });
             getSession().then((session) => {
                 if (session) {
-                    const permissions = getPermissionsFromRaw(session?.data?.permissions)
+                    let permissions = getPermissionsFromRaw(session?.data?.permissions)
                     const userRoles = session.data.userRoles ? JSON.parse(session.data.userRoles) : []
+
+                    // Fallback when the data-driven permission set is empty (RBAC
+                    // permission tables not seeded in this env, or the login-time
+                    // lookup failed): derive permissions from role labels so
+                    // privileged users are never sent to /noaccess. Mirrors the
+                    // middleware MW-03 fallback.
+                    if (permissions.length === 0) {
+                        permissions = getPermissionsFromRoles(userRoles)
+                    }
 
                     if (!session.data.databaseUser || session.data.databaseUser.status == 0) {
                         router.push('/noaccess')

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import { getSession } from "next-auth/client"
-import { getPermissionsFromRaw, getLandingPageFromPermissions } from "../utils/permissionUtils"
+import { getPermissionsFromRaw, getPermissionsFromRoles, getLandingPageFromPermissions } from "../utils/permissionUtils"
 
 export async function getServerSideProps(ctx) {
   const session = await getSession(ctx)
@@ -18,8 +18,17 @@ export async function getServerSideProps(ctx) {
   }
 
   // Resolve permissions and landing page
-  const permissions = getPermissionsFromRaw(session.data.permissions)
+  let permissions = getPermissionsFromRaw(session.data.permissions)
   const userRoles = session.data.userRoles ? JSON.parse(session.data.userRoles) : []
+
+  // Fallback when the data-driven permission set is empty (RBAC permission
+  // tables not seeded in this env, or the login-time lookup failed): derive
+  // permissions from role labels so privileged users are never sent to
+  // /noaccess. Mirrors the middleware MW-03 fallback.
+  if (permissions.length === 0) {
+    permissions = getPermissionsFromRoles(userRoles)
+  }
+
   const landingPage = getLandingPageFromPermissions(permissions, userRoles)
 
   return { redirect: { destination: landingPage, permanent: false } }


### PR DESCRIPTION
**Incident hotfix.** The data-driven RBAC middleware fail-safe (#738) was incomplete: it patched only `middleware.ts`, but the `/noaccess` decision is *also* made in `Login.js` and `pages/index.js`, which call `getLandingPageFromPermissions` directly. On reciter-dev (unseeded permission tables + local CWID login), a Superuser resolved **empty permissions** → landed on `/noaccess` at login — a full lockout.

This applies the same `getPermissionsFromRoles()` fallback to both landing paths, so a privileged user whose JWT carries roles but empty permissions lands on their correct page. `search/index.js` gates on roles (which resolve), so it's untouched.

- ✅ `next build` exit 0
- ✅ Mirrors the already-unit-tested middleware fallback (`getPermissionsFromRoles`, 8 passing tests)
- Recovery path for the lockout caused by deploying the data-driven RBAC build without seeded tables.