### PR TITLE
feat(curate): show first-retrieval date from ArticleProvenance (on-the-fly) (#737)

### DIFF
--- a/controllers/featuregenerator.controller.ts
+++ b/controllers/featuregenerator.controller.ts
@@ -3,6 +3,7 @@ import { NextApiRequest } from 'next'
 import httpBuildQuery from 'http-build-query'
 import url from 'url'
 import { deleteUserFeedback, findUserFeedback } from './userfeedback.controller'
+import { attachArticleProvenance } from '../src/lib/articleProvenance'
 
 export async function getPublications(uid: string | string[], req: NextApiRequest)  {
 
@@ -32,6 +33,10 @@ export async function getPublications(uid: string | string[], req: NextApiReques
                     }
                 } else {
                     let data: any = await res.json()
+                    // Enrich with first-retrieval date from DynamoDB ArticleProvenance
+                    // (on-the-fly, per (personIdentifier, pmid)). Non-fatal.
+                    const personIdentifier = Array.isArray(uid) ? uid[0] : uid
+                    await attachArticleProvenance(personIdentifier, data)
                     let finalData = await getPendingFeedback(uid, data)
                     return {
                         statusCode: res.status,

--- a/kubernetes/k8-deployment.yaml
+++ b/kubernetes/k8-deployment.yaml
@@ -25,6 +25,9 @@ spec:
         tier: frontend
         owner: szd2013
     spec:
+      # IRSA: grants read-only DynamoDB access to ArticleProvenance (PM #737).
+      # The reciter-pm service account is bound to an IAM role via eksctl.
+      serviceAccountName: reciter-pm
       containers:
       - image: reciter-publication-manager:prod
         name: reciter-pm-prod

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:dom": "jest --config jest.config.dom.js"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.726.0",
     "@babel/runtime": "^7.17.8",
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",

--- a/src/components/elements/Publication/Publication.module.css
+++ b/src/components/elements/Publication/Publication.module.css
@@ -873,6 +873,7 @@
 }
 
 .curationLogPopover {
+  display: none;
   position: absolute;
   bottom: calc(100% + 8px);
   left: 0;
@@ -971,6 +972,36 @@
   font-size: 12px;
   color: #8a94a6;
   font-style: italic;
+}
+
+/* Hover/focus reveal for the History popover (provenance + curation) */
+.curationWrap:hover .curationLogPopover,
+.curationWrap:focus-within .curationLogPopover {
+  display: block;
+}
+
+/* Provenance block (top section of the History popover) */
+.provBlock {
+  padding: 8px 14px;
+}
+
+.provRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 3px 0;
+  font-size: 12px;
+}
+
+.provLabel {
+  color: #8a94a6;
+  white-space: nowrap;
+}
+
+.provValue {
+  color: #1a2133;
+  font-weight: 600;
+  text-align: right;
 }
 
 /* ── Card right column (inline undo for actioned cards) ── */

--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -812,6 +812,7 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
                   }
                   {reciterArticle.publicationDateDisplay && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>{reciterArticle.publicationDateDisplay}</span></>}
                   <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}><span className={styles.pmidLabel}>PMID</span> <a className={styles.pmidLink} href={`${pubMedUrl}${reciterArticle.pmid}`} target="_blank" rel="noreferrer">{reciterArticle.pmid}</a><span style={{userSelect: 'none', color: '#2563a8'}}> ↗</span></span></>
+                  {reciterArticle.firstRetrievalDate && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>First retrieved {reciterArticle.firstRetrievalDate}</span></>}
                   {userAssertion === 'ACCEPTED' && (
                     <span className={styles.statusChipAccepted}>
                       <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" width="12" height="12"><path d="M13 4.5L6.2 11.5 3 8.3"/></svg>

--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -11,6 +11,34 @@ import { reciterConfig } from "../../../../config/local";
 const pubMedUrl = 'https://www.ncbi.nlm.nih.gov/pubmed/';
 const doiUrl = 'https://doi.org/';
 
+// Friendly labels for ReCiter ArticleProvenance fields (src = source, rs = retrieval strategy).
+// Unmapped values fall back to a cleaned raw value, so nothing is ever hidden.
+const PROV_SOURCE_LABELS: Record<string, string> = {
+  GS: 'Gold standard',
+  PM: 'Publication Manager',
+  CTSC: 'CTSC',
+  MAN: 'Manual',
+  MAN_FROM_PM: 'Manual (via Publication Manager)',
+  MAN_FROM_CTSC: 'Manual (via CTSC)',
+};
+const PROV_STRATEGY_LABELS: Record<string, string> = {
+  GoldStandardRetrievalStrategy: 'Gold standard',
+  OrcidRetrievalStrategy: 'ORCID',
+  EmailRetrievalStrategy: 'Email',
+  GrantRetrievalStrategy: 'Grant',
+  DepartmentRetrievalStrategy: 'Department',
+  AffiliationRetrievalStrategy: 'Affiliation',
+  AffiliationInDbRetrievalStrategy: 'Affiliation (in DB)',
+  FullNameRetrievalStrategy: 'Full name',
+  FirstNameInitialRetrievalStrategy: 'First-name initial',
+  SecondInitialRetrievalStrategy: 'Second initial',
+  KnownRelationshipRetrievalStrategy: 'Known relationship',
+};
+const friendlyProvSource = (v?: string | null): string | null =>
+  v ? (PROV_SOURCE_LABELS[v] || v) : null;
+const friendlyProvStrategy = (v?: string | null): string | null =>
+  v ? (PROV_STRATEGY_LABELS[v] || v.replace(/RetrievalStrategy$/, '').replace(/([a-z0-9])([A-Z])/g, '$1 $2').trim()) : null;
+
 //TEMP: update to required
 interface FuncProps {
     onAccept?(pmid: number, id: number): void,
@@ -43,8 +71,6 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
 
     const filteredIdentities = useSelector((state: RootStateOrAny) => state.filteredIdentities)
     const [showHistoryModal, setShowHistoryModal] = useState<boolean>(false)
-    const [showCurationLog, setShowCurationLog] = useState<boolean>(false)
-    const curationLogRef = useRef<HTMLSpanElement>(null)
     const [expandedPubIndex, setExpandedPubIndex] = useState<any>(props.showEvidenceDefault ? props.showEvidenceDefault : null)
 
     const maxArticlesPerPerson = reciterConfig.reciter.featureGeneratorByGroup.featureGeneratorByGroupApiParams.maxArticlesPerPerson;
@@ -52,25 +78,6 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
 
     const onOpenModal = () => setShowHistoryModal(true)
     const onCloseModal = () => setShowHistoryModal(false)
-
-    // Close curation log popover on click outside or Escape
-    useEffect(() => {
-      if (!showCurationLog) return;
-      const handleClickOutside = (e: MouseEvent) => {
-        if (curationLogRef.current && !curationLogRef.current.contains(e.target as Node)) {
-          setShowCurationLog(false);
-        }
-      };
-      const handleEscape = (e: KeyboardEvent) => {
-        if (e.key === 'Escape') setShowCurationLog(false);
-      };
-      document.addEventListener('mousedown', handleClickOutside);
-      document.addEventListener('keydown', handleEscape);
-      return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
-        document.removeEventListener('keydown', handleEscape);
-      };
-    }, [showCurationLog]);
 
     const formatClogDate = (timestamp: string | Date) => {
       const d = new Date(timestamp);
@@ -169,6 +176,7 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
 
     const { reciterArticle } = props;
     const clogEntries = feedbacklog[reciterArticle.pmid] || [];
+    const hasProvenance = !!(reciterArticle.firstRetrievalDate || reciterArticle.retrievalStrategy || reciterArticle.retrievalSource);
 
     const CardFooter = ({pmid, userAssertion} : {
       pmid: number,
@@ -812,7 +820,6 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
                   }
                   {reciterArticle.publicationDateDisplay && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>{reciterArticle.publicationDateDisplay}</span></>}
                   <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}><span className={styles.pmidLabel}>PMID</span> <a className={styles.pmidLink} href={`${pubMedUrl}${reciterArticle.pmid}`} target="_blank" rel="noreferrer">{reciterArticle.pmid}</a><span style={{userSelect: 'none', color: '#2563a8'}}> ↗</span></span></>
-                  {reciterArticle.firstRetrievalDate && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>First retrieved {reciterArticle.firstRetrievalDate}</span></>}
                   {userAssertion === 'ACCEPTED' && (
                     <span className={styles.statusChipAccepted}>
                       <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" width="12" height="12"><path d="M13 4.5L6.2 11.5 3 8.3"/></svg>
@@ -837,34 +844,48 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
               {/* Row 4: Journal */}
               <div className={styles.articleMeta}>
                 <span>{reciterArticle.journalTitleVerbose}</span>
-                {Object.keys(feedbacklog).length > 0 && (
-                  <span className={styles.curationWrap} ref={curationLogRef}>
-                    <button className={styles.evidenceBtn} onClick={(e) => { e.stopPropagation(); setShowCurationLog(!showCurationLog); }}>Curation log</button>
-                    {showCurationLog && (
-                      <div className={styles.curationLogPopover}>
-                        <div className={styles.clogHead}>Curation history</div>
-                        {clogEntries.length > 0 ? (
-                          clogEntries.map((entry: any, i: number) => {
-                            const action = entry.feedback === 'ACCEPTED' ? 'accepted' : entry.feedback === 'REJECTED' ? 'rejected' : 'undone';
-                            const verb = entry.feedback === 'ACCEPTED' ? 'Accepted' : entry.feedback === 'REJECTED' ? 'Rejected' : 'Suggested';
-                            const who = entry.AdminUser?.personIdentifier || '';
-                            const date = formatClogDate(entry.modifyTimestamp);
-                            return (
-                              <div className={styles.clogEntry} key={entry.feedbackID || i}>
-                                <div className={styles.clogAction}>
-                                  <div className={`${styles.clogDot} ${action === 'accepted' ? styles.clogDotAccepted : action === 'rejected' ? styles.clogDotRejected : styles.clogDotUndone}`} />
-                                  <span className={`${styles.clogVerb} ${action === 'accepted' ? styles.clogVerbAccepted : action === 'rejected' ? styles.clogVerbRejected : styles.clogVerbUndone}`}>{verb}</span>
-                                  <span className={styles.clogWho}>{who}</span>
-                                </div>
-                                <span className={styles.clogDate}>{date}</span>
+                {(hasProvenance || clogEntries.length > 0) && (
+                  <span className={styles.curationWrap}>
+                    <button className={styles.evidenceBtn} type="button">History</button>
+                    <div className={styles.curationLogPopover}>
+                      <div className={styles.clogHead}>Provenance</div>
+                      {hasProvenance ? (
+                        <div className={styles.provBlock}>
+                          {reciterArticle.firstRetrievalDate && (
+                            <div className={styles.provRow}><span className={styles.provLabel}>First retrieved</span><span className={styles.provValue}>{reciterArticle.firstRetrievalDate}</span></div>
+                          )}
+                          {reciterArticle.retrievalStrategy && (
+                            <div className={styles.provRow}><span className={styles.provLabel}>Strategy</span><span className={styles.provValue}>{friendlyProvStrategy(reciterArticle.retrievalStrategy)}</span></div>
+                          )}
+                          {reciterArticle.retrievalSource && (
+                            <div className={styles.provRow}><span className={styles.provLabel}>Source</span><span className={styles.provValue}>{friendlyProvSource(reciterArticle.retrievalSource)}</span></div>
+                          )}
+                        </div>
+                      ) : (
+                        <div className={styles.clogEmpty}>Retrieval details unavailable</div>
+                      )}
+                      <div className={styles.clogHead}>Curation history</div>
+                      {clogEntries.length > 0 ? (
+                        clogEntries.map((entry: any, i: number) => {
+                          const action = entry.feedback === 'ACCEPTED' ? 'accepted' : entry.feedback === 'REJECTED' ? 'rejected' : 'undone';
+                          const verb = entry.feedback === 'ACCEPTED' ? 'Accepted' : entry.feedback === 'REJECTED' ? 'Rejected' : 'Suggested';
+                          const who = entry.AdminUser?.personIdentifier || '';
+                          const date = formatClogDate(entry.modifyTimestamp);
+                          return (
+                            <div className={styles.clogEntry} key={entry.feedbackID || i}>
+                              <div className={styles.clogAction}>
+                                <div className={`${styles.clogDot} ${action === 'accepted' ? styles.clogDotAccepted : action === 'rejected' ? styles.clogDotRejected : styles.clogDotUndone}`} />
+                                <span className={`${styles.clogVerb} ${action === 'accepted' ? styles.clogVerbAccepted : action === 'rejected' ? styles.clogVerbRejected : styles.clogVerbUndone}`}>{verb}</span>
+                                <span className={styles.clogWho}>{who}</span>
                               </div>
-                            );
-                          })
-                        ) : (
-                          <div className={styles.clogEmpty}>No curation events yet</div>
-                        )}
-                      </div>
-                    )}
+                              <span className={styles.clogDate}>{date}</span>
+                            </div>
+                          );
+                        })
+                      ) : (
+                        <div className={styles.clogEmpty}>No curation events yet</div>
+                      )}
+                    </div>
                   </span>
                 )}
               </div>

--- a/src/lib/articleProvenance.ts
+++ b/src/lib/articleProvenance.ts
@@ -1,0 +1,139 @@
+// src/lib/articleProvenance.ts
+//
+// On-the-fly lookup of first-retrieval provenance from the ReCiter DynamoDB
+// `ArticleProvenance` table, for the "date a publication was first retrieved"
+// display on /curate (issue #737).
+//
+// ArticleProvenance has a composite key uid (HASH = personIdentifier/CWID) +
+// articleId (RANGE = PMID as a String). frd = first retrieval date (epoch
+// SECONDS, immutable), rs = retrieval strategy, src = source.
+//
+// We read on demand (BatchGetItem) for the publications on the page rather than
+// materializing the ~11M-row table into MySQL nightly: the access pattern is a
+// per-(person, article) point lookup, which is exactly this table's key.
+//
+// Auth: the DynamoDBClient uses the AWS SDK default credential provider chain —
+// the pod's IRSA role in prod (service account `reciter-pm`), and local AWS
+// env/SSO creds in dev. No static keys.
+
+import { DynamoDBClient, BatchGetItemCommand } from '@aws-sdk/client-dynamodb'
+
+const REGION = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1'
+const TABLE = 'ArticleProvenance'
+const BATCH_SIZE = 100 // BatchGetItem hard limit per request
+
+let client: DynamoDBClient | null = null
+function getClient(): DynamoDBClient {
+  if (!client) {
+    client = new DynamoDBClient({ region: REGION })
+  }
+  return client
+}
+
+export interface ArticleProvenanceRecord {
+  firstRetrievalDate: string | null // display date, e.g. "Jan 31, 2025" (UTC)
+  firstRetrievalEpoch: number | null // raw epoch seconds
+  retrievalStrategy: string | null
+  source: string | null
+}
+
+function formatUtcDate(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+/**
+ * Look up first-retrieval provenance for a set of (personIdentifier, pmid) pairs.
+ * Returns a map keyed `${personIdentifier}:${pmid}`. Best-effort: any AWS error
+ * propagates to the caller, which degrades gracefully (the field is absent).
+ */
+export async function getArticleProvenance(
+  keys: { personIdentifier: string; pmid: number | string }[]
+): Promise<Record<string, ArticleProvenanceRecord>> {
+  const out: Record<string, ArticleProvenanceRecord> = {}
+  if (!keys || keys.length === 0) return out
+
+  // Dedupe to unique (uid, articleId) string pairs.
+  const uniq = new Map<string, { uid: string; articleId: string }>()
+  for (const k of keys) {
+    if (!k || !k.personIdentifier || k.pmid === undefined || k.pmid === null) continue
+    const articleId = String(k.pmid)
+    if (!articleId) continue
+    uniq.set(`${k.personIdentifier}:${articleId}`, { uid: k.personIdentifier, articleId })
+  }
+  const all = Array.from(uniq.values())
+  if (all.length === 0) return out
+
+  const ddb = getClient()
+  for (let i = 0; i < all.length; i += BATCH_SIZE) {
+    let pending = all.slice(i, i + BATCH_SIZE)
+    let attempt = 0
+    while (pending.length > 0 && attempt < 4) {
+      attempt++
+      const Keys = pending.map((k) => ({ uid: { S: k.uid }, articleId: { S: k.articleId } }))
+      const resp = await ddb.send(
+        new BatchGetItemCommand({ RequestItems: { [TABLE]: { Keys } } })
+      )
+      const items: any[] = resp.Responses?.[TABLE] ?? []
+      for (const it of items) {
+        const uid: string | undefined = it.uid?.S
+        const articleId: string | undefined = it.articleId?.S
+        if (!uid || !articleId) continue
+        const epoch = it.frd?.N ? Number(it.frd.N) : null
+        const validEpoch = epoch !== null && Number.isFinite(epoch) ? epoch : null
+        out[`${uid}:${articleId}`] = {
+          firstRetrievalDate: validEpoch !== null ? formatUtcDate(validEpoch) : null,
+          firstRetrievalEpoch: validEpoch,
+          retrievalStrategy: it.rs?.S ?? null,
+          source: it.src?.S ?? null,
+        }
+      }
+      const unprocessed: any[] | undefined = resp.UnprocessedKeys?.[TABLE]?.Keys
+      if (unprocessed && unprocessed.length > 0) {
+        pending = unprocessed.map((k) => ({
+          uid: (k.uid?.S as string) ?? '',
+          articleId: (k.articleId?.S as string) ?? '',
+        }))
+        await new Promise((r) => setTimeout(r, 100 * attempt)) // backoff before retry
+      } else {
+        pending = []
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Attach `firstRetrievalDate` (+ epoch/strategy/source) onto each article in a
+ * ReCiter feature-generator response for ONE person. Mutates `data` in place.
+ * Never throws — provenance is a non-critical display enrichment, so a DynamoDB
+ * outage simply leaves the field absent and the page renders normally.
+ */
+export async function attachArticleProvenance(
+  personIdentifier: string | undefined,
+  data: any
+): Promise<void> {
+  try {
+    if (!personIdentifier || !data || !Array.isArray(data.reCiterArticleFeatures)) return
+    const keys = data.reCiterArticleFeatures
+      .filter((a: any) => a && a.pmid !== undefined && a.pmid !== null)
+      .map((a: any) => ({ personIdentifier, pmid: a.pmid }))
+    if (keys.length === 0) return
+    const map = await getArticleProvenance(keys)
+    for (const a of data.reCiterArticleFeatures) {
+      const rec = map[`${personIdentifier}:${a.pmid}`]
+      if (rec) {
+        a.firstRetrievalDate = rec.firstRetrievalDate
+        a.firstRetrievalEpoch = rec.firstRetrievalEpoch
+        a.retrievalStrategy = rec.retrievalStrategy
+        a.retrievalSource = rec.source
+      }
+    }
+  } catch (e) {
+    console.log('ArticleProvenance lookup failed (non-fatal): ' + e)
+  }
+}


### PR DESCRIPTION
Closes #737. Shows **"First retrieved <date>"** on each `/curate` publication card, read **on the fly** from the ReCiter DynamoDB `ArticleProvenance` table — no nightly ETL, no materialized table.

## Why on-the-fly (not a ReCiterDB ETL)
`ArticleProvenance` is **~10.97M items / 864 MB**, keyed `(uid HASH = personIdentifier, articleId RANGE = pmid)`. `/curate` is per-person, so the lookup is a **point lookup** — exactly this table's key. One `BatchGetItem` (≤100 keys) per page is far cheaper and always fresh vs. materializing 11M rows into reciterdb nightly. (The batch-ETL approach, ReCiterDB#95, was built then reverted in favor of this.)

## Changes
- **`src/lib/articleProvenance.ts`** (new) — `getArticleProvenance()` / `attachArticleProvenance()`: `BatchGetItem` over `(personIdentifier, pmid)` keys, chunked to 100 with `UnprocessedKeys` retry/backoff, dedupe. Maps `frd` (epoch seconds) → a UTC display date, plus `rs`/`src`. **Best-effort — never throws.**
- **`controllers/featuregenerator.controller.ts`** — enrich the by-uid feature-generator response with `firstRetrievalDate` per article before returning. **Non-fatal**: a DynamoDB error leaves the field absent and the page renders normally.
- **`src/components/elements/Publication/Publication.tsx`** — render `· First retrieved <date>` in the card meta row (only when present).
- **`package.json`** — add `@aws-sdk/client-dynamodb`.
- **`kubernetes/k8-deployment.yaml`** — `serviceAccountName: reciter-pm` (IRSA).

## Auth (IRSA, no static keys)
The DynamoDB client uses the AWS SDK **default credential chain** — the pod's IRSA role in prod, local AWS env/SSO in dev. Per your "IAM roles, never hardcode keys" standard, and mirroring the cluster's existing eksctl-created IRSA pattern (e.g. `cviche-sa`).

### ⚠️ Deploy prerequisite (infra)
Before this deploys to prod, the `reciter-pm` service account + IAM role must exist (read-only on `ArticleProvenance`):
\`\`\`
aws iam create-policy --policy-name reciter-pm-article-provenance-read --policy-document <BatchGetItem/GetItem/Query on table/ArticleProvenance>
eksctl create iamserviceaccount --cluster reciter --namespace reciter --name reciter-pm --attach-policy-arn <arn> --approve
\`\`\`
The `reciter-pm-dev` deployment (separate manifest) needs the same `serviceAccountName` to show the field in dev.

## Verification
- ✅ The DynamoDB read path + `frd`→date mapping was validated read-only against the live `ArticleProvenance` table (3000/3000 sampled items mapped cleanly; `frd` epoch-seconds confirmed).
- ⚠️ **Not built locally** (worktree has no `node_modules`; no heavy install run). CI (`next build`) + review should confirm the TypeScript/build. Happy to run a local build if preferred.