### PR TITLE
feat(curate): unified "History" panel — provenance + curation log

### DIFF
--- a/src/components/elements/Publication/Publication.module.css
+++ b/src/components/elements/Publication/Publication.module.css
@@ -873,6 +873,7 @@
 }
 
 .curationLogPopover {
+  display: none;
   position: absolute;
   bottom: calc(100% + 8px);
   left: 0;
@@ -971,6 +972,36 @@
   font-size: 12px;
   color: #8a94a6;
   font-style: italic;
+}
+
+/* Hover/focus reveal for the History popover (provenance + curation) */
+.curationWrap:hover .curationLogPopover,
+.curationWrap:focus-within .curationLogPopover {
+  display: block;
+}
+
+/* Provenance block (top section of the History popover) */
+.provBlock {
+  padding: 8px 14px;
+}
+
+.provRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 3px 0;
+  font-size: 12px;
+}
+
+.provLabel {
+  color: #8a94a6;
+  white-space: nowrap;
+}
+
+.provValue {
+  color: #1a2133;
+  font-weight: 600;
+  text-align: right;
 }
 
 /* ── Card right column (inline undo for actioned cards) ── */

--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -11,6 +11,34 @@ import { reciterConfig } from "../../../../config/local";
 const pubMedUrl = 'https://www.ncbi.nlm.nih.gov/pubmed/';
 const doiUrl = 'https://doi.org/';
 
+// Friendly labels for ReCiter ArticleProvenance fields (src = source, rs = retrieval strategy).
+// Unmapped values fall back to a cleaned raw value, so nothing is ever hidden.
+const PROV_SOURCE_LABELS: Record<string, string> = {
+  GS: 'Gold standard',
+  PM: 'Publication Manager',
+  CTSC: 'CTSC',
+  MAN: 'Manual',
+  MAN_FROM_PM: 'Manual (via Publication Manager)',
+  MAN_FROM_CTSC: 'Manual (via CTSC)',
+};
+const PROV_STRATEGY_LABELS: Record<string, string> = {
+  GoldStandardRetrievalStrategy: 'Gold standard',
+  OrcidRetrievalStrategy: 'ORCID',
+  EmailRetrievalStrategy: 'Email',
+  GrantRetrievalStrategy: 'Grant',
+  DepartmentRetrievalStrategy: 'Department',
+  AffiliationRetrievalStrategy: 'Affiliation',
+  AffiliationInDbRetrievalStrategy: 'Affiliation (in DB)',
+  FullNameRetrievalStrategy: 'Full name',
+  FirstNameInitialRetrievalStrategy: 'First-name initial',
+  SecondInitialRetrievalStrategy: 'Second initial',
+  KnownRelationshipRetrievalStrategy: 'Known relationship',
+};
+const friendlyProvSource = (v?: string | null): string | null =>
+  v ? (PROV_SOURCE_LABELS[v] || v) : null;
+const friendlyProvStrategy = (v?: string | null): string | null =>
+  v ? (PROV_STRATEGY_LABELS[v] || v.replace(/RetrievalStrategy$/, '').replace(/([a-z0-9])([A-Z])/g, '$1 $2').trim()) : null;
+
 //TEMP: update to required
 interface FuncProps {
     onAccept?(pmid: number, id: number): void,
@@ -43,8 +71,6 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
 
     const filteredIdentities = useSelector((state: RootStateOrAny) => state.filteredIdentities)
     const [showHistoryModal, setShowHistoryModal] = useState<boolean>(false)
-    const [showCurationLog, setShowCurationLog] = useState<boolean>(false)
-    const curationLogRef = useRef<HTMLSpanElement>(null)
     const [expandedPubIndex, setExpandedPubIndex] = useState<any>(props.showEvidenceDefault ? props.showEvidenceDefault : null)
 
     const maxArticlesPerPerson = reciterConfig.reciter.featureGeneratorByGroup.featureGeneratorByGroupApiParams.maxArticlesPerPerson;
@@ -52,25 +78,6 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
 
     const onOpenModal = () => setShowHistoryModal(true)
     const onCloseModal = () => setShowHistoryModal(false)
-
-    // Close curation log popover on click outside or Escape
-    useEffect(() => {
-      if (!showCurationLog) return;
-      const handleClickOutside = (e: MouseEvent) => {
-        if (curationLogRef.current && !curationLogRef.current.contains(e.target as Node)) {
-          setShowCurationLog(false);
-        }
-      };
-      const handleEscape = (e: KeyboardEvent) => {
-        if (e.key === 'Escape') setShowCurationLog(false);
-      };
-      document.addEventListener('mousedown', handleClickOutside);
-      document.addEventListener('keydown', handleEscape);
-      return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
-        document.removeEventListener('keydown', handleEscape);
-      };
-    }, [showCurationLog]);
 
     const formatClogDate = (timestamp: string | Date) => {
       const d = new Date(timestamp);
@@ -169,6 +176,7 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
 
     const { reciterArticle } = props;
     const clogEntries = feedbacklog[reciterArticle.pmid] || [];
+    const hasProvenance = !!(reciterArticle.firstRetrievalDate || reciterArticle.retrievalStrategy || reciterArticle.retrievalSource);
 
     const CardFooter = ({pmid, userAssertion} : {
       pmid: number,
@@ -812,7 +820,6 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
                   }
                   {reciterArticle.publicationDateDisplay && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>{reciterArticle.publicationDateDisplay}</span></>}
                   <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}><span className={styles.pmidLabel}>PMID</span> <a className={styles.pmidLink} href={`${pubMedUrl}${reciterArticle.pmid}`} target="_blank" rel="noreferrer">{reciterArticle.pmid}</a><span style={{userSelect: 'none', color: '#2563a8'}}> ↗</span></span></>
-                  {reciterArticle.firstRetrievalDate && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>First retrieved {reciterArticle.firstRetrievalDate}</span></>}
                   {userAssertion === 'ACCEPTED' && (
                     <span className={styles.statusChipAccepted}>
                       <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" width="12" height="12"><path d="M13 4.5L6.2 11.5 3 8.3"/></svg>
@@ -837,34 +844,48 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
               {/* Row 4: Journal */}
               <div className={styles.articleMeta}>
                 <span>{reciterArticle.journalTitleVerbose}</span>
-                {Object.keys(feedbacklog).length > 0 && (
-                  <span className={styles.curationWrap} ref={curationLogRef}>
-                    <button className={styles.evidenceBtn} onClick={(e) => { e.stopPropagation(); setShowCurationLog(!showCurationLog); }}>Curation log</button>
-                    {showCurationLog && (
-                      <div className={styles.curationLogPopover}>
-                        <div className={styles.clogHead}>Curation history</div>
-                        {clogEntries.length > 0 ? (
-                          clogEntries.map((entry: any, i: number) => {
-                            const action = entry.feedback === 'ACCEPTED' ? 'accepted' : entry.feedback === 'REJECTED' ? 'rejected' : 'undone';
-                            const verb = entry.feedback === 'ACCEPTED' ? 'Accepted' : entry.feedback === 'REJECTED' ? 'Rejected' : 'Suggested';
-                            const who = entry.AdminUser?.personIdentifier || '';
-                            const date = formatClogDate(entry.modifyTimestamp);
-                            return (
-                              <div className={styles.clogEntry} key={entry.feedbackID || i}>
-                                <div className={styles.clogAction}>
-                                  <div className={`${styles.clogDot} ${action === 'accepted' ? styles.clogDotAccepted : action === 'rejected' ? styles.clogDotRejected : styles.clogDotUndone}`} />
-                                  <span className={`${styles.clogVerb} ${action === 'accepted' ? styles.clogVerbAccepted : action === 'rejected' ? styles.clogVerbRejected : styles.clogVerbUndone}`}>{verb}</span>
-                                  <span className={styles.clogWho}>{who}</span>
-                                </div>
-                                <span className={styles.clogDate}>{date}</span>
+                {(hasProvenance || clogEntries.length > 0) && (
+                  <span className={styles.curationWrap}>
+                    <button className={styles.evidenceBtn} type="button">History</button>
+                    <div className={styles.curationLogPopover}>
+                      <div className={styles.clogHead}>Provenance</div>
+                      {hasProvenance ? (
+                        <div className={styles.provBlock}>
+                          {reciterArticle.firstRetrievalDate && (
+                            <div className={styles.provRow}><span className={styles.provLabel}>First retrieved</span><span className={styles.provValue}>{reciterArticle.firstRetrievalDate}</span></div>
+                          )}
+                          {reciterArticle.retrievalStrategy && (
+                            <div className={styles.provRow}><span className={styles.provLabel}>Strategy</span><span className={styles.provValue}>{friendlyProvStrategy(reciterArticle.retrievalStrategy)}</span></div>
+                          )}
+                          {reciterArticle.retrievalSource && (
+                            <div className={styles.provRow}><span className={styles.provLabel}>Source</span><span className={styles.provValue}>{friendlyProvSource(reciterArticle.retrievalSource)}</span></div>
+                          )}
+                        </div>
+                      ) : (
+                        <div className={styles.clogEmpty}>Retrieval details unavailable</div>
+                      )}
+                      <div className={styles.clogHead}>Curation history</div>
+                      {clogEntries.length > 0 ? (
+                        clogEntries.map((entry: any, i: number) => {
+                          const action = entry.feedback === 'ACCEPTED' ? 'accepted' : entry.feedback === 'REJECTED' ? 'rejected' : 'undone';
+                          const verb = entry.feedback === 'ACCEPTED' ? 'Accepted' : entry.feedback === 'REJECTED' ? 'Rejected' : 'Suggested';
+                          const who = entry.AdminUser?.personIdentifier || '';
+                          const date = formatClogDate(entry.modifyTimestamp);
+                          return (
+                            <div className={styles.clogEntry} key={entry.feedbackID || i}>
+                              <div className={styles.clogAction}>
+                                <div className={`${styles.clogDot} ${action === 'accepted' ? styles.clogDotAccepted : action === 'rejected' ? styles.clogDotRejected : styles.clogDotUndone}`} />
+                                <span className={`${styles.clogVerb} ${action === 'accepted' ? styles.clogVerbAccepted : action === 'rejected' ? styles.clogVerbRejected : styles.clogVerbUndone}`}>{verb}</span>
+                                <span className={styles.clogWho}>{who}</span>
                               </div>
-                            );
-                          })
-                        ) : (
-                          <div className={styles.clogEmpty}>No curation events yet</div>
-                        )}
-                      </div>
-                    )}
+                              <span className={styles.clogDate}>{date}</span>
+                            </div>
+                          );
+                        })
+                      ) : (
+                        <div className={styles.clogEmpty}>No curation events yet</div>
+                      )}
+                    </div>
                   </span>
                 )}
               </div>


### PR DESCRIPTION
Co-locates **article provenance** and **curation history** into one hover-revealed **"History"** panel on the `/curate` publication card — per the design reviewed with PA (`~/Dropbox/Projects/ReCiter/pm-provenance-history-design.md`).

## What changed (2 files, pure front-end)
- Removed the standalone inline "First retrieved …" date and the click-toggled "Curation log" popover.
- Added a single **"History"** trigger that reveals one panel on **hover** (reuses the card's existing hover-popover pattern; drops the click-toggle state + outside-click listener):
  - **Provenance** block (first retrieved · strategy · source) from the ReCiter `ArticleProvenance` lib (#737). All three fields, with **friendly labels** mapped from ReCiter's real `rs`/`src` vocabulary (`GS`→Gold standard, `OrcidRetrievalStrategy`→ORCID, `MAN_FROM_PM`→Manual (via Publication Manager), …) and a de-camelCase fallback so an unmapped value is never hidden.
  - **Curation history** block — the existing accept/reject/undo decision list, unchanged.
- **Gating change:** the panel now shows whenever **provenance OR a decision exists** (the old log was hidden until an article had ≥1 decision), so a never-curated article still exposes its retrieval provenance.

## Dependency / sequencing
Stacks on **#737** (the `ArticleProvenance` lookup lib) — base is `feature/article-provenance-frd`, so this diff is *only* the panel. **#737 is not yet on `dev_Upd`.** To ship: land #737 → `dev_Upd`, then retarget/merge this; or combine both. (No lock blocker — the Dockerfile uses `npm install --legacy-peer-deps`, so #737's new `@aws-sdk/client-dynamodb` dep installs at build time.)

## Verification
- `tsc --noEmit`: **0 errors in `Publication.tsx`** (the only error is an environmental `@aws-sdk` import on `articleProvenance.ts` — the borrowed local `node_modules` lacks the dep; present at baseline, not from this change).
- Full diff self-reviewed (JSX balanced; inline-date removal leaves the PMID line intact).
- ⚠️ **Not smoke-tested in a live browser.** Provenance values only populate where DynamoDB `ArticleProvenance` is reachable (IRSA on the dev/prod pods) — not from a local dev box, and the feature isn't on `dev_Upd` yet. **Validate on reciter-dev** once #737 + this deploy: hover "History" → provenance block (3 fields, friendly labels) + decision list; never-curated article still shows the panel; provenance-absent article degrades to "Retrieval details unavailable".

## Known limitations / follow-ups
- Popover opens upward (matches the existing curation-log direction); could clip near the very top of the list — v1.1 polish if needed.
- Hover has no touch affordance (curate is desktop-only today).
- Friendly-label maps reflect ReCiter's `rs`/`src` vocabulary from source; confirm against real `ArticleProvenance` rows on dev and extend the maps if any value shows raw.

## Out of scope (by decision)
Authorships triage card (natural fast-follow — same component reusable), a dedicated detail panel, and a merged single-timeline view.
