### PR TITLE
feat(curate): per-card History panel — provenance + canonical curation history

### DIFF
--- a/config/local.js
+++ b/config/local.js
@@ -100,6 +100,11 @@ export const reciterConfig = {
         reciterUpdateGoldStandardEndpoint:
                 process.env.RECITER_API_BASE_URL + '/reciter/goldstandard',
         /**
+         * Read-only curation audit history (FeedbackLog + ArticleProvenance) by uid.
+         */
+        reciterFeedbackLogEndpoint:
+                process.env.RECITER_API_BASE_URL + '/reciter/feedback-log/',
+        /**
          * This endpoints serves to do CRUD on user feedback. This is used to track the publication feedback in the application. When refreshed
          * the feedback is erased from the database.
          */

--- a/controllers/db/manage-users/user.controller.ts
+++ b/controllers/db/manage-users/user.controller.ts
@@ -11,6 +11,33 @@ models.AdminUser.hasMany(models.AdminDepartment, {as:'AdminDepartment', constrai
 models.AdminUser.hasMany(models.AdminUsersRole, { as: 'listRoles', constraints: false, foreignKey: 'userID' });
 models.AdminUsersRole.belongsTo(models.AdminRole, { as: 'listRole', constraints: false, foreignKey: 'roleID' });
 
+/**
+ * Phase 34: resolve a set of admin_users.userID values to display names, for the
+ * curation Audit History (FeedbackLog.curatedBy). Returns a { userID: name } map;
+ * ids that are missing/invalid (e.g. 0 = unknown) are simply absent from the map.
+ */
+export const findAdminUserNamesByIds = async (ids: number[]): Promise<{ [id: number]: string }> => {
+  const map: { [id: number]: string } = {};
+  const valid = (ids || []).filter((id) => Number.isInteger(id) && id > 0);
+  if (valid.length === 0) {
+    return map;
+  }
+  try {
+    const users: any[] = await models.AdminUser.findAll({
+      where: { userID: { [Op.in]: valid } },
+      attributes: ['userID', 'nameFirst', 'nameLast'],
+      raw: true,
+    });
+    users.forEach((u) => {
+      const name = [u.nameFirst, u.nameLast].filter(Boolean).join(' ').trim();
+      map[u.userID] = name || String(u.userID);
+    });
+  } catch (e) {
+    console.log('findAdminUserNamesByIds error', e);
+  }
+  return map;
+};
+
 export const listAllUsers = async (
   req: NextApiRequest,
   res: NextApiResponse

--- a/controllers/featuregenerator.controller.ts
+++ b/controllers/featuregenerator.controller.ts
@@ -3,6 +3,7 @@ import { NextApiRequest } from 'next'
 import httpBuildQuery from 'http-build-query'
 import url from 'url'
 import { deleteUserFeedback, findUserFeedback } from './userfeedback.controller'
+import { attachArticleProvenance } from '../src/lib/articleProvenance'
 
 export async function getPublications(uid: string | string[], req: NextApiRequest)  {
 
@@ -32,6 +33,10 @@ export async function getPublications(uid: string | string[], req: NextApiReques
                     }
                 } else {
                     let data: any = await res.json()
+                    // Enrich with first-retrieval date from DynamoDB ArticleProvenance
+                    // (on-the-fly, per (personIdentifier, pmid)). Non-fatal.
+                    const personIdentifier = Array.isArray(uid) ? uid[0] : uid
+                    await attachArticleProvenance(personIdentifier, data)
                     let finalData = await getPendingFeedback(uid, data)
                     return {
                         statusCode: res.status,

--- a/controllers/featuregenerator.controller.ts
+++ b/controllers/featuregenerator.controller.ts
@@ -36,7 +36,13 @@ export async function getPublications(uid: string | string[], req: NextApiReques
                     // Enrich with first-retrieval date from DynamoDB ArticleProvenance
                     // (on-the-fly, per (personIdentifier, pmid)). Non-fatal.
                     const personIdentifier = Array.isArray(uid) ? uid[0] : uid
-                    await attachArticleProvenance(personIdentifier, data)
+                    // Bound the provenance enrichment so a degraded DynamoDB never stalls
+                    // the /curate page; attachArticleProvenance is non-fatal and simply
+                    // leaves the fields absent if it doesn't finish within the deadline.
+                    await Promise.race([
+                        attachArticleProvenance(personIdentifier, data),
+                        new Promise((resolve) => setTimeout(resolve, 1500)),
+                    ])
                     let finalData = await getPendingFeedback(uid, data)
                     return {
                         statusCode: res.status,

--- a/controllers/feedbacklog.controller.ts
+++ b/controllers/feedbacklog.controller.ts
@@ -1,0 +1,28 @@
+import { reciterConfig } from '../config/local'
+
+/**
+ * Phase 34: fetch curation audit history (FeedbackLog + ArticleProvenance) for a uid
+ * from the ReCiter engine. Returns { statusCode, data } on success or
+ * { statusCode, statusText } on error. Never throws.
+ */
+export async function getFeedbackLog(uid: string): Promise<{ statusCode: number; data?: any; statusText?: string }> {
+    return fetch(`${reciterConfig.reciter.reciterFeedbackLogEndpoint}${encodeURIComponent(uid)}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            'api-key': reciterConfig.reciter.adminApiKey,
+            'User-Agent': 'reciter-pub-manager-server'
+        }
+    })
+        .then(async (res) => {
+            if (res.status !== 200) {
+                return { statusCode: res.status, statusText: await res.text() }
+            }
+            const data: any = await res.json()
+            return { statusCode: 200, data }
+        })
+        .catch((error) => {
+            console.log('ReCiter feedback-log api is not reachable: ' + error)
+            return { statusCode: error.status || 500, statusText: String(error) }
+        })
+}

--- a/controllers/goldstandard.controller.ts
+++ b/controllers/goldstandard.controller.ts
@@ -3,14 +3,18 @@ import { NextApiRequest } from 'next'
 import url from 'url'
 import { saveUserFeedback } from './userfeedback.controller'
 
-export async function updateGoldStandard(req: NextApiRequest)  {
+export async function updateGoldStandard(req: NextApiRequest, curatedBy?: number)  {
 
     const {
         query: { goldStandardUpdateFlag }
       } = req;
 
     
-   return fetch(`${reciterConfig.reciter.reciterUpdateGoldStandardEndpoint}?goldStandardUpdateFlag=${goldStandardUpdateFlag}&source=publication-manager`, {
+    // Phase 34: forward the curating user's id so ReCiter records who performed the action
+    const curatedByParam = (curatedBy !== undefined && curatedBy !== null && !Number.isNaN(curatedBy))
+        ? `&curatedBy=${curatedBy}` : '';
+
+   return fetch(`${reciterConfig.reciter.reciterUpdateGoldStandardEndpoint}?goldStandardUpdateFlag=${goldStandardUpdateFlag}&source=publication-manager${curatedByParam}`, {
         method: "POST",
         headers: {
             'Content-Type': 'application/json',

--- a/kubernetes/k8-deployment.yaml
+++ b/kubernetes/k8-deployment.yaml
@@ -25,6 +25,9 @@ spec:
         tier: frontend
         owner: szd2013
     spec:
+      # IRSA: grants read-only DynamoDB access to ArticleProvenance (PM #737).
+      # The reciter-pm service account is bound to an IAM role via eksctl.
+      serviceAccountName: reciter-pm
       containers:
       - image: reciter-publication-manager:prod
         name: reciter-pm-prod

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:dom": "jest --config jest.config.dom.js"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.726.0",
     "@babel/runtime": "^7.17.8",
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",

--- a/src/components/elements/Publication/Publication.module.css
+++ b/src/components/elements/Publication/Publication.module.css
@@ -873,6 +873,7 @@
 }
 
 .curationLogPopover {
+  display: none;
   position: absolute;
   bottom: calc(100% + 8px);
   left: 0;
@@ -971,6 +972,36 @@
   font-size: 12px;
   color: #8a94a6;
   font-style: italic;
+}
+
+/* Hover/focus reveal for the History popover (provenance + curation) */
+.curationWrap:hover .curationLogPopover,
+.curationWrap:focus-within .curationLogPopover {
+  display: block;
+}
+
+/* Provenance block (top section of the History popover) */
+.provBlock {
+  padding: 8px 14px;
+}
+
+.provRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 3px 0;
+  font-size: 12px;
+}
+
+.provLabel {
+  color: #8a94a6;
+  white-space: nowrap;
+}
+
+.provValue {
+  color: #1a2133;
+  font-weight: 600;
+  text-align: right;
 }
 
 /* ── Card right column (inline undo for actioned cards) ── */

--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -812,6 +812,7 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
                   }
                   {reciterArticle.publicationDateDisplay && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>{reciterArticle.publicationDateDisplay}</span></>}
                   <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}><span className={styles.pmidLabel}>PMID</span> <a className={styles.pmidLink} href={`${pubMedUrl}${reciterArticle.pmid}`} target="_blank" rel="noreferrer">{reciterArticle.pmid}</a><span style={{userSelect: 'none', color: '#2563a8'}}> ↗</span></span></>
+                  {reciterArticle.firstRetrievalDate && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>First retrieved {reciterArticle.firstRetrievalDate}</span></>}
                   {userAssertion === 'ACCEPTED' && (
                     <span className={styles.statusChipAccepted}>
                       <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" width="12" height="12"><path d="M13 4.5L6.2 11.5 3 8.3"/></svg>

--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -1,15 +1,42 @@
-import React, { useState, useEffect, useRef, FunctionComponent } from "react"
+import React, { useState, FunctionComponent } from "react"
 import styles from './Publication.module.css';
 import { Container, Row, Col, Button, Accordion, Card } from "react-bootstrap";
 import type { Author } from '../../../../types/Author';
 import { useSelector, useDispatch } from "react-redux";
 import { RootStateOrAny } from "../../../types/redux";
-import HistoryModal from "./HistoryModal";
 import { showEvidenceByDefault } from "../../../redux/actions/actions";
 import { reciterConfig } from "../../../../config/local";
 
 const pubMedUrl = 'https://www.ncbi.nlm.nih.gov/pubmed/';
 const doiUrl = 'https://doi.org/';
+
+// Friendly labels for ReCiter ArticleProvenance fields (src = source, rs = retrieval strategy).
+// Unmapped values fall back to a cleaned raw value, so nothing is ever hidden.
+const PROV_SOURCE_LABELS: Record<string, string> = {
+  GS: 'Gold standard',
+  PM: 'Publication Manager',
+  CTSC: 'CTSC',
+  MAN: 'Manual',
+  MAN_FROM_PM: 'Manual (via Publication Manager)',
+  MAN_FROM_CTSC: 'Manual (via CTSC)',
+};
+const PROV_STRATEGY_LABELS: Record<string, string> = {
+  GoldStandardRetrievalStrategy: 'Gold standard',
+  OrcidRetrievalStrategy: 'ORCID',
+  EmailRetrievalStrategy: 'Email',
+  GrantRetrievalStrategy: 'Grant',
+  DepartmentRetrievalStrategy: 'Department',
+  AffiliationRetrievalStrategy: 'Affiliation',
+  AffiliationInDbRetrievalStrategy: 'Affiliation (in DB)',
+  FullNameRetrievalStrategy: 'Full name',
+  FirstNameInitialRetrievalStrategy: 'First-name initial',
+  SecondInitialRetrievalStrategy: 'Second initial',
+  KnownRelationshipRetrievalStrategy: 'Known relationship',
+};
+const friendlyProvSource = (v?: string | null): string | null =>
+  v ? (PROV_SOURCE_LABELS[v] || v) : null;
+const friendlyProvStrategy = (v?: string | null): string | null =>
+  v ? (PROV_STRATEGY_LABELS[v] || v.replace(/RetrievalStrategy$/, '').replace(/([a-z0-9])([A-Z])/g, '$1 $2').trim()) : null;
 
 //TEMP: update to required
 interface FuncProps {
@@ -42,35 +69,10 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
     const [showZeroWeight, setShowZeroWeight] = useState<boolean>(false)
 
     const filteredIdentities = useSelector((state: RootStateOrAny) => state.filteredIdentities)
-    const [showHistoryModal, setShowHistoryModal] = useState<boolean>(false)
-    const [showCurationLog, setShowCurationLog] = useState<boolean>(false)
-    const curationLogRef = useRef<HTMLSpanElement>(null)
     const [expandedPubIndex, setExpandedPubIndex] = useState<any>(props.showEvidenceDefault ? props.showEvidenceDefault : null)
 
     const maxArticlesPerPerson = reciterConfig.reciter.featureGeneratorByGroup.featureGeneratorByGroupApiParams.maxArticlesPerPerson;
     const dispatch = useDispatch();
-
-    const onOpenModal = () => setShowHistoryModal(true)
-    const onCloseModal = () => setShowHistoryModal(false)
-
-    // Close curation log popover on click outside or Escape
-    useEffect(() => {
-      if (!showCurationLog) return;
-      const handleClickOutside = (e: MouseEvent) => {
-        if (curationLogRef.current && !curationLogRef.current.contains(e.target as Node)) {
-          setShowCurationLog(false);
-        }
-      };
-      const handleEscape = (e: KeyboardEvent) => {
-        if (e.key === 'Escape') setShowCurationLog(false);
-      };
-      document.addEventListener('mousedown', handleClickOutside);
-      document.addEventListener('keydown', handleEscape);
-      return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
-        document.removeEventListener('keydown', handleEscape);
-      };
-    }, [showCurationLog]);
 
     const formatClogDate = (timestamp: string | Date) => {
       const d = new Date(timestamp);
@@ -169,6 +171,7 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
 
     const { reciterArticle } = props;
     const clogEntries = feedbacklog[reciterArticle.pmid] || [];
+    const hasProvenance = !!(reciterArticle.firstRetrievalDate || reciterArticle.retrievalStrategy || reciterArticle.retrievalSource);
 
     const CardFooter = ({pmid, userAssertion} : {
       pmid: number,
@@ -812,7 +815,6 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
                   }
                   {reciterArticle.publicationDateDisplay && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>{reciterArticle.publicationDateDisplay}</span></>}
                   <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}><span className={styles.pmidLabel}>PMID</span> <a className={styles.pmidLink} href={`${pubMedUrl}${reciterArticle.pmid}`} target="_blank" rel="noreferrer">{reciterArticle.pmid}</a><span style={{userSelect: 'none', color: '#2563a8'}}> ↗</span></span></>
-                  {reciterArticle.firstRetrievalDate && <><span className={styles.cardMetaSep}>·</span><span className={styles.cardDate}>First retrieved {reciterArticle.firstRetrievalDate}</span></>}
                   {userAssertion === 'ACCEPTED' && (
                     <span className={styles.statusChipAccepted}>
                       <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" width="12" height="12"><path d="M13 4.5L6.2 11.5 3 8.3"/></svg>
@@ -837,34 +839,48 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
               {/* Row 4: Journal */}
               <div className={styles.articleMeta}>
                 <span>{reciterArticle.journalTitleVerbose}</span>
-                {Object.keys(feedbacklog).length > 0 && (
-                  <span className={styles.curationWrap} ref={curationLogRef}>
-                    <button className={styles.evidenceBtn} onClick={(e) => { e.stopPropagation(); setShowCurationLog(!showCurationLog); }}>Curation log</button>
-                    {showCurationLog && (
-                      <div className={styles.curationLogPopover}>
-                        <div className={styles.clogHead}>Curation history</div>
-                        {clogEntries.length > 0 ? (
-                          clogEntries.map((entry: any, i: number) => {
-                            const action = entry.feedback === 'ACCEPTED' ? 'accepted' : entry.feedback === 'REJECTED' ? 'rejected' : 'undone';
-                            const verb = entry.feedback === 'ACCEPTED' ? 'Accepted' : entry.feedback === 'REJECTED' ? 'Rejected' : 'Suggested';
-                            const who = entry.AdminUser?.personIdentifier || '';
-                            const date = formatClogDate(entry.modifyTimestamp);
-                            return (
-                              <div className={styles.clogEntry} key={entry.feedbackID || i}>
-                                <div className={styles.clogAction}>
-                                  <div className={`${styles.clogDot} ${action === 'accepted' ? styles.clogDotAccepted : action === 'rejected' ? styles.clogDotRejected : styles.clogDotUndone}`} />
-                                  <span className={`${styles.clogVerb} ${action === 'accepted' ? styles.clogVerbAccepted : action === 'rejected' ? styles.clogVerbRejected : styles.clogVerbUndone}`}>{verb}</span>
-                                  <span className={styles.clogWho}>{who}</span>
-                                </div>
-                                <span className={styles.clogDate}>{date}</span>
+                {(hasProvenance || clogEntries.length > 0) && (
+                  <span className={styles.curationWrap}>
+                    <button className={styles.evidenceBtn} type="button" aria-label="Curation history and provenance" aria-describedby={`hist-pop-${reciterArticle.pmid}`}>History</button>
+                    <div className={styles.curationLogPopover} id={`hist-pop-${reciterArticle.pmid}`} role="group" aria-label="Provenance and curation history">
+                      <div className={styles.clogHead}>Provenance</div>
+                      {hasProvenance ? (
+                        <div className={styles.provBlock}>
+                          {reciterArticle.firstRetrievalDate && (
+                            <div className={styles.provRow}><span className={styles.provLabel}>First retrieved</span><span className={styles.provValue}>{reciterArticle.firstRetrievalDate}</span></div>
+                          )}
+                          {reciterArticle.retrievalStrategy && (
+                            <div className={styles.provRow}><span className={styles.provLabel}>Strategy</span><span className={styles.provValue}>{friendlyProvStrategy(reciterArticle.retrievalStrategy)}</span></div>
+                          )}
+                          {reciterArticle.retrievalSource && (
+                            <div className={styles.provRow}><span className={styles.provLabel}>Source</span><span className={styles.provValue}>{friendlyProvSource(reciterArticle.retrievalSource)}</span></div>
+                          )}
+                        </div>
+                      ) : (
+                        <div className={styles.clogEmpty}>Retrieval details unavailable</div>
+                      )}
+                      <div className={styles.clogHead}>Curation history</div>
+                      {clogEntries.length > 0 ? (
+                        clogEntries.map((entry: any, i: number) => {
+                          const action = entry.feedback === 'ACCEPTED' ? 'accepted' : entry.feedback === 'REJECTED' ? 'rejected' : 'undone';
+                          const verb = entry.feedback === 'ACCEPTED' ? 'Accepted' : entry.feedback === 'REJECTED' ? 'Rejected' : 'Suggested';
+                          const who = entry.curatorName || 'Unknown';
+                          const date = entry.modifyTimestamp ? formatClogDate(entry.modifyTimestamp) : '';
+                          return (
+                            <div className={styles.clogEntry} key={entry.feedbackID || i}>
+                              <div className={styles.clogAction}>
+                                <div className={`${styles.clogDot} ${action === 'accepted' ? styles.clogDotAccepted : action === 'rejected' ? styles.clogDotRejected : styles.clogDotUndone}`} />
+                                <span className={`${styles.clogVerb} ${action === 'accepted' ? styles.clogVerbAccepted : action === 'rejected' ? styles.clogVerbRejected : styles.clogVerbUndone}`}>{verb}</span>
+                                <span className={styles.clogWho}>{who}</span>
                               </div>
-                            );
-                          })
-                        ) : (
-                          <div className={styles.clogEmpty}>No curation events yet</div>
-                        )}
-                      </div>
-                    )}
+                              <span className={styles.clogDate}>{date}</span>
+                            </div>
+                          );
+                        })
+                      ) : (
+                        <div className={styles.clogEmpty}>No curation events yet</div>
+                      )}
+                    </div>
                   </span>
                 )}
               </div>
@@ -936,15 +952,6 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
             </div>
           )}
         </div>
-
-
-        <HistoryModal
-          showModal={showHistoryModal}
-          onOpen={onOpenModal}
-          onClose={onCloseModal}
-          id={reciterArticle.pmid}
-          userId={props.personIdentifier}
-        />
       </div>
     );
 }

--- a/src/lib/articleProvenance.ts
+++ b/src/lib/articleProvenance.ts
@@ -1,0 +1,139 @@
+// src/lib/articleProvenance.ts
+//
+// On-the-fly lookup of first-retrieval provenance from the ReCiter DynamoDB
+// `ArticleProvenance` table, for the "date a publication was first retrieved"
+// display on /curate (issue #737).
+//
+// ArticleProvenance has a composite key uid (HASH = personIdentifier/CWID) +
+// articleId (RANGE = PMID as a String). frd = first retrieval date (epoch
+// SECONDS, immutable), rs = retrieval strategy, src = source.
+//
+// We read on demand (BatchGetItem) for the publications on the page rather than
+// materializing the ~11M-row table into MySQL nightly: the access pattern is a
+// per-(person, article) point lookup, which is exactly this table's key.
+//
+// Auth: the DynamoDBClient uses the AWS SDK default credential provider chain —
+// the pod's IRSA role in prod (service account `reciter-pm`), and local AWS
+// env/SSO creds in dev. No static keys.
+
+import { DynamoDBClient, BatchGetItemCommand } from '@aws-sdk/client-dynamodb'
+
+const REGION = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1'
+const TABLE = 'ArticleProvenance'
+const BATCH_SIZE = 100 // BatchGetItem hard limit per request
+
+let client: DynamoDBClient | null = null
+function getClient(): DynamoDBClient {
+  if (!client) {
+    client = new DynamoDBClient({ region: REGION })
+  }
+  return client
+}
+
+export interface ArticleProvenanceRecord {
+  firstRetrievalDate: string | null // display date, e.g. "Jan 31, 2025" (UTC)
+  firstRetrievalEpoch: number | null // raw epoch seconds
+  retrievalStrategy: string | null
+  source: string | null
+}
+
+function formatUtcDate(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+/**
+ * Look up first-retrieval provenance for a set of (personIdentifier, pmid) pairs.
+ * Returns a map keyed `${personIdentifier}:${pmid}`. Best-effort: any AWS error
+ * propagates to the caller, which degrades gracefully (the field is absent).
+ */
+export async function getArticleProvenance(
+  keys: { personIdentifier: string; pmid: number | string }[]
+): Promise<Record<string, ArticleProvenanceRecord>> {
+  const out: Record<string, ArticleProvenanceRecord> = {}
+  if (!keys || keys.length === 0) return out
+
+  // Dedupe to unique (uid, articleId) string pairs.
+  const uniq = new Map<string, { uid: string; articleId: string }>()
+  for (const k of keys) {
+    if (!k || !k.personIdentifier || k.pmid === undefined || k.pmid === null) continue
+    const articleId = String(k.pmid)
+    if (!articleId) continue
+    uniq.set(`${k.personIdentifier}:${articleId}`, { uid: k.personIdentifier, articleId })
+  }
+  const all = Array.from(uniq.values())
+  if (all.length === 0) return out
+
+  const ddb = getClient()
+  for (let i = 0; i < all.length; i += BATCH_SIZE) {
+    let pending = all.slice(i, i + BATCH_SIZE)
+    let attempt = 0
+    while (pending.length > 0 && attempt < 4) {
+      attempt++
+      const Keys = pending.map((k) => ({ uid: { S: k.uid }, articleId: { S: k.articleId } }))
+      const resp = await ddb.send(
+        new BatchGetItemCommand({ RequestItems: { [TABLE]: { Keys } } })
+      )
+      const items: any[] = resp.Responses?.[TABLE] ?? []
+      for (const it of items) {
+        const uid: string | undefined = it.uid?.S
+        const articleId: string | undefined = it.articleId?.S
+        if (!uid || !articleId) continue
+        const epoch = it.frd?.N ? Number(it.frd.N) : null
+        const validEpoch = epoch !== null && Number.isFinite(epoch) ? epoch : null
+        out[`${uid}:${articleId}`] = {
+          firstRetrievalDate: validEpoch !== null ? formatUtcDate(validEpoch) : null,
+          firstRetrievalEpoch: validEpoch,
+          retrievalStrategy: it.rs?.S ?? null,
+          source: it.src?.S ?? null,
+        }
+      }
+      const unprocessed: any[] | undefined = resp.UnprocessedKeys?.[TABLE]?.Keys
+      if (unprocessed && unprocessed.length > 0) {
+        pending = unprocessed.map((k) => ({
+          uid: (k.uid?.S as string) ?? '',
+          articleId: (k.articleId?.S as string) ?? '',
+        }))
+        await new Promise((r) => setTimeout(r, 100 * attempt)) // backoff before retry
+      } else {
+        pending = []
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Attach `firstRetrievalDate` (+ epoch/strategy/source) onto each article in a
+ * ReCiter feature-generator response for ONE person. Mutates `data` in place.
+ * Never throws — provenance is a non-critical display enrichment, so a DynamoDB
+ * outage simply leaves the field absent and the page renders normally.
+ */
+export async function attachArticleProvenance(
+  personIdentifier: string | undefined,
+  data: any
+): Promise<void> {
+  try {
+    if (!personIdentifier || !data || !Array.isArray(data.reCiterArticleFeatures)) return
+    const keys = data.reCiterArticleFeatures
+      .filter((a: any) => a && a.pmid !== undefined && a.pmid !== null)
+      .map((a: any) => ({ personIdentifier, pmid: a.pmid }))
+    if (keys.length === 0) return
+    const map = await getArticleProvenance(keys)
+    for (const a of data.reCiterArticleFeatures) {
+      const rec = map[`${personIdentifier}:${a.pmid}`]
+      if (rec) {
+        a.firstRetrievalDate = rec.firstRetrievalDate
+        a.firstRetrievalEpoch = rec.firstRetrievalEpoch
+        a.retrievalStrategy = rec.retrievalStrategy
+        a.retrievalSource = rec.source
+      }
+    }
+  } catch (e) {
+    console.log('ArticleProvenance lookup failed (non-fatal): ' + e)
+  }
+}

--- a/src/pages/api/reciter/feedback-log/[uid].ts
+++ b/src/pages/api/reciter/feedback-log/[uid].ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getFeedbackLog } from "../../../../../controllers/feedbacklog.controller"
+import { findAdminUserNamesByIds } from "../../../../../controllers/db/manage-users/user.controller"
+import { reciterConfig } from '../../../../../config/local'
+import { checkCurationScope } from '../../../../utils/checkCurationScope'
+
+/**
+ * GET /api/reciter/feedback-log/[uid]
+ *
+ * Returns the curation audit history for a person, proxied from ReCiter's
+ * /reciter/feedback-log/{uid}. Requires the backend api-key header and gates
+ * visibility by curate access (a user can only see history for people they may
+ * curate — same rule as the goldstandard save route).
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== "GET") {
+        return res.status(400).send({ statusCode: 400, message: "HTTP Method supported is GET" })
+    }
+    if (req.headers.authorization === undefined) {
+        return res.status(400).send({ statusCode: 400, message: "Authorization header is needed" })
+    }
+    if (req.headers.authorization !== reciterConfig.backendApiKey) {
+        return res.status(401).send({ statusCode: 401, message: "Authorization header is incorrect" })
+    }
+
+    const { uid } = req.query
+    const targetUid = Array.isArray(uid) ? uid[0] : uid
+    if (!targetUid) {
+        return res.status(400).send({ statusCode: 400, message: "uid is required" })
+    }
+
+    try {
+        const scopeCheck = await checkCurationScope(req, targetUid)
+        if (!scopeCheck.allowed) {
+            return res.status(scopeCheck.status!).send({ statusCode: scopeCheck.status!, message: scopeCheck.message })
+        }
+
+        const apiResponse = await getFeedbackLog(targetUid)
+        if (apiResponse.statusCode === 200) {
+            const data = apiResponse.data
+            // Resolve curatedBy (admin_users.userID) -> display name for the UI.
+            if (Array.isArray(data)) {
+                const ids: number[] = Array.from(
+                    new Set(data.map((e: any) => Number(e.curatedBy)).filter((n: number) => Number.isInteger(n) && n > 0))
+                )
+                const nameMap = await findAdminUserNamesByIds(ids)
+                data.forEach((e: any) => {
+                    const cb = Number(e.curatedBy)
+                    e.curatorName = (Number.isInteger(cb) && cb > 0 && nameMap[cb]) ? nameMap[cb] : null
+                })
+            }
+            return res.status(200).send(data)
+        }
+        return res.status(apiResponse.statusCode || 500).send({
+            statusCode: apiResponse.statusCode || 500,
+            message: apiResponse.statusText
+        })
+    } catch (err) {
+        console.error('[feedback-log] Unhandled error:', err)
+        return res.status(500).send({ statusCode: 500, message: 'Internal server error' })
+    }
+}

--- a/src/pages/api/reciter/update/goldstandard.ts
+++ b/src/pages/api/reciter/update/goldstandard.ts
@@ -1,7 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { getToken } from 'next-auth/jwt'
 import { updateGoldStandard } from "../../../../../controllers/goldstandard.controller"
 import { reciterConfig } from '../../../../../config/local'
 import { checkCurationScope } from '../../../../utils/checkCurationScope'
+import models from '../../../../db/sequelize'
 
 type Error = {
     statusCode: number,
@@ -28,7 +30,29 @@ export default async function handler(
             }
         }
 
-        const apiResponse = await updateGoldStandard(req);
+        // Phase 34: resolve the curating user's admin_users.userID from the JWT so
+        // ReCiter can record who performed the action (FeedbackLog.curatedBy).
+        // Mirrors the Authorships path's resolveCurator: fall back to an AdminUser
+        // lookup by CWID (token.username) when the JWT lacks databaseUser.userID,
+        // so the classic Curate path resolves the curator as reliably as AAR.
+        let curatedBy: number | undefined = undefined;
+        try {
+            const token: any = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+            let userID = token?.databaseUser?.userID;
+            if ((userID === undefined || userID === null) && token?.username) {
+                const au: any = await models.AdminUser.findOne({
+                    where: { personIdentifier: token.username }, attributes: ['userID'],
+                });
+                userID = au?.userID;
+            }
+            if (userID !== undefined && userID !== null && !Number.isNaN(Number(userID))) {
+                curatedBy = Number(userID);
+            }
+        } catch (e) {
+            // Leave curatedBy undefined -> ReCiter defaults to 0 (unknown).
+        }
+
+        const apiResponse = await updateGoldStandard(req, curatedBy);
         if(apiResponse.statusCode === 200) {
             res.status(apiResponse.statusCode).send({
                 statusCode: apiResponse.statusCode,

--- a/src/redux/actions/actions.js
+++ b/src/redux/actions/actions.js
@@ -1160,12 +1160,51 @@ export const publicationsFetchGroupData = (ids, updateData) => dispatch => {
         })
 }
 
+// Phase 34: the curation-history panel now reads the canonical ReCiter FeedbackLog
+// (DynamoDB) via /api/reciter/feedback-log/[uid] instead of the legacy PM MySQL
+// admin_feedback_log. The canonical endpoint returns a flat array of rows
+// { articleId, feedback, curatedBy, curatorName, createTimestamp(epoch s), sk, src,
+//   provenanceRs/Frd/Src }. Normalize each row so the per-card panel renders unchanged:
+// it reads canonical curatorName directly, plus a few legacy aliases — articleIdentifier
+// (bucketing key), feedbackID (React key), modifyTimestamp (formatted date) — so the
+// existing render code needs no field-by-field rewrite.
+const normalizeFeedbackRow = (row) => {
+    const epochSec = Number(row && row.createTimestamp) || 0;
+    return {
+        ...row,
+        articleIdentifier: row && row.articleId,
+        feedbackID: row && row.sk,
+        modifyTimestamp: epochSec ? new Date(epochSec * 1000).toISOString() : null,
+    };
+};
+
+// Bucket the flat canonical array by articleId (PMID) for per-card lookup, newest first.
+const groupFeedbackByArticle = (rows) => {
+    const data = {};
+    (Array.isArray(rows) ? rows : []).forEach((raw) => {
+        const row = normalizeFeedbackRow(raw);
+        const key = row.articleIdentifier;
+        if (key === undefined || key === null) return;
+        if (!data[key]) data[key] = [];
+        data[key].push(row);
+    });
+    Object.keys(data).forEach((k) => {
+        data[k].sort((a, b) => {
+            const at = Number(a.createTimestamp) || 0;
+            const bt = Number(b.createTimestamp) || 0;
+            if (bt !== at) return bt - at;
+            return String(b.sk || '').localeCompare(String(a.sk || ''));
+        });
+    });
+    return data;
+};
+
 export const fetchFeedbacklog = (id) => dispatch => {
     dispatch({
         type: methods.FEEDBACKLOG_FETCH_DATA
     })
 
-    fetch(`/api/db/admin/feedbacklog/${id}`, {
+    fetch(`/api/reciter/feedback-log/${id}`, {
         credentials: "same-origin",
         method: 'GET',
         headers: {
@@ -1185,13 +1224,7 @@ export const fetchFeedbacklog = (id) => dispatch => {
             }
         }
     }).then(data => {
-        let articleIds = data.map((feedback) => { return feedback.articleIdentifier })
-        articleIds = articleIds.filter((feedback, i) => { return articleIds.indexOf(feedback) === i });
-        let feedbacklogData = {};
-        articleIds.forEach((articleId) => {
-            let articleFeedbacks = data.filter((feedbackLog) => { if (feedbackLog.articleIdentifier === articleId) return feedbackLog });
-            feedbacklogData[articleId] = articleFeedbacks;
-        })
+        const feedbacklogData = groupFeedbackByArticle(data);
 
         dispatch({
             type: methods.FEEDBACKLOG_CHANGE_DATA,
@@ -1226,7 +1259,7 @@ export const fetchGroupFeedbacklog = (ids) => dispatch => {
 
     let feedbackLogs = [];
     for (let id of ids) {
-        fetch(`/api/db/admin/feedbacklog/${id}`, {
+        fetch(`/api/reciter/feedback-log/${id}`, {
             credentials: "same-origin",
             method: 'GET',
             headers: {
@@ -1238,13 +1271,7 @@ export const fetchGroupFeedbacklog = (ids) => dispatch => {
             return response.json()
         }).then(data => {
             if (data?.length) {
-                let articleIds = data.map((feedback) => { return feedback.articleIdentifier })
-                articleIds = articleIds.filter((feedback, i) => { return articleIds.indexOf(feedback) === i });
-                let feedbacklogData = {};
-                articleIds.forEach((articleId) => {
-                    let articleFeedbacks = data.filter((feedbackLog) => { if (feedbackLog.articleIdentifier === articleId) return feedbackLog });
-                    feedbacklogData[articleId] = articleFeedbacks;
-                })
+                const feedbacklogData = groupFeedbackByArticle(data);
                 feedbackLogs.push({ [id]: feedbacklogData });
             }
         }).catch(error => {


### PR DESCRIPTION
## What

Adds a per-card hover **History** panel to each `/curate` publication card:

- **Provenance** — first-retrieved date, retrieval strategy, source (friendly labels), shown for every retrieved article including **never-curated** ones, via the #737 `ArticleProvenance` on-the-fly lib.
- **Curation history** — action · curator · date, read from the **canonical ReCiter FeedbackLog (DynamoDB)** through a new `GET /api/reciter/feedback-log/[uid]` proxy, replacing the legacy PM MySQL `admin_feedback_log` as the panel's **READ** source.

The legacy `admin_feedback_log` **write** path is unchanged — it remains the PM-local system of record. Only the panel's read was repointed; the canonical source is more complete (it captures actions the legacy table under-reports).

## How

**Backend**
- `feedback-log/[uid].ts` proxy — gated on the backend api-key + `checkCurationScope` (same rule as the goldstandard save); enriches each row with `curatorName` via `findAdminUserNamesByIds` (robust to number/string `curatedBy`).
- `curatedBy` capture on the goldstandard save — resolves the curator's `admin_users.userID` from the JWT, with an `AdminUser`-by-CWID fallback mirroring the Authorships path's `resolveCurator` (parity, fewer "Unknown" rows).

**Frontend**
- Redux `fetchFeedbacklog`/`fetchGroupFeedbacklog` repointed + normalized at the action layer (bucketed by `articleId`, newest-first; canonical fields + a few legacy aliases so the render code is untouched).
- Panel reads canonical `curatorName` with an **Unknown** fallback; null-date guarded; friendly-label maps for strategy/source.
- Removed the dead `HistoryModal` mount; provenance enrichment bounded with a 1.5s deadline so degraded DynamoDB can't stall `/curate`.

## Verification
- `tsc --noEmit`: clean (no new errors; pre-existing `__tests__` jest-globals errors only).
- `npm test` (jest.config.js): **97/97 passing**.
- Adversarial multi-agent review: all confirmed findings addressed (curatedBy coercion, a11y, dead-code removal, hot-path deadline).
- Live FeedbackLog/DynamoDB behavior validated on reciter-dev after deploy.

## ⚠️ Deploy prerequisite for the provenance half (not blocking the history half)
The provenance block reads DynamoDB directly, which needs IRSA. Two gaps found on the `reciter` cluster:
1. `k8-buildspec.yml` deploys via `kubectl set image` only — it never applies `k8-deployment.yaml`, so #737's `serviceAccountName: reciter-pm` won't take effect.
2. The `reciter-pm` ServiceAccount **does not exist** in the `reciter` namespace, and `reciter-pm-{dev,prod}` currently run on the `default` SA (no IRSA).

So **curation history works on deploy** (api-key proxy), but the **provenance block will render empty** until an IRSA-annotated SA (DynamoDB read on `ArticleProvenance`) is provisioned and bound. Tracked as a follow-up infra task.

## Dependencies / disposition
- Includes #737 (provenance lib) directly. **Supersedes #714** (audit-history UI — stale, calm-redesign conflicts), **#743** (article-provenance-frd — #737 is delivered here), and **#745** (provenance-history-panel — read the wrong source). All three closed.

Not merged — for review.
