### PR TITLE
fix(curate): spell out retrieval strategies + clarify pending history label

### DIFF
--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -20,18 +20,34 @@ const PROV_SOURCE_LABELS: Record<string, string> = {
   MAN_FROM_PM: 'Manual (via Publication Manager)',
   MAN_FROM_CTSC: 'Manual (via CTSC)',
 };
+// ArticleProvenance.rs stores either a legacy short code (FNI, EMAIL, …) or the
+// full retrieval-strategy class name (FirstNameInitialRetrievalStrategy, …),
+// depending on when the row was written. Map both forms to one spelled-out label.
 const PROV_STRATEGY_LABELS: Record<string, string> = {
-  GoldStandardRetrievalStrategy: 'Gold standard',
-  OrcidRetrievalStrategy: 'ORCID',
-  EmailRetrievalStrategy: 'Email',
-  GrantRetrievalStrategy: 'Grant',
-  DepartmentRetrievalStrategy: 'Department',
-  AffiliationRetrievalStrategy: 'Affiliation',
-  AffiliationInDbRetrievalStrategy: 'Affiliation (in DB)',
-  FullNameRetrievalStrategy: 'Full name',
+  // legacy short codes (production data)
+  FNI: 'First-name initial',
+  SI: 'Second initial',
+  FN: 'Full name',
+  EMAIL: 'Email',
+  ORC: 'ORCID',
+  AFF: 'Affiliation',
+  AFFD: 'Affiliation (in database)',
+  DEP: 'Department',
+  REL: 'Known relationship',
+  GR: 'Grant',
+  GS: 'Gold standard',
+  // full strategy class names (current ReCiter)
   FirstNameInitialRetrievalStrategy: 'First-name initial',
   SecondInitialRetrievalStrategy: 'Second initial',
+  FullNameRetrievalStrategy: 'Full name',
+  EmailRetrievalStrategy: 'Email',
+  OrcidRetrievalStrategy: 'ORCID',
+  AffiliationRetrievalStrategy: 'Affiliation',
+  AffiliationInDbRetrievalStrategy: 'Affiliation (in database)',
+  DepartmentRetrievalStrategy: 'Department',
   KnownRelationshipRetrievalStrategy: 'Known relationship',
+  GrantRetrievalStrategy: 'Grant',
+  GoldStandardRetrievalStrategy: 'Gold standard',
 };
 const friendlyProvSource = (v?: string | null): string | null =>
   v ? (PROV_SOURCE_LABELS[v] || v) : null;
@@ -863,7 +879,7 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
                       {clogEntries.length > 0 ? (
                         clogEntries.map((entry: any, i: number) => {
                           const action = entry.feedback === 'ACCEPTED' ? 'accepted' : entry.feedback === 'REJECTED' ? 'rejected' : 'undone';
-                          const verb = entry.feedback === 'ACCEPTED' ? 'Accepted' : entry.feedback === 'REJECTED' ? 'Rejected' : 'Suggested';
+                          const verb = entry.feedback === 'ACCEPTED' ? 'Accepted' : entry.feedback === 'REJECTED' ? 'Rejected' : 'Returned to pending';
                           const who = entry.curatorName || 'Unknown';
                           const date = entry.modifyTimestamp ? formatClogDate(entry.modifyTimestamp) : '';
                           return (


### PR DESCRIPTION
Follow-up to #747 from reciter-dev review (two display fixes; no logic/data changes).

## 1. Spell out retrieval strategies
`ArticleProvenance.rs` stores a **mix** of legacy short codes (`FNI`, `EMAIL`, `FN`, `AFF`, `AFFD`, `DEP`, `REL`, `SI`, `ORC`, …) and full class names (`FirstNameInitialRetrievalStrategy`, …) depending on when the row was written. The label map only covered the full names, so short codes like **`FNI`** rendered raw. Now both forms map to one spelled-out label (sentence case), e.g. `FNI`/`FirstNameInitialRetrievalStrategy` → "First-name initial".

## 2. "Returned to pending" (was "Suggested")
A `PENDING` FeedbackLog row is written **only when an article's accept/reject is removed** (returned to pending) — per ReCiter `DynamoDbGoldStandardService`. The old "Suggested" label implied a system suggestion, which is misleading. Now labeled "Returned to pending".

`tsc --noEmit` clean (no new errors). Not merged — for review.
