### PR TITLE
fix(curate/search): render PubMed HTML in titles, unclip ACTIONS dropdown, fix History popover overflow

### DIFF
--- a/__tests__/htmlText.test.ts
+++ b/__tests__/htmlText.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for the inline-HTML sanitizer used to render PubMed markup in
+ * article titles/journals (issue #750). Verifies the security boundary:
+ * only attribute-free inline formatting survives; everything else is dropped.
+ */
+import { sanitizeInlineHtml, stripHtml } from '../src/utils/htmlText';
+
+describe('sanitizeInlineHtml', () => {
+  it('renders allowed inline formatting tags', () => {
+    expect(sanitizeInlineHtml('Variations in <i>KIAA0319L</i>, encoding AAVR'))
+      .toBe('Variations in <i>KIAA0319L</i>, encoding AAVR');
+    expect(sanitizeInlineHtml('H<sub>2</sub>O and E=mc<sup>2</sup>'))
+      .toBe('H<sub>2</sub>O and E=mc<sup>2</sup>');
+    expect(sanitizeInlineHtml('<b>bold</b> <em>em</em> <strong>s</strong>'))
+      .toBe('<b>bold</b> <em>em</em> <strong>s</strong>');
+  });
+
+  it('strips attributes from allowed tags (no event handlers survive)', () => {
+    expect(sanitizeInlineHtml('<i onclick="steal()">x</i>')).toBe('<i>x</i>');
+    expect(sanitizeInlineHtml('<i class="x" style="color:red">y</i>')).toBe('<i>y</i>');
+  });
+
+  it('drops disallowed tags entirely but keeps their text', () => {
+    expect(sanitizeInlineHtml('a<script>alert(1)</script>b')).toBe('aalert(1)b');
+    expect(sanitizeInlineHtml('<img src=x onerror=alert(1)>')).toBe('');
+    expect(sanitizeInlineHtml('<a href="javascript:alert(1)">link</a>')).toBe('link');
+    expect(sanitizeInlineHtml('<div><p>hi</p></div>')).toBe('hi');
+  });
+
+  it('leaves entities and plain text untouched', () => {
+    expect(sanitizeInlineHtml('Tom &amp; Jerry')).toBe('Tom &amp; Jerry');
+    expect(sanitizeInlineHtml('plain title')).toBe('plain title');
+  });
+
+  it('handles null/undefined/empty', () => {
+    expect(sanitizeInlineHtml(undefined)).toBe('');
+    expect(sanitizeInlineHtml(null)).toBe('');
+    expect(sanitizeInlineHtml('')).toBe('');
+  });
+});
+
+describe('stripHtml', () => {
+  it('removes tags and decodes common entities', () => {
+    expect(stripHtml('Variations in <i>KIAA0319L</i>')).toBe('Variations in KIAA0319L');
+    expect(stripHtml('H<sub>2</sub>O')).toBe('H2O');
+    expect(stripHtml('Tom &amp; Jerry &lt;3')).toBe('Tom & Jerry <3');
+    expect(stripHtml('&#65;&#x42;C')).toBe('ABC');
+  });
+
+  it('handles null/undefined/empty', () => {
+    expect(stripHtml(undefined)).toBe('');
+    expect(stripHtml(null)).toBe('');
+    expect(stripHtml('')).toBe('');
+  });
+});

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -6,6 +6,7 @@ import MenuItem from "@mui/material/MenuItem";
 import Snackbar from "@mui/material/Snackbar";
 import Checkbox from "@mui/material/Checkbox";
 import { reciterConfig } from "../../../../config/local";
+import { sanitizeInlineHtml, stripHtml } from "../../../utils/htmlText";
 
 // ---- types ---------------------------------------------------------------
 interface AuthorshipRow {
@@ -875,8 +876,8 @@ const AuthorshipCard = ({
           </div>
 
           {/* L3 — paper meta (quiet/truncated). PMID link now lives in the evidence panel. */}
-          <div style={{ fontSize: 12.5, color: "#94a3b8", marginTop: 4, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={r.title}>
-            {r.title} · <i>{r.journal}</i>{r.entrez_date ? ` · ${r.entrez_date}` : ""}
+          <div style={{ fontSize: 12.5, color: "#94a3b8", marginTop: 4, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={stripHtml(r.title)}>
+            <span dangerouslySetInnerHTML={{ __html: sanitizeInlineHtml(r.title) }} /> · <i><span dangerouslySetInnerHTML={{ __html: sanitizeInlineHtml(r.journal) }} /></i>{r.entrez_date ? ` · ${r.entrez_date}` : ""}
           </div>
 
           {/* L4 — full affiliation (WCM highlighted), wraps to multiple lines + disclosure */}

--- a/src/components/elements/CurateIndividual/ReciterTabContent.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabContent.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import Publication from "../Publication/Publication";
 import FilterPubSection from "./FilterPubSection";
 import filterPublicationsBySearchText from "../../../utils/filterPublicationsBySearchText";
+import { stripHtml } from "../../../utils/htmlText";
 import sortPublications from "../../../utils/sortPublications";
 import Pagination from '../Pagination/Pagination';
 import { useSession } from "next-auth/client";
@@ -165,7 +166,7 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
   // so this is the catchable "you just did X — undo?" line. Reverts via the same path.
   const fireUndoToast = (pmid: number, userAssertion: string, article: any) => {
     const accepted = userAssertion === 'ACCEPTED';
-    const title = article?.articleTitle || article?.title || `PMID ${pmid}`;
+    const title = stripHtml(article?.articleTitle || article?.title) || `PMID ${pmid}`;
     const shortTitle = title.length > 60 ? title.slice(0, 60).trim() + '…' : title;
     const toastId = `undo-${pmid}`;
     const doUndo = () => {

--- a/src/components/elements/Profile/Profile.tsx
+++ b/src/components/elements/Profile/Profile.tsx
@@ -12,6 +12,15 @@ import { useSession } from 'next-auth/client';
 import { allowedPermissions } from "../../../utils/constants";
 import { toast } from "react-toastify";
 import { reportError } from "../../../utils/reportError";
+import { stripHtml } from "../../../utils/htmlText";
+
+// Title/journal fields can carry PubMed inline markup (<i>, <sub>, …); strip to
+// plain text for spreadsheet cells, which can't render HTML.
+const HTML_BEARING_FIELDS = ['articleTitle', 'articleTitleRTF', 'journalTitleVerbose'];
+const stripHtmlFields = (row: any): any => {
+  HTML_BEARING_FIELDS.forEach((k) => { if (row && row[k]) row[k] = stripHtml(row[k]); });
+  return row;
+};
 
 interface PrimaryName {
   firstInitial?: string,
@@ -227,7 +236,7 @@ const Profile = ({
             itemRow = { ...itemRow, ...item[obj] };
           }
         })
-        worksheet.addRow(itemRow);
+        worksheet.addRow(stripHtmlFields(itemRow));
       })
       const buf = await workbook.csv.writeBuffer();
       let blobFromBuffer = new Blob([buf]);

--- a/src/components/elements/Publication/Publication.module.css
+++ b/src/components/elements/Publication/Publication.module.css
@@ -876,22 +876,29 @@
   display: none;
   position: absolute;
   bottom: calc(100% + 8px);
-  left: 0;
-  width: 280px;
+  /* Anchor to the right of the History link and extend leftward over the card.
+     The link sits at the end of the journal row, so a left-anchored panel could
+     run off the right edge of the viewport; right-anchoring keeps it on-screen. */
+  left: auto;
+  right: 0;
+  width: 380px;
+  max-width: min(380px, calc(100vw - 32px));
   background: #fff;
   border: 1px solid #e8e2d9;
   border-radius: 8px;
   box-shadow: 0 6px 24px rgba(26, 33, 51, 0.12), 0 2px 8px rgba(26, 33, 51, 0.07);
   z-index: 200;
-  overflow: hidden;
+  /* Long histories scroll internally instead of dominating the page. */
+  max-height: min(70vh, 460px);
+  overflow: hidden auto;
 }
 
-/* Arrow pointing down */
+/* Arrow pointing down, near the right edge under the History link */
 .curationLogPopover::after {
   content: '';
   position: absolute;
   top: 100%;
-  left: 16px;
+  right: 16px;
   border: 6px solid transparent;
   border-top-color: #e8e2d9;
 }
@@ -900,7 +907,7 @@
   content: '';
   position: absolute;
   top: calc(100% - 1px);
-  left: 16px;
+  right: 16px;
   border: 6px solid transparent;
   border-top-color: #fff;
   z-index: 1;

--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -6,6 +6,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { RootStateOrAny } from "../../../types/redux";
 import { showEvidenceByDefault } from "../../../redux/actions/actions";
 import { reciterConfig } from "../../../../config/local";
+import { sanitizeInlineHtml } from "../../../utils/htmlText";
 
 const pubMedUrl = 'https://www.ncbi.nlm.nih.gov/pubmed/';
 const doiUrl = 'https://doi.org/';
@@ -845,8 +846,8 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
                   )}
                 </div>
               </div>
-              {/* Row 2: Title */}
-              <div className={styles.articleTitle}>{reciterArticle.articleTitle}</div>
+              {/* Row 2: Title — render PubMed inline markup (e.g. <i>) as formatting, sanitized */}
+              <div className={styles.articleTitle} dangerouslySetInnerHTML={{ __html: sanitizeInlineHtml((reciterArticle as any).articleTitleRTF || reciterArticle.articleTitle) }} />
               {/* Row 3: Authors */}
               <div className={styles.articleAuthors}>
                 {reciterArticle.reCiterArticleAuthorFeatures?.length > 0 &&

--- a/src/components/elements/Report/ReportResults.tsx
+++ b/src/components/elements/Report/ReportResults.tsx
@@ -34,7 +34,7 @@ export const ReportResults: React.FC<ReportResultsProps> = ({ reportingWebDispla
           return (
             <ReportsResultPane
             key={row.pmid}
-            title={row.articleTitle}
+            title={row.articleTitleRTF || row.articleTitle}
             pmid={row.pmid}
             doi={row.doi}
             citationCount={row.citationCountNIH}

--- a/src/components/elements/Report/ReportsResultPane.tsx
+++ b/src/components/elements/Report/ReportsResultPane.tsx
@@ -3,6 +3,7 @@ import styles from "./ReportsResultPane.module.css";
 import { AuthorsComponent } from "../Common/AuthorsComponent";
 import { Author } from "../../../../types/Author";
 import { setHelptextInfo, setReportFilterLabels, setReportFilterDisplayRank, setIsVisible } from "../../../utils/constants";
+import { sanitizeInlineHtml } from "../../../utils/htmlText";
 
 interface ReportsResultPaneProps {
   title: string
@@ -119,7 +120,7 @@ export const ReportsResultPane: React.FC<ReportsResultPaneProps> = ({
       </div>
 
       {/* Row 2: Title */}
-      <div className={styles.articleTitle} dangerouslySetInnerHTML={{ __html: title }} />
+      <div className={styles.articleTitle} dangerouslySetInnerHTML={{ __html: sanitizeInlineHtml(title) }} />
 
       {/* Row 3: Authors */}
       <div className={styles.articleAuthors}>

--- a/src/components/elements/Report/SearchSummary.tsx
+++ b/src/components/elements/Report/SearchSummary.tsx
@@ -16,7 +16,15 @@ import { ArrowLeft, ArrowRight } from "@mui/icons-material";
 import { setReportFilterDisplayRank, setReportFilterLabels,setIsVisible, setReportFilterKeyNames } from "../../../utils/constants";
 import { toast } from "react-toastify";
 import { reportError } from "../../../utils/reportError";
+import { stripHtml } from "../../../utils/htmlText";
 
+// Title/journal fields can carry PubMed inline markup (<i>, <sub>, …); strip to
+// plain text for spreadsheet cells, which can't render HTML.
+const HTML_BEARING_FIELDS = ['articleTitle', 'articleTitleRTF', 'journalTitleVerbose'];
+const stripHtmlFields = (row: any): any => {
+  HTML_BEARING_FIELDS.forEach((k) => { if (row && row[k]) row[k] = stripHtml(row[k]); });
+  return row;
+};
 
 const SearchSummary = ({
   reportLabelsForSort,
@@ -292,7 +300,7 @@ const SearchSummary = ({
         })
         itemRow = {...itemRow, authors: item.authors?.replace(/[\])}[{(]/g, '')};
         itemRow = {...itemRow, authorPosition: item.authorPosition?.replace(/[\])}[{(]/g, '')};
-        worksheet.addRow(itemRow);
+        worksheet.addRow(stripHtmlFields(itemRow));
       })
 
       // write the content using writeBuffer
@@ -390,7 +398,7 @@ const SearchSummary = ({
         })
         itemRow = {...itemRow, authors: item.authors?.replace(/[\])}[{(]/g, '')};
         itemRow = {...itemRow, authorPosition: item.authorPosition?.replace(/[\])}[{(]/g, '')};
-        worksheet.addRow(itemRow);
+        worksheet.addRow(stripHtmlFields(itemRow));
       })
 
       // write the content using writeBuffer

--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -666,7 +666,7 @@ const Search = () => {
             <Dropdown.Toggle variant="primary" id={`actions_${identity.personIdentifier}`}>
               Curate Publications
             </Dropdown.Toggle>
-            <Dropdown.Menu className={styles.actionMenu}>
+            <Dropdown.Menu className={styles.actionMenu} popperConfig={{ strategy: 'fixed' }}>
               <Dropdown.Item className={styles.actionMenuItem} onClick={() => onClickProfile(identity.personIdentifier)}>Curate Publications</Dropdown.Item>
               <Dropdown.Item className={styles.actionMenuItem} onClick={() => redirectToCurate("report", identity)}>Create Reports</Dropdown.Item>
               <Dropdown.Item className={styles.actionMenuItem} onClick={() => { setShowprofileID(identity.personIdentifier); handleShow(); }}>View Profile</Dropdown.Item>

--- a/src/utils/htmlText.tsx
+++ b/src/utils/htmlText.tsx
@@ -1,0 +1,62 @@
+/**
+ * Inline-HTML helpers for bibliographic text.
+ *
+ * PubMed-sourced article titles (and journal names) carry inline markup such as
+ * `<i>KIAA0319L</i>`, `<sub>`, `<sup>`, `<b>`, and `&amp;` entities. ReCiterDB stores
+ * both a plain `articleTitle` (which still contains the literal tag text) and an
+ * HTML `articleTitleRTF` variant. Interpolating either as a React text child escapes
+ * the markup, so the tags show literally in the UI ("...variations in <i>KIAA0319L</i>...").
+ *
+ * `sanitizeInlineHtml` renders that markup safely by RECONSTRUCTION: it keeps only a
+ * tight whitelist of attribute-free inline formatting tags and drops everything else
+ * (scripts, anchors, attributes, event handlers). This is dependency-free and
+ * SSR-safe — no DOMPurify/jsdom, no `window`, identical output on server and client
+ * (so no hydration mismatch). Pair it with `dangerouslySetInnerHTML`, e.g.
+ *   <div dangerouslySetInnerHTML={{ __html: sanitizeInlineHtml(title) }} />
+ *
+ * `stripHtml` removes all tags and decodes a few common entities to plain text — use
+ * it for spreadsheet exports, `title=` tooltips, and toasts where HTML can't render.
+ */
+
+// Attribute-free inline formatting only. No block, anchor, media, or script tags.
+const ALLOWED_TAGS = new Set(['i', 'em', 'b', 'strong', 'sub', 'sup', 'u', 'span']);
+
+const TAG_RE = /<\/?([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/g;
+
+/**
+ * Return an HTML string containing ONLY whitelisted, attribute-free inline tags from
+ * the input; all other tags are removed and text/entities are preserved. Safe to pass
+ * to dangerouslySetInnerHTML.
+ */
+export function sanitizeInlineHtml(input?: string | null): string {
+  if (input === undefined || input === null) return '';
+  return String(input).replace(TAG_RE, (match, tag) => {
+    const t = String(tag).toLowerCase();
+    if (!ALLOWED_TAGS.has(t)) return '';
+    const closing = /^<\s*\//.test(match);
+    return closing ? `</${t}>` : `<${t}>`;
+  });
+}
+
+const ENTITY_MAP: Record<string, string> = {
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+};
+
+/**
+ * Strip all tags and decode common named/numeric entities to a plain-text string.
+ * For exports, tooltips, and toasts.
+ */
+export function stripHtml(input?: string | null): string {
+  if (input === undefined || input === null) return '';
+  const noTags = String(input).replace(/<\/?[a-zA-Z][^>]*>/g, '');
+  return noTags.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (m, code) => {
+    if (code[0] === '#') {
+      const num = code[1] === 'x' || code[1] === 'X'
+        ? parseInt(code.slice(2), 16)
+        : parseInt(code.slice(1), 10);
+      return Number.isFinite(num) ? String.fromCodePoint(num) : m;
+    }
+    const decoded = ENTITY_MAP[code.toLowerCase()];
+    return decoded !== undefined ? decoded : m;
+  });
+}


### PR DESCRIPTION
Three independent presentation fixes reported from reciter-dev review.

### 1. Render PubMed inline HTML in titles/journals — Closes #750
Article titles carry PubMed inline markup (`<i>`, `<sub>`, `<sup>`, …) that was leaking as raw text (e.g. "variations in `<i>KIAA0319L</i>`"). New dependency-free, SSR-safe sanitizer `src/utils/htmlText.tsx` renders only attribute-free inline formatting tags and drops everything else (scripts/anchors/attributes). Applied to the Curate card title, Authorships review card title+journal, and Reports (which previously used an UNsanitized `dangerouslySetInnerHTML` — now sanitized and fed the `articleTitleRTF` column). Tags are stripped to plain text for spreadsheet exports and the undo toast. Unit-tested incl. XSS cases (`__tests__/htmlText.test.ts`, 7 passing).

### 2. ACTIONS dropdown no longer clipped on Find People — Closes #751
The "Curate Publications" menu was cropped by `.table { overflow: hidden }` + the `.table-responsive` scroll wrapper. The react-bootstrap `Dropdown.Menu` now renders with Popper `strategy: 'fixed'`, positioning against the viewport so it escapes both clipping ancestors.

### 3. History popover stays on-screen — Closes #752
The per-card History popover was a fixed 280px panel anchored `left:0` to the inline History link; since that link sits at the end of the journal row, a wide panel ran off the right edge of the viewport and covered neighbouring cards. Now right-anchored (extends left over the card), widened to a responsive 380px, height-capped with internal scroll.

**Verification:** `tsc --noEmit` clean on changed files; sanitizer unit tests pass; dev server boots and webpack-compiles cleanly. Visual confirmation on reciter-dev pending (UI changes).
