### PR TITLE
fix(search): anchor ACTIONS dropdown menu to its button

### DIFF
--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -666,7 +666,7 @@ const Search = () => {
             <Dropdown.Toggle variant="primary" id={`actions_${identity.personIdentifier}`}>
               Curate Publications
             </Dropdown.Toggle>
-            <Dropdown.Menu className={styles.actionMenu} popperConfig={{ strategy: 'fixed' }}>
+            <Dropdown.Menu className={styles.actionMenu} popperConfig={{ strategy: 'fixed' }} renderOnMount>
               <Dropdown.Item className={styles.actionMenuItem} onClick={() => onClickProfile(identity.personIdentifier)}>Curate Publications</Dropdown.Item>
               <Dropdown.Item className={styles.actionMenuItem} onClick={() => redirectToCurate("report", identity)}>Create Reports</Dropdown.Item>
               <Dropdown.Item className={styles.actionMenuItem} onClick={() => { setShowprofileID(identity.personIdentifier); handleShow(); }}>View Profile</Dropdown.Item>


### PR DESCRIPTION
## Problem
On the `/search` results table, opening the **Curate Publications** dropdown in the rightmost ACTIONS column renders the menu at the **viewport top-left** (over the sidebar) instead of under its button.

## Cause
The menu uses `popperConfig={{ strategy: 'fixed' }}` (added in `e24512e` to stop it being clipped by the table's `overflow`). A fixed-strategy `Dropdown.Menu` mounts lazily on first open, so Popper positions it *before it has been measured* → it lands at `(0,0)`. This is react-bootstrap's known "wrong position on first open" behavior, pronounced under the fixed strategy.

## Fix
Add `renderOnMount` to the `Dropdown.Menu`. react-bootstrap then pre-renders the menu into the DOM and runs Popper's position-correction pass (`popper.update()`), so the menu is measured and anchored to its toggle on the first click. The `strategy: 'fixed'` overflow-escape is preserved. One-prop change.

Verified against the installed `react-bootstrap@2.10.10` source (`DropdownMenu.js`: `renderOnMount` gates the pre-mount + `popper.update()` correction).

## Not related to the Node 22 migration
Client-side positioning only; no runtime dependency changed. Pre-existing behavior from the `strategy:'fixed'` fix.

## Verification status
- `next build` passes (Node 22).
- **Visual confirmation pending** — reproducing `/search` locally needs DB/auth env this branch doesn't carry. Please confirm the menu anchors correctly once this reaches `reciter-pm-dev`.