### PR TITLE
fix(reports): stop RTF export failing with SequelizeDatabaseError

### DIFF
--- a/controllers/db/reports/publication.report.controller.ts
+++ b/controllers/db/reports/publication.report.controller.ts
@@ -34,9 +34,11 @@ export const generatePubsRtf = async (
 								
     if (apiBody.personIdentifiers && apiBody.personIdentifiers.length > 0) {
       generatePubsRtfOutput = await sequelize.query(
-        "CALL generatePubsRTF (:uids , :pmids, :limit)",
+        // generatePubsRTF takes 2 args (personIdentifierArray, pmidArray) — no limit.
+        // Passing :limit caused ER_SP_WRONG_NO_OF_ARGS (SequelizeDatabaseError).
+        "CALL generatePubsRTF (:uids , :pmids)",
         {
-          replacements: { uids: apiBody.personIdentifiers.join(','), pmids: apiBody.pmids.join(','), limit: apiBody.limit },
+          replacements: { uids: apiBody.personIdentifiers.join(','), pmids: apiBody.pmids.join(',') },
           raw: true,
         }
       );


### PR DESCRIPTION
## Problem
On the Reports page, **Export to RTF** fails with a `SequelizeDatabaseError` whenever an author/person filter is applied (the normal case).

## Root cause
The people-filtered branch calls the stored procedure with **three** args:
```
CALL generatePubsRTF (:uids , :pmids, :limit)
```
but the deployed procedure takes only **two** (`personIdentifierArray`, `pmidArray`). MySQL raises `1318 ER_SP_WRONG_NO_OF_ARGS`, which Sequelize re-throws as `SequelizeDatabaseError`. Pre-existing since the controller's first commit (`fff32c8`); the sibling `generatePubsNoPeopleRTF` had the identical bug fixed earlier (`b1ac138`), but `generatePubsRTF` was left on the 3-arg call.

Not related to the Node 18→22 migration — normal DB queries work (the DB connection is fine); this is purely an argument-count mismatch on one procedure call.

## Fix
Drop the unsupported `:limit` argument so the `CALL` matches the procedure signature. (The proc has no limit parameter, so `:limit` was never applied even before it started erroring.)

## Verified against the live dev DB
Queried `information_schema.parameters` on the dev database for the actual signatures:

| Procedure | Live args | Controller sent | Status |
|---|---|---|---|
| `generatePubsRTF` | 2 (`personIdentifierArray`, `pmidArray`) | 3 | ❌ fixed here |
| `generatePubsNoPeopleRTF` | 1 (`pmidArray`) | 1 | ✅ already correct |
| `generatePubsPeopleOnlyRTF` | 2 (`personIdentifierArray`, `maxLimit`) | 2 | ✅ correct — **left unchanged** |

Note: the ReciterDB *repo* schema shows `generatePubsPeopleOnlyRTF` with 1 arg, which would suggest a second bug — but the **live dev DB** has it at 2 args matching the controller, so that call is correct. Schema-drift between the repo and the live DB; trusting the live DB.

## Verification
- `next build` passes (Node 22).
- **Runtime confirmation pending deploy** — needs an Export-to-RTF with a person filter on `reciter-pm-dev` to confirm the download succeeds.