### PR TITLE
fix: Curate nav gating + date sort labels (Mahender feedback)

### DIFF
--- a/src/components/elements/Navbar/SideNavbar.tsx
+++ b/src/components/elements/Navbar/SideNavbar.tsx
@@ -205,6 +205,15 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
   const userPermissions = JSON.parse(session.data.userRoles);
   const isSuperuser = userPermissions.some((role: any) => role.roleLabel === "Superuser");
 
+  // A user "has their own profile" when they hold a Curator_Self role carrying a
+  // personIdentifier (faculty/postdoc who can curate themselves). Those users may open
+  // Curate Publications directly; everyone else (e.g. a Superuser with no profile of
+  // their own) must first pick a person from Find People, so the link stays disabled
+  // until a search is active.
+  const hasOwnProfile = userPermissions.some(
+    (role: any) => role.roleLabel === "Curator_Self" && role.personIdentifier
+  );
+
   // Phase 9: Parse scope/proxy data and derive capabilities
   const scopeData = session?.data?.scopeData ? JSON.parse(session.data.scopeData) : null;
   const proxyPersonIds = session?.data?.proxyPersonIds ? JSON.parse(session.data.proxyPersonIds) : [];
@@ -231,7 +240,10 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
       imgUrl: SettingsIconTools,
       imgUrlActive: settingsIconActive,
       muiIcon: <IconCurate />,
-      disabled: false,
+      // Hidden-until-context: greyed out unless a Find People search is active, so a
+      // user with no profile of their own (e.g. Superuser) can't jump straight here.
+      // Users who have their own profile keep it enabled to curate themselves.
+      disabled: (Object.keys(filters).length === 0) && !hasOwnProfile,
       allowedRoleNames: ["Superuser", "Curator_All","Curator_Self","Curator_Scoped"],
       isRequired:true
     },

--- a/src/components/elements/Report/SearchSummary.tsx
+++ b/src/components/elements/Report/SearchSummary.tsx
@@ -454,6 +454,8 @@ const SearchSummary = ({
               const {labelName, keyName} = sortOption || {};
               const isActive = selected.type === keyName;
               const isDesc = selected.order === 'DESC';
+              // Date columns read oddly as "High → Low"; show newest/oldest instead.
+              const isDateSort = /date/i.test(keyName || '') || /date/i.test(labelName || '');
               return (
                 <button
                   type="button"
@@ -469,7 +471,7 @@ const SearchSummary = ({
                   style={{ width: '100%', background: 'none', border: 'none', fontFamily: 'inherit', textAlign: 'left' }}
                 >
                   <span className={styles.sortLabel}>{labelName}</span>
-                  {isActive && <span className={styles.sortDirection}>{isDesc ? 'High → Low' : 'Low → High'}</span>}
+                  {isActive && <span className={styles.sortDirection}>{isDateSort ? (isDesc ? 'Newest → Oldest' : 'Oldest → Newest') : (isDesc ? 'High → Low' : 'Low → High')}</span>}
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style={{ opacity: isActive ? 1 : 0.3, flexShrink: 0 }}>
                     {(isActive && !isDesc) ? (
                       <path d="M7 11V3M7 3L4 6M7 3l3 3" stroke={isActive ? '#2563a8' : '#6b6560'} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>


### PR DESCRIPTION
Two small UI fixes from Mahender's feedback. Independent of the Node 22 migration and of the RTF export fix (#765).

## 1. Curate Publications nav link — `SideNavbar.tsx`
**Problem:** A Superuser with no profile of their own could click **Curate Publications** directly from the sidebar with no person selected (it just bounces to Find People). In the previous version the link was greyed out until you searched.

**Fix:** Restore the "not until you search" gating, with an exception for self-curators:
```ts
const hasOwnProfile = userPermissions.some(
  (role) => role.roleLabel === "Curator_Self" && role.personIdentifier
);
// on the Curate item:
disabled: (Object.keys(filters).length === 0) && !hasOwnProfile,
```
- **Superuser / admin with no profile** → greyed out until a Find People search is active (matches old behavior).
- **Faculty/postdoc with their own profile** (a `Curator_Self` role carrying a `personIdentifier`) → stays enabled, so they can curate themselves directly.

`hasOwnProfile` uses the same self-curator signal as `permissionUtils`/`middleware` (`roleLabel === 'Curator_Self'` + `personIdentifier`). This only affects whether the menu item is clickable — route access is still enforced by middleware.

## 2. Date sort direction labels — `SearchSummary.tsx`
**Problem:** the Reports "Sort by" dropdown showed `High → Low / Low → High` for every column, including Date Added — unusual wording for dates.

**Fix:** date columns now show `Newest → Oldest / Oldest → Newest`; numeric columns keep `High → Low`. Date columns are detected by the sort key/label containing "date" (matches `datePublicationAddedToEntrez`, `publicationDateStandarized`; no numeric key matches).

## Verification
- `next build` passes (Node 22).
- Behavioral confirmation pending deploy: (1) as a no-profile Superuser the Curate link is greyed until searching; (2) sorting Reports by Date Added shows Newest/Oldest.