### PR TITLE
fix(curate): send profile holders to their own curate page

### DIFF
--- a/src/pages/curate/index.js
+++ b/src/pages/curate/index.js
@@ -3,12 +3,16 @@ import { AppLayout } from "../../components/layouts/AppLayout"
 import { getSession } from "next-auth/client"
 
 // The group curation surface (the multi-person People/Org/Institution/Person-Type queue)
-// has been retired. Curate individuals via Find People (/search -> person -> /curate/[cwid])
-// or use the Authorships review queue. Any visit to /curate redirects to Find People.
-export async function getServerSideProps() {
+// has been retired. A visitor who has their own profile (a Curator_Self role carrying a
+// personIdentifier) is sent straight to curate themselves; everyone else goes to Find
+// People to pick a person to curate.
+export async function getServerSideProps(ctx) {
+    const session = await getSession(ctx);
+    const userRoles = session?.data?.userRoles ? JSON.parse(session.data.userRoles) : [];
+    const selfRole = userRoles.find((r) => r.roleLabel === "Curator_Self" && r.personIdentifier);
     return {
         redirect: {
-            destination: "/search",
+            destination: selfRole ? `/curate/${selfRole.personIdentifier}` : "/search",
             permanent: false,
         },
     };


### PR DESCRIPTION
Follow-up to #766. Confirmed on the dev site (paa2013) + dev DB that the Curate nav link is correctly enabled for profile holders — but clicking it redirected them to Find People, which read as "nothing happens."

## Change
`/curate`'s `getServerSideProps` now checks the session and routes by whether the user has their own profile:
```js
const userRoles = session?.data?.userRoles ? JSON.parse(session.data.userRoles) : [];
const selfRole = userRoles.find((r) => r.roleLabel === "Curator_Self" && r.personIdentifier);
destination: selfRole ? `/curate/${selfRole.personIdentifier}` : "/search"
```
- **Has own profile** (a `Curator_Self` role carrying a `personIdentifier`, auto-assigned at login when a Person record exists) → `/curate/{their-cwid}` to curate themselves.
- **No profile** (e.g. a Superuser with no Person record) → `/search`, unchanged.

The nav link still points at `/curate`, so the sidebar highlight on `/curate/*` is unaffected, and the greyed-until-search gating from #766 still applies to no-profile users.

Reuses the same self-curator signal as `permissionUtils`/`middleware` and mirrors the session-reading pattern in `src/pages/index.js`.

## Verification
- `next build` passes (Node 22).
- Runtime check pending deploy: as paa2013, clicking Curate Publications should land on `/curate/paa2013` (not `/search`).