### PR TITLE
fix(reports): export downloads use real filename, not a blob UUID

### DIFF
--- a/src/components/elements/Report/SearchSummary.tsx
+++ b/src/components/elements/Report/SearchSummary.tsx
@@ -134,6 +134,7 @@ const SearchSummary = ({
       var link = document.createElement('a')  // once we have the file buffer BLOB from the post request we simply need to send a GET request to retrieve the file data
       link.href = window.URL.createObjectURL(fileBlob)
       link.download = fileName;
+      document.body.appendChild(link); // Chrome honors the download filename only for an anchor in the DOM; detached anchors save as a blob UUID.
       link.click()
       link.remove();
       setExportArticleLoading(false);
@@ -180,6 +181,7 @@ const SearchSummary = ({
       var link = document.createElement('a')  // once we have the file buffer BLOB from the post request we simply need to send a GET request to retrieve the file data
       link.href = window.URL.createObjectURL(fileBlob)
       link.download = fileName;
+      document.body.appendChild(link); // Chrome honors the download filename only for an anchor in the DOM; detached anchors save as a blob UUID.
       link.click()
       link.remove();
       setExportArticlePplLoading(false);
@@ -310,6 +312,7 @@ const SearchSummary = ({
       var link = document.createElement('a')  // once we have the file buffer BLOB from the post request we simply need to send a GET request to retrieve the file data
       link.href = window.URL.createObjectURL(blobFromBuffer);
       link.download = fileName;
+      document.body.appendChild(link); // Chrome honors the download filename only for an anchor in the DOM; detached anchors save as a blob UUID.
       link.click()
       link.remove();
     } catch (error) {
@@ -408,6 +411,7 @@ const SearchSummary = ({
       var link = document.createElement('a')  // once we have the file buffer BLOB from the post request we simply need to send a GET request to retrieve the file data
       link.href = window.URL.createObjectURL(blobFromBuffer);
       link.download = fileName;
+      document.body.appendChild(link); // Chrome honors the download filename only for an anchor in the DOM; detached anchors save as a blob UUID.
       link.click()
       link.remove();
     } catch (error) {


### PR DESCRIPTION
Follow-up to #765 (which fixed the RTF export crash). With the export now working, the download was saving under a random UUID (e.g. `5decb1ec-4e96-4ac0-8175-348491fb5e94`) instead of `ArticleReport-ReCiter-<date>.rtf`.

## Cause
All four export-download blocks in `SearchSummary.tsx` (RTF ×2, CSV ×2) build an anchor, set `link.download`, `click()`, and `remove()` — but never append the anchor to the document:
```js
var link = document.createElement('a')
link.href = window.URL.createObjectURL(fileBlob)
link.download = fileName;
link.click()          // detached anchor
link.remove();
```
Chrome ignores the `download` filename for a **detached** anchor pointing at a `blob:` URL and falls back to the blob's UUID.

## Fix
Append the anchor to `document.body` before clicking (the existing `link.remove()` then cleans it up), in all four paths.

## Verification
- `next build` passes (Node 22).
- **Must be verified in real Chrome** — Playwright/Chromium reads the `download` attribute regardless of DOM attachment, so it always reports the correct filename and cannot reproduce this bug. After deploy: hard-refresh, export, confirm the file saves as `ArticleReport-ReCiter-<date>.rtf`.

## Note (out of scope)
The export is also slow — the `generatePubsRTF` stored procedure builds the RTF server-side and can take a while on large sets (the "spinning"). Separate performance concern, not addressed here.