### PR TITLE
fix(search): hide Curate Publications for people a self-only curator can't curate

### DIFF
--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -582,6 +582,21 @@ const Search = () => {
     return false;
   }
   
+  // Per-row curate authorization for the Actions dropdown. Mirrors the backend
+  // checkCurationScope gate so the UI never offers "Curate Publications" for a
+  // person the user cannot actually curate: curate-all roles (Superuser /
+  // Curator_All / scoped, which set isCuratorAll) may curate anyone; a proxy
+  // holder may curate the people they proxy for; a self-only curator may curate
+  // only their own row. Everyone else (e.g. a pure Reporter_All) gets
+  // report/profile actions but no Curate Publications.
+  const canCuratePerson = (identity) => {
+    if (isSuperUser || isCuratorAll) return true;
+    const pid = identity?.personIdentifier;
+    if (isProxyFor(proxyPersonIds, pid)) return true;
+    if (isCuratorSelf) return pid === loggedInPersonIdentifier;
+    return false;
+  };
+
   const RoleSplitDropdown = (identity) => {
     
     if(dropdownTitle && dropdownTitle =='Curate Publications' && isCuratorSelf && !isReporterAll && !isCuratorAll && !isSuperUser
@@ -639,6 +654,7 @@ const Search = () => {
   if (paginatedIdentities?.length > 0) {
     // setCurateIds(paginatedIdentities);
     tableBody = paginatedIdentities.map(function (identity, identityIndex) {
+      const rowCanCurate = canCuratePerson(identity);
       return <tr key={identityIndex}>
         <td key={`${identityIndex}__name`} width="34%">
         {
@@ -664,10 +680,10 @@ const Search = () => {
         <td key={`${identityIndex}__actions`} width="24%" className={styles.actionsCell}>
           <Dropdown className="d-inline-block">
             <Dropdown.Toggle variant="primary" id={`actions_${identity.personIdentifier}`}>
-              Curate Publications
+              {rowCanCurate ? "Curate Publications" : "Create Reports"}
             </Dropdown.Toggle>
             <Dropdown.Menu className={styles.actionMenu} popperConfig={{ strategy: 'fixed' }} renderOnMount>
-              <Dropdown.Item className={styles.actionMenuItem} onClick={() => onClickProfile(identity.personIdentifier)}>Curate Publications</Dropdown.Item>
+              {rowCanCurate && <Dropdown.Item className={styles.actionMenuItem} onClick={() => onClickProfile(identity.personIdentifier)}>Curate Publications</Dropdown.Item>}
               <Dropdown.Item className={styles.actionMenuItem} onClick={() => redirectToCurate("report", identity)}>Create Reports</Dropdown.Item>
               <Dropdown.Item className={styles.actionMenuItem} onClick={() => { setShowprofileID(identity.personIdentifier); handleShow(); }}>View Profile</Dropdown.Item>
             </Dropdown.Menu>


### PR DESCRIPTION
## Problem

Reported on reciter-dev: a user with **Curator_Self + Reporter_All** could click **Curate Publications** from the Find People results for *another* person and land on `/curate/<cwid>`. The button should not be visible for people the user cannot curate.

## Root cause

The calm-redesign commit (`e416dfe`, #741) replaced the old role-aware action control in the search-results **Actions** column with a hard-coded Bootstrap dropdown that renders **Curate Publications → `onClickProfile` → `/curate/:cwid`** for *every row and every role*, with no self/scope check. The role-aware `RoleSplitDropdown` in `Search.js` was left behind as dead code.

The backend gate (`checkCurationScope`) still blocks the actual write, so this is a UI-authorization leak, not a data breach.

## Fix

- Add `canCuratePerson(identity)` in `Search.js`, mirroring the backend `checkCurationScope` authorization: curate-all roles (Superuser / Curator_All / scoped) may curate anyone; a proxy holder may curate people they proxy for; a self-only curator may curate only their own row; everyone else (e.g. pure Reporter_All) gets no Curate action.
- Gate the Actions dropdown with it: the toggle falls back to **Create Reports** and the **Curate Publications** menu item is hidden for non-curatable rows.

| Roles | Own / proxied row | Other rows |
|---|---|---|
| Superuser / Curator_All / scoped | Curate | Curate |
| **Curator_Self + Reporter_All** (reported) | Curate | Create Reports |
| Reporter_All only | Create Reports (proxy: Curate) | Create Reports |

## Testing

- `next/babel` parse of the edited file: pass
- Authorization-matrix self-check (7 assertions incl. the reported combo): pass
- Not runtime-tested as the exact `Curator_Self + Reporter_All` user locally (needs a seeded test user) — please verify on the deploy preview / reciter-dev.

## Notes

- Targets `dev_Upd_NextJS14SNode18` (the branch deployed to reciter-dev).
- The header "Go to → Curate Publications" bulk select was reviewed and is a **no-op** (`/curate` group index redirects to `/search`) — no change needed.
