### PR TITLE
fix(search): guard session-claim JSON.parse so a bad JWT claim can't crash the Search page

### DIFF
--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -19,6 +19,11 @@ import { allowedPermissions, allowedSettings, dropdownItemsReport, dropdownItems
 //import {RoleManagerHelper} from  "../../../utils/RoleManagerHelper"
 import Profile from "../Profile/Profile";
 
+// Guard against malformed/absent session claims so a bad JWT value can't white-screen the page.
+const safeParse = (value, fallback) => {
+  try { return value != null ? JSON.parse(value) : fallback; } catch { return fallback; }
+};
+
 const Search = () => {
 
   const [session, loading] = useSession();
@@ -74,7 +79,7 @@ const Search = () => {
   useEffect(() => {
     dispatch(showEvidenceByDefault(null))
     dispatch(clearFilters())
-    let adminSettings = JSON.parse(session.adminSettings);
+    let adminSettings = safeParse(session.adminSettings, []);
     var viewAttributes = [];
     if (updatedAdminSettings.length > 0) {
       // updated settings from manage settings page
@@ -86,7 +91,7 @@ const Search = () => {
     } else {
       // regular settings from session
       let data = adminSettings.find(obj => obj.viewName === "findPeople")
-      viewAttributes = JSON.parse(data.viewAttributes)
+      viewAttributes = data ? safeParse(data.viewAttributes, []) : []
       let cwidLabel = viewAttributes.find(data => data.labelUserKey === "personIdentifier")
       setNameOrcwidLabel(cwidLabel)
     }
@@ -94,7 +99,7 @@ const Search = () => {
     // view attributes data from session or updated settings
     setFindPeopleLabels(viewAttributes)
 
-    let userPermissions = JSON.parse(session.data.userRoles);
+    let userPermissions = safeParse(session.data.userRoles, []);
     //RoleManagerHelper.showOrHideCurateReportMenu(userPermissions,allowedPermissions);
     if (userPermissions && userPermissions.length === 1 && userPermissions.some(role => role.roleLabel === allowedPermissions.Reporter_All)) {
         setDropdownTitle("Create Report");


### PR DESCRIPTION
## Problem

The Search page fails to load in production with a runtime error while every other tab loads fine. Root cause: `Search.js` parses session claims with **unguarded `JSON.parse`** inside the render effect:

- `JSON.parse(session.adminSettings)`
- `JSON.parse(data.viewAttributes)`
- `JSON.parse(session.data.userRoles)`

When any of these claims arrives **malformed or absent** — e.g. a JWT/token serialization mismatch between environments — `JSON.parse` throws a `SyntaxError` during render, taking down the whole Search page. Nothing else imports these values, which is exactly why only Search breaks.

## Fix

- Add a `safeParse(value, fallback)` helper (try/catch, falls back to a safe empty value).
- Apply it to all three session-claim parses.
- Guard the downstream `adminSettings.find(...)` result so an empty fallback can't move the crash to `data.viewAttributes`.

The page now **degrades gracefully** (empty admin settings / roles) instead of white-screening on a bad claim.

## Scope / notes

- Pure defensive change — no behavior change when the claims are well-formed.
- This addresses the *symptom* (crash). If the claims are genuinely malformed in prod, the underlying **JWT claim serialization** (what sets `userRoles` / `adminSettings` on the session) should still be verified separately, or scope/roles will silently render empty.
- The same class of unguarded parse exists on the feature branches (`dev_Upd_NextJS14SNode18` parses `scopeData`/`proxyPersonIds`/`userRoles` at the top of the component); the same guard should be forward-ported there.

## Verification

- Not runtime-tested locally (change is isolated JS in a render effect). Relying on CI build/typecheck. Please confirm the Search page loads in a prod-like session before merge.