### PR TITLE
PM#771 + PM#772: external-source add-publication (OpenAlex + Scopus)

### DIFF
--- a/config/local.js
+++ b/config/local.js
@@ -100,6 +100,13 @@ export const reciterConfig = {
         reciterUpdateGoldStandardEndpoint:
                 process.env.RECITER_API_BASE_URL + '/reciter/goldstandard',
         /**
+         * PM#771 — external-source (OpenAlex/Scopus/WoS) manual-add publications.
+         * POST/GET/DELETE against the same Java ingress as the other /reciter/* calls,
+         * so RECITER_API_BASE_URL + the admin api-key are sufficient (no new env var).
+         */
+        reciterExternalArticleEndpoint:
+                process.env.RECITER_API_BASE_URL + '/reciter/external-article/by/uid',
+        /**
          * This endpoints serves to do CRUD on user feedback. This is used to track the publication feedback in the application. When refreshed
          * the feedback is erased from the database.
          */
@@ -116,6 +123,13 @@ export const reciterConfig = {
     reciterPubmed: {
         searchPubmedEndpoint: process.env.RECITER_API_BASE_URL + '/pubmed/query-complex/',
         searchPubmedCountEndpoint: process.env.RECITER_API_BASE_URL + '/pubmed/query-number-pubmed-articles/',
+    },
+    /**
+     * PM#771 — OpenAlex is a free, keyless public API. It is queried ONLY server-side
+     * (via the PM /api/reciter/search/openalex route), never from the browser.
+     */
+    openAlex: {
+        searchHost: 'https://api.openalex.org',
     },
     /**
      * ReCiter-Publication-Manager uses Json web token for session management and validating a valid sesssion. This secret will be used to sign the web token.

--- a/controllers/externalArticle.controller.ts
+++ b/controllers/externalArticle.controller.ts
@@ -1,0 +1,72 @@
+import { reciterConfig } from '../config/local'
+import { NextApiRequest } from 'next'
+
+// PM#771 — proxy the ReCiter external-article API (OpenAlex/Scopus/WoS manual-add).
+// Same mechanism as goldstandard.controller / pubmed.controller: PM route gates on
+// the app backendApiKey, then this controller calls the Java service with the admin
+// api-key header. The target person uid always comes from the route param, and
+// addedBy is resolved from the JWT in the route (never trusted from the client).
+
+const base = () => reciterConfig.reciter.reciterExternalArticleEndpoint
+
+function javaHeaders() {
+    return {
+        'Content-Type': 'application/json',
+        'api-key': reciterConfig.reciter.adminApiKey,
+        'User-Agent': 'reciter-pub-manager-server',
+    }
+}
+
+async function readBody(res: Response) {
+    try { return await res.json() } catch (e) {
+        try { return await res.text() } catch (e2) { return null }
+    }
+}
+
+// GET all external articles for a person (includes suppressed rows).
+export async function getExternalArticles(uid: string) {
+    return fetch(`${base()}?uid=${encodeURIComponent(uid)}`, {
+        method: 'GET',
+        headers: javaHeaders(),
+    })
+        .then(async (res) => ({ statusCode: res.status, statusText: await readBody(res) }))
+        .catch((error) => {
+            console.log('ReCiter external-article GET is not reachable: ' + error)
+            return { statusCode: error.status || 500, statusText: error }
+        })
+}
+
+// POST a new external article. `force` maps to the &force=true retry for WARNING dups.
+// addedBy is stamped server-side (curator CWID from the JWT).
+export async function addExternalArticle(uid: string, body: any, addedBy: string | undefined, force: boolean) {
+    // Never trust a client-supplied addedBy; stamp it from the JWT server-side.
+    const { addedBy: _ignore, ...rest } = body || {}
+    const payload = addedBy ? { ...rest, addedBy } : rest
+
+    let uri = `${base()}?uid=${encodeURIComponent(uid)}`
+    if (force) uri += '&force=true'
+
+    return fetch(uri, {
+        method: 'POST',
+        headers: javaHeaders(),
+        body: JSON.stringify(payload),
+    })
+        .then(async (res) => ({ statusCode: res.status, statusText: await readBody(res) }))
+        .catch((error) => {
+            console.log('ReCiter external-article POST is not reachable: ' + error)
+            return { statusCode: error.status || 500, statusText: error }
+        })
+}
+
+// DELETE (= revoke) an external article by articleId.
+export async function deleteExternalArticle(uid: string, articleId: string) {
+    return fetch(`${base()}?uid=${encodeURIComponent(uid)}&articleId=${encodeURIComponent(articleId)}`, {
+        method: 'DELETE',
+        headers: javaHeaders(),
+    })
+        .then(async (res) => ({ statusCode: res.status, statusText: await readBody(res) }))
+        .catch((error) => {
+            console.log('ReCiter external-article DELETE is not reachable: ' + error)
+            return { statusCode: error.status || 500, statusText: error }
+        })
+}

--- a/controllers/openalex.controller.ts
+++ b/controllers/openalex.controller.ts
@@ -1,0 +1,89 @@
+import { reciterConfig } from '../config/local'
+import { NextApiRequest } from 'next'
+
+// PM#771 — server-side OpenAlex search. OpenAlex is free + keyless, but per the
+// acceptance criteria it MUST be proxied through this PM route and never called
+// from the browser. Results are normalized into the same shape the external-article
+// POST body expects, so the client can hand a preview row straight back to the
+// add route (the PM route injects addedBy from the JWT).
+
+const looksLikeDoi = (q: string): string | null => {
+    if (!q) return null
+    // Accept raw DOI, doi.org URL, or "doi:10...." forms; extract the 10.xxxx/... part.
+    const m = q.match(/10\.\d{4,9}\/[^\s"]+/i)
+    return m ? m[0].replace(/[).,;]+$/, '') : null
+}
+
+// Map one OpenAlex "work" -> external-article POST body (minus addedBy, set server-side).
+function normalizeWork(work: any) {
+    if (!work || !work.id) return null
+    const openalexId = String(work.id).replace('https://openalex.org/', '')
+    const doi = work.doi ? String(work.doi).replace('https://doi.org/', '') : undefined
+
+    let pmid: number | undefined = undefined
+    if (work.ids && work.ids.pmid) {
+        const digits = String(work.ids.pmid).match(/(\d+)\s*$/)
+        if (digits) pmid = Number(digits[1])
+    }
+
+    const journalOrVenue = work.primary_location
+        && work.primary_location.source
+        && work.primary_location.source.display_name
+        ? work.primary_location.source.display_name
+        : undefined
+
+    const authors = (Array.isArray(work.authorships) ? work.authorships : [])
+        .map((a: any) => a && a.author && a.author.display_name)
+        .filter(Boolean)
+
+    return {
+        articleId: 'OPENALEX:' + openalexId,
+        title: work.title || work.display_name || '',
+        doi: doi,
+        pmid: pmid,
+        journalOrVenue: journalOrVenue,
+        authors: authors,
+        pubDate: work.publication_date,
+        publicationType: work.type,
+        sourceType: 'OPENALEX',
+        method: 'dropdown-search',
+        rawRecord: JSON.stringify(work),
+    }
+}
+
+export async function searchOpenAlex(req: NextApiRequest) {
+    const rawQuery: string = (req.body && (req.body.query || req.body.search) || '').toString().trim()
+    if (!rawQuery) {
+        return { statusCode: 400, statusText: { message: 'A search query (title or DOI) is required.' } }
+    }
+
+    const doi = looksLikeDoi(rawQuery)
+    const base = reciterConfig.openAlex.searchHost
+    const uri = doi
+        ? `${base}/works?filter=doi:${encodeURIComponent(doi)}&per_page=10`
+        : `${base}/works?search=${encodeURIComponent(rawQuery)}&per_page=10`
+
+    return fetch(uri, {
+        method: 'GET',
+        headers: {
+            'Accept': 'application/json',
+            'User-Agent': 'reciter-pub-manager-server',
+        },
+    })
+        .then(async (res) => {
+            if (res.status !== 200) {
+                let responseText: any
+                try { responseText = await res.json() } catch (e) { responseText = await res.text() }
+                return { statusCode: res.status, statusText: responseText }
+            }
+            const data: any = await res.json()
+            const results = (Array.isArray(data.results) ? data.results : [])
+                .map(normalizeWork)
+                .filter(Boolean)
+            return { statusCode: 200, statusText: results }
+        })
+        .catch((error) => {
+            console.log('OpenAlex search api is not reachable: ' + error)
+            return { statusCode: 502, statusText: { message: 'OpenAlex search is temporarily unavailable.' } }
+        })
+}

--- a/controllers/pubmedLookup.controller.ts
+++ b/controllers/pubmedLookup.controller.ts
@@ -1,0 +1,20 @@
+// PM#771 — check whether a DOI is present in PubMed. External records are unscored,
+// so before adding an external (OpenAlex) work we confirm it is genuinely NOT in
+// PubMed; if it is, the curator is steered to the PubMed accept path so the article
+// becomes scored evidence. OpenAlex's own PMID field is incomplete (~21% of
+// PubMed-indexed works lack it), so we ask PubMed directly by DOI.
+// ponytail: keyless eutils, fine at per-click volume; add an NCBI key if rate-limited.
+
+const EUTILS = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi'
+
+// Returns the PMID if the DOI resolves to a PubMed record, else null.
+export async function findPubmedByDoi(doi: string): Promise<number | null> {
+    if (!doi) return null
+    const term = encodeURIComponent(`${doi}[AID]`)
+    const url = `${EUTILS}?db=pubmed&retmode=json&term=${term}`
+    const res = await fetch(url, { headers: { 'User-Agent': 'reciter-pub-manager-server' } })
+    if (!res.ok) throw new Error(`eutils HTTP ${res.status}`)
+    const data: any = await res.json()
+    const idlist = (data && data.esearchresult && data.esearchresult.idlist) || []
+    return idlist.length ? Number(idlist[0]) : null
+}

--- a/controllers/scopusSearch.controller.ts
+++ b/controllers/scopusSearch.controller.ts
@@ -1,0 +1,92 @@
+// PM#772 — Scopus author-search proxy for the Scopus Authorships tab. Two modes:
+//   - authors:   resolve a person's Scopus Author ID from their name + WCM affiliation
+//   - documents: list a Scopus Author ID's documents (AU-ID query)
+// Server-side only; uses the Scopus API key + inst token from the environment (the
+// inst token is required — key alone 401s). Docs are normalized into the same shape
+// the external-article POST expects, so accept flows reuse the #771 add pipeline.
+// ponytail: proxies Scopus directly from PM for the local build; rewire to the Java
+// Scopus retrieval tool's author-search endpoint (ScopusTool#26) after the freeze.
+
+const SCOPUS_SEARCH = 'https://api.elsevier.com/content/search/scopus'
+const SCOPUS_AUTHOR = 'https://api.elsevier.com/content/search/author'
+
+function scopusHeaders() {
+    return {
+        'X-ELS-APIKey': process.env.SCOPUS_API_KEY || '',
+        'X-ELS-Insttoken': process.env.SCOPUS_INST_TOKEN || '',
+        'Accept': 'application/json',
+    }
+}
+
+export function scopusConfigured(): boolean {
+    return !!(process.env.SCOPUS_API_KEY && process.env.SCOPUS_INST_TOKEN)
+}
+
+// One Scopus Search entry -> external-article POST body (minus addedBy, set server-side).
+function normalizeScopusDoc(entry: any) {
+    if (!entry) return null
+    const scopusId = String(entry['dc:identifier'] || '').replace(/^SCOPUS_ID:/, '')
+    if (!scopusId) return null
+    const pmidRaw = entry['pubmed-id']
+    const creator = entry['dc:creator']
+    return {
+        articleId: 'SCOPUS:' + scopusId,
+        title: entry['dc:title'] || '',
+        doi: entry['prism:doi'] || undefined,
+        pmid: pmidRaw ? Number(pmidRaw) : undefined,
+        journalOrVenue: entry['prism:publicationName'] || undefined,
+        authors: creator ? [creator] : [],   // Scopus search view returns first author only
+        pubDate: entry['prism:coverDate'] || undefined,
+        publicationType: entry['subtypeDescription'] || undefined,
+        sourceType: 'SCOPUS',
+        method: 'scopus-authorships-tab',
+        rawRecord: JSON.stringify(entry),
+    }
+}
+
+// Resolve candidate Scopus Author IDs for a person by name + WCM affiliation.
+export async function searchScopusAuthors(lastName: string, firstName: string) {
+    if (!lastName) return []
+    const parts = [`authlast(${lastName})`]
+    if (firstName) parts.push(`authfirst(${firstName})`)
+    parts.push('affil(Weill Cornell)')
+    const q = encodeURIComponent(parts.join(' AND '))
+    const res = await fetch(`${SCOPUS_AUTHOR}?query=${q}&count=10`, { headers: scopusHeaders() })
+    if (!res.ok) throw new Error(`Scopus author search HTTP ${res.status}`)
+    const data: any = await res.json()
+    const entries = (data['search-results'] && data['search-results'].entry) || []
+    return entries
+        .map((e: any) => ({
+            authorId: String(e['dc:identifier'] || '').replace(/^AUTHOR_ID:/, ''),
+            surname: (e['preferred-name'] || {}).surname,
+            givenName: (e['preferred-name'] || {})['given-name'],
+            docCount: e['document-count'],
+            affiliation: (e['affiliation-current'] || {})['affiliation-name'],
+        }))
+        .filter((a: any) => a.authorId)
+}
+
+// Scopus returns up to this many docs per request; totalResults reports the real count.
+const SCOPUS_PAGE_CAP = 200
+
+// Search Scopus documents by author id, keyword, or doi. Returns the normalized page
+// plus the true total so the UI can tell the curator when there is more than we fetched.
+export async function searchScopusDocuments(by: string, term: string): Promise<{ results: any[], total: number }> {
+    const t = (term || '').trim()
+    if (!t) return { results: [], total: 0 }
+    let query: string
+    let sort = '&sort=-coverDate'
+    if (by === 'keyword') { query = `TITLE-ABS-KEY(${t})`; sort = '' }            // relevance order
+    else if (by === 'doi') { query = `DOI(${t})` }
+    else { query = `AU-ID(${t.replace(/^AUTHOR_ID:/i, '')})` }                    // default: author id
+    const res = await fetch(`${SCOPUS_SEARCH}?query=${encodeURIComponent(query)}&count=${SCOPUS_PAGE_CAP}${sort}`, { headers: scopusHeaders() })
+    if (!res.ok) throw new Error(`Scopus doc search HTTP ${res.status}`)
+    const data: any = await res.json()
+    const sr = data['search-results'] || {}
+    // Scopus returns a single entry carrying an 'error' field (no dc:identifier) on no match.
+    const entries = (sr.entry || []).filter((e: any) => e && e['dc:identifier'])
+    return {
+        results: entries.map(normalizeScopusDoc).filter(Boolean),
+        total: Number(sr['opensearch:totalResults'] || 0),
+    }
+}

--- a/src/components/elements/CurateIndividual/ExternalPublicationCard.module.css
+++ b/src/components/elements/CurateIndividual/ExternalPublicationCard.module.css
@@ -1,0 +1,299 @@
+.card {
+    position: relative;
+    display: flex;
+    gap: 12px;
+    border: 1px solid #e3e8ef;
+    border-radius: 8px;
+    background: #fff;
+    padding: 14px 16px;
+    margin-bottom: 10px;
+}
+
+.cardSuppressed {
+    opacity: 0.55;
+    background: #f7f8fa;
+}
+
+.main {
+    flex: 1;
+    min-width: 0;
+}
+
+.headerRow {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 4px;
+    flex-wrap: wrap;
+}
+
+.sourceBadge {
+    display: inline-flex;
+    align-items: center;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: #eef2ff;
+    color: #3538cd;
+    border: 1px solid #c7d2fe;
+    text-transform: none;
+    white-space: nowrap;
+}
+
+.noScoreBadge {
+    font-size: 11px;
+    color: #8a94a6;
+    font-style: italic;
+}
+
+.suppressedTag {
+    font-size: 11px;
+    font-weight: 600;
+    color: #b45309;
+    background: #fef3c7;
+    border: 1px solid #fde68a;
+    border-radius: 10px;
+    padding: 2px 8px;
+}
+
+.title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1f2733;
+    line-height: 1.35;
+    margin-bottom: 4px;
+}
+
+.authors {
+    font-size: 12.5px;
+    color: #55607a;
+    line-height: 1.4;
+    margin-bottom: 4px;
+}
+
+.meta {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    font-size: 12px;
+    color: #55607a;
+    margin-bottom: 4px;
+}
+
+.venue {
+    font-weight: 500;
+    color: #384152;
+}
+
+.typeBadge {
+    font-size: 11px;
+    color: #55607a;
+    background: #f1f3f7;
+    border-radius: 4px;
+    padding: 1px 6px;
+}
+
+.links {
+    display: flex;
+    gap: 14px;
+    font-size: 12px;
+    color: #55607a;
+}
+
+.links a {
+    color: #2563eb;
+    text-decoration: none;
+}
+
+.links a:hover {
+    text-decoration: underline;
+}
+
+.actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-end;
+    justify-content: flex-start;
+    min-width: 96px;
+}
+
+.btnAdd {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border: none;
+    background: #16a34a;
+    color: #fff;
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 6px 14px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.btnAdd:hover {
+    background: #15803d;
+}
+
+.btnAdd:disabled {
+    background: #9fd8b4;
+    cursor: default;
+}
+
+.btnDelete {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border: 1px solid #e3a1a1;
+    background: #fff;
+    color: #b31b1b;
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.btnDelete:hover {
+    background: #fdecec;
+}
+
+.btnAnyway {
+    border: 1px solid #d97706;
+    background: #fff;
+    color: #b45309;
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.btnAnyway:hover {
+    background: #fffbeb;
+}
+
+.addedTag {
+    font-size: 12px;
+    font-weight: 600;
+    color: #16a34a;
+}
+
+/* 409 handling */
+.blockedBox {
+    margin-top: 8px;
+    border: 1px solid #fecaca;
+    background: #fef2f2;
+    border-radius: 6px;
+    padding: 8px 10px;
+    font-size: 12px;
+    color: #991b1b;
+}
+
+.warningBox {
+    margin-top: 8px;
+    border: 1px solid #fde68a;
+    background: #fffbeb;
+    border-radius: 6px;
+    padding: 8px 10px;
+    font-size: 12px;
+    color: #92400e;
+}
+
+.warningTitle {
+    font-weight: 700;
+    margin-bottom: 4px;
+}
+
+.matchRow {
+    padding: 4px 0;
+    border-top: 1px dashed #fcd34d;
+}
+
+.matchRow:first-of-type {
+    border-top: none;
+}
+
+.warningActions {
+    margin-top: 8px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+/* In PubMed — steer to the scored PubMed path instead of adding as external */
+.pubmedBox {
+    margin-top: 8px;
+    border: 1px solid #bfdbfe;
+    background: #eff6ff;
+    border-radius: 6px;
+    padding: 8px 10px;
+    font-size: 12px;
+    color: #1e40af;
+}
+
+.pubmedTitle {
+    font-weight: 700;
+    margin-bottom: 2px;
+}
+
+.btnPubmed {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border: none;
+    background: #1f4e79;
+    color: #fff;
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.btnPubmed:hover {
+    background: #163a5a;
+}
+
+.checkingTag {
+    font-size: 12px;
+    color: #55607a;
+    font-style: italic;
+}
+
+/* Already in this person's record (accepted) — inform, no add */
+.acceptedBox {
+    margin-top: 8px;
+    border: 1px solid #bbf7d0;
+    background: #f0fdf4;
+    border-radius: 6px;
+    padding: 8px 10px;
+    font-size: 12px;
+    color: #166534;
+}
+
+.recordTag {
+    font-size: 12px;
+    font-weight: 600;
+    color: #55607a;
+    white-space: nowrap;
+}
+
+.btnReject {
+    border: 1px solid #cbd3e0;
+    background: #fff;
+    color: #55607a;
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.btnReject:hover {
+    background: #f1f3f7;
+}

--- a/src/components/elements/CurateIndividual/ExternalPublicationCard.tsx
+++ b/src/components/elements/CurateIndividual/ExternalPublicationCard.tsx
@@ -1,0 +1,225 @@
+import React, { FunctionComponent } from "react"
+import styles from './ExternalPublicationCard.module.css'
+import CheckIcon from '@mui/icons-material/Check'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+
+// PM#771 — a source-badged external publication row. Deliberately NO authorship
+// score tile (external pubs are not scored by ReCiter). Two modes:
+//   'preview' — a search result, with an Add affordance + 409 BLOCKED / WARNING UI.
+//               If the work is in PubMed (PMID from OpenAlex, or found via DOI lookup)
+//               we steer the curator to the scored PubMed path instead of adding an
+//               unscored external record.
+//   'list'    — an already-added external pub, with a Delete (= revoke) affordance
+const doiUrl = 'https://doi.org/'
+const pubMedUrl = 'https://www.ncbi.nlm.nih.gov/pubmed/'
+
+const SOURCE_LABELS: Record<string, string> = {
+    OPENALEX: 'OpenAlex',
+    SCOPUS: 'Scopus',
+    WOS: 'Web of Science',
+}
+
+export type AddState = {
+    status: 'idle' | 'adding' | 'checking' | 'blocked' | 'warning' | 'inPubmed' | 'added',
+    message?: string,
+    matches?: Array<{ type?: string, matchedId?: string, detail?: string }>,
+    pmid?: number,
+}
+
+interface FuncProps {
+    item: any,
+    mode: 'preview' | 'list',
+    addState?: AddState,
+    onAdd?: (item: any) => void,
+    onAddAnyway?: (item: any) => void,
+    onAddViaPubMed?: (pmid: number, item: any) => void,
+    // Current status of a PMID in this person's record, for annotating search results.
+    recordStatusOf?: (pmid: number) => 'ACCEPTED' | 'REJECTED' | 'PENDING' | null,
+    // Dismiss a suggestion (Scopus Authorships feed only); local, not GoldStandard.
+    onReject?: (item: any) => void,
+    onDelete?: (articleId: string) => void,
+}
+
+// Map the server's duplicate match type(s) to a state-specific, actionable headline.
+function blockedHeadline(matches?: Array<{ type?: string }>): string {
+    const types = (matches || []).map((m) => m.type)
+    if (types.includes('PMID_IN_GOLD_STANDARD')) return 'Already accepted for this person.'
+    if (types.includes('PMID_REJECTED_IN_GOLD_STANDARD')) return 'Previously rejected for this person.'
+    if (types.includes('PMID_IN_CANDIDATES')) return 'Already a pending suggestion — review it in the Suggested tab.'
+    if (types.some((t) => t === 'ALREADY_ADDED' || t === 'PMID_MATCH_EXTERNAL' || t === 'DOI_MATCH_EXTERNAL')) {
+        return 'Already added as an external publication.'
+    }
+    if (types.includes('DOI_MATCH')) return "A publication with this DOI is already in the person's record."
+    return "This publication is already in the person's record."
+}
+
+const ExternalPublicationCard: FunctionComponent<FuncProps> = (props) => {
+    const { item, mode, addState } = props
+
+    const sourceType: string = item.sourceType || 'OPENALEX'
+    const sourceLabel = SOURCE_LABELS[sourceType] || sourceType
+
+    // Authors can be a string[] (preview/normalized) or a comma-joined string (list row).
+    let authorsText = ''
+    if (Array.isArray(item.authors)) {
+        authorsText = item.authors.filter(Boolean).join(', ')
+    } else if (typeof item.authors === 'string') {
+        authorsText = item.authors
+    }
+
+    const venue = item.journalOrVenue || item.venue || item.journal
+    const date = item.pubDate || item.publicationDate || item.displayDate
+    const pubType = item.publicationType
+    const doi = item.doi
+    const pmid = item.pmid
+    const suppressed = mode === 'list' && !!item.suppressed
+    const status = addState?.status || 'idle'
+
+    // The work is in PubMed if OpenAlex gave us a PMID, or a DOI lookup found one.
+    // In that case steer to the scored PubMed path rather than an unscored external add.
+    const pubmedPmid: number | undefined = mode === 'preview'
+        ? (item.pmid || (status === 'inPubmed' ? addState?.pmid : undefined))
+        : undefined
+
+    // Is this PMID already in the person's record (accepted / rejected / pending)?
+    const recStatus = (pubmedPmid && props.recordStatusOf) ? props.recordStatusOf(pubmedPmid) : null
+
+    return (
+        <div className={`${styles.card} ${suppressed ? styles.cardSuppressed : ''}`}>
+            <div className={styles.main}>
+                <div className={styles.headerRow}>
+                    <span className={styles.sourceBadge}>{sourceLabel}</span>
+                    <span className={styles.noScoreBadge}>No authorship score</span>
+                    {suppressed && (
+                        <span className={styles.suppressedTag}>
+                            Superseded{item.supersededByPmid ? ` by PMID ${item.supersededByPmid}` : ''}
+                        </span>
+                    )}
+                </div>
+
+                <div className={styles.title}>{item.title || '(untitled)'}</div>
+
+                <div className={styles.authors}>
+                    {authorsText ? authorsText : 'No authors listed'}
+                </div>
+
+                <div className={styles.meta}>
+                    {venue && <span className={styles.venue}>{venue}</span>}
+                    {date && <span>{date}</span>}
+                    {pubType && <span className={styles.typeBadge}>{pubType}</span>}
+                </div>
+
+                <div className={styles.links}>
+                    {doi && <span><a href={`${doiUrl}${doi}`} target="_blank" rel="noreferrer">DOI &#8599;</a></span>}
+                    {pmid && <span>PMID: <a href={`${pubMedUrl}${pmid}`} target="_blank" rel="noreferrer">{pmid}</a></span>}
+                    {item.articleId && <span>ID: {item.articleId}</span>}
+                </div>
+
+                {/* Already in this person's record — inform, no add */}
+                {mode === 'preview' && pubmedPmid && recStatus && status !== 'added' && (
+                    recStatus === 'ACCEPTED' ? (
+                        <div className={styles.acceptedBox}>
+                            <strong>Already accepted for this person</strong> (PMID {pubmedPmid}). Nothing to add.
+                        </div>
+                    ) : recStatus === 'REJECTED' ? (
+                        <div className={styles.blockedBox}>
+                            <strong>Previously rejected for this person</strong> (PMID {pubmedPmid}).
+                        </div>
+                    ) : (
+                        <div className={styles.warningBox}>
+                            <strong>Already a pending suggestion</strong> (PMID {pubmedPmid}) — review it in the Suggested tab.
+                        </div>
+                    )
+                )}
+
+                {/* In PubMed but NOT yet in the record — steer to the scored PubMed path */}
+                {mode === 'preview' && pubmedPmid && !recStatus && status !== 'added' && (
+                    <div className={styles.pubmedBox}>
+                        <div className={styles.pubmedTitle}>This work is in PubMed (PMID {pubmedPmid}).</div>
+                        <div>Add it via PubMed so it counts as scored evidence for this person, instead of as an unscored external record.</div>
+                    </div>
+                )}
+
+                {/* 409 BLOCKED — no override affordance, state-specific explanation */}
+                {mode === 'preview' && status === 'blocked' && (
+                    <div className={styles.blockedBox}>
+                        <div style={{ fontWeight: 700, marginBottom: 4 }}>Cannot add — {blockedHeadline(addState?.matches)}</div>
+                        {addState?.message && <div>{addState.message}</div>}
+                        {addState?.matches?.map((m, i) => (
+                            <div key={i} className={styles.matchRow}>
+                                {m.type}{m.matchedId ? ` — ${m.matchedId}` : ''}{m.detail ? `: ${m.detail}` : ''}
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {/* 409 WARNING — suspected duplicate side-by-side, explicit Add anyway */}
+                {mode === 'preview' && status === 'warning' && (
+                    <div className={styles.warningBox}>
+                        <div className={styles.warningTitle}>Possible duplicate</div>
+                        <div>{addState?.message}</div>
+                        {addState?.matches?.map((m, i) => (
+                            <div key={i} className={styles.matchRow}>
+                                {m.type}{m.matchedId ? ` — ${m.matchedId}` : ''}{m.detail ? `: ${m.detail}` : ''}
+                            </div>
+                        ))}
+                        <div className={styles.warningActions}>
+                            <button
+                                className={styles.btnAnyway}
+                                onClick={() => props.onAddAnyway && props.onAddAnyway(item)}
+                            >
+                                Add anyway
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            <div className={styles.actions}>
+                {mode === 'preview' && status === 'added' && (
+                    <span className={styles.addedTag}>Added &#10003;</span>
+                )}
+                {mode === 'preview' && status !== 'added' && pubmedPmid && recStatus && (
+                    <span className={styles.recordTag}>
+                        {recStatus === 'ACCEPTED' ? 'Accepted' : recStatus === 'REJECTED' ? 'Rejected' : 'Pending'}
+                    </span>
+                )}
+                {mode === 'preview' && status !== 'added' && pubmedPmid && !recStatus && (
+                    <button
+                        className={styles.btnPubmed}
+                        onClick={() => props.onAddViaPubMed && props.onAddViaPubMed(pubmedPmid, item)}
+                    >
+                        Add via PubMed &#8594;
+                    </button>
+                )}
+                {mode === 'preview' && status !== 'added' && !pubmedPmid && (
+                    <button
+                        className={styles.btnAdd}
+                        disabled={status === 'adding' || status === 'checking' || status === 'blocked' || status === 'warning'}
+                        onClick={() => props.onAdd && props.onAdd(item)}
+                    >
+                        <CheckIcon style={{ fontSize: 14 }} /> {status === 'adding' ? 'Adding…' : status === 'checking' ? 'Checking…' : 'Add'}
+                    </button>
+                )}
+                {mode === 'preview' && props.onReject && status !== 'added' && (
+                    <button
+                        className={styles.btnReject}
+                        onClick={() => props.onReject && props.onReject(item)}
+                    >
+                        Reject
+                    </button>
+                )}
+                {mode === 'list' && (
+                    <button
+                        className={styles.btnDelete}
+                        onClick={() => props.onDelete && props.onDelete(item.articleId)}
+                    >
+                        <DeleteOutlineIcon style={{ fontSize: 15 }} /> Delete
+                    </button>
+                )}
+            </div>
+        </div>
+    )
+}
+
+export default ExternalPublicationCard

--- a/src/components/elements/CurateIndividual/ReciterTabs.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabs.tsx
@@ -6,6 +6,10 @@ import styles from "./CurateIndividual.module.css";
 import { useDispatch, useSelector } from "react-redux";
 import { RootStateOrAny } from "../../../types/redux";
 import TabAddPublication from "../TabAddPublication/TabAddPublication";
+import TabAddExternalPublication from "./TabAddExternalPublication";
+import TabScopusAuthorships from "./TabScopusAuthorships";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
 import { allowedPermissions } from "../../../utils/constants";
 import { useSession } from "next-auth/react";
 import { clearPubMedData, showEvidenceByDefault, reciterFetchData } from "../../../redux/actions/actions";
@@ -20,8 +24,11 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
   const { data: session, status } = useSession(); const loading = status === "loading";
   const isSearchText = useSelector((state: RootStateOrAny) => state.curateSearchtext)
   const showEvidenceDefault = useSelector((state: RootStateOrAny) => state.showEvidenceDefault)
-  const [pubSearchFilters, setPubSearchFilters] = useState();
+  const [pubSearchFilters, setPubSearchFilters] = useState<any>();
   const [refreshState, setRefreshState] = useState<'idle' | 'loading' | 'done'>('idle');
+  // Single "+ Add publication" dropdown (PubMed / OpenAlex / …) — keeps the tab-bar
+  // compact as more external sources (Scopus, WoS) are added.
+  const [addMenuAnchor, setAddMenuAnchor] = useState<null | HTMLElement>(null);
 
   // Smart change tracking: compare current assertions to originals
   const originalAssertions = useRef<Map<number, string>>(new Map());
@@ -37,6 +44,7 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
     { name: 'Rejected', value: 'REJECTED',allowedRoleNames: ["Superuser", "Curator_All","Curator_Self"] },
     { name: addnewtabName, value: 'addNewRecord',allowedRoleNames: ["Superuser","Curator_Self","Curator_All"] },
     { name: pubMedTabName, value: 'AddPub', allowedRoleNames: ["Superuser","Curator_Self","Curator_All"] },
+    { name: 'External', value: 'External', allowedRoleNames: ["Superuser","Curator_Self","Curator_All"] },
   ]
 
   useEffect(() => {
@@ -127,6 +135,26 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
     dispatch(showEvidenceByDefault(false));
   }
 
+  // Steer an in-PubMed external result to the scored PubMed path: pre-fill the PubMed
+  // tab's search with the PMID and switch to it, so the curator accepts it as evidence.
+  const handleAddViaPubMed = (pmid: number) => {
+    setPubSearchFilters({ pubMendSearchText: String(pmid) });
+    onTabChange('AddPub');
+  }
+
+  // Current status of a PMID in this person's record, to annotate external search
+  // results: ACCEPTED / REJECTED / PENDING (suggested), or null if not in the record.
+  const getPmidStatus = (pmid: number): 'ACCEPTED' | 'REJECTED' | 'PENDING' | null => {
+    if (!pmid) return null;
+    for (const tab of (filteredData as any[])) {
+      if (tab.value !== 'NULL' && tab.value !== 'ACCEPTED' && tab.value !== 'REJECTED') continue;
+      if ((tab.data || []).some((a: any) => Number(a.pmid) === Number(pmid))) {
+        return tab.value === 'NULL' ? 'PENDING' : tab.value;
+      }
+    }
+    return null;
+  }
+
   const handleRefresh = () => {
     if (refreshState !== 'idle') return;
     setRefreshState('loading');
@@ -199,19 +227,53 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
               )}
             </button>
           )}
-          {key === 'AddPub' ? (
-            <div className={styles.addRecordIndicator}>
+          {(key === 'AddPub' || key === 'External' || key === 'ScopusAuth') ? (
+            <div
+              className={styles.addRecordIndicator}
+              onClick={(e) => setAddMenuAnchor(e.currentTarget)}
+              style={{ cursor: 'pointer' }}
+              title="Switch add source"
+            >
               <span className={styles.addRecordPulse} />
-              Adding record from PubMed
+              {key === 'AddPub' ? 'Adding record from PubMed' : key === 'External' ? 'Adding record from OpenAlex' : 'Scopus'}
+              <span style={{ marginLeft: 4 }}>&#9662;</span>
             </div>
           ) : (
             <button
               className={styles.addRecordBtn}
-              onClick={() => onTabChange('AddPub')}
+              onClick={(e) => setAddMenuAnchor(e.currentTarget)}
             >
-              + Add record via PubMed
+              + Add publication &#9662;
             </button>
           )}
+          <Menu
+            anchorEl={addMenuAnchor}
+            open={Boolean(addMenuAnchor)}
+            onClose={() => setAddMenuAnchor(null)}
+            MenuListProps={{ dense: true }}
+          >
+            <MenuItem
+              selected={key === 'AddPub'}
+              onClick={() => { setAddMenuAnchor(null); onTabChange('AddPub'); }}
+              sx={{ fontSize: 13, fontWeight: 600, fontFamily: 'inherit' }}
+            >
+              PubMed
+            </MenuItem>
+            <MenuItem
+              selected={key === 'External'}
+              onClick={() => { setAddMenuAnchor(null); onTabChange('External'); }}
+              sx={{ fontSize: 13, fontWeight: 600, fontFamily: 'inherit' }}
+            >
+              OpenAlex
+            </MenuItem>
+            <MenuItem
+              selected={key === 'ScopusAuth'}
+              onClick={() => { setAddMenuAnchor(null); onTabChange('ScopusAuth'); }}
+              sx={{ fontSize: 13, fontWeight: 600, fontFamily: 'inherit' }}
+            >
+              Scopus
+            </MenuItem>
+          </Menu>
         </div>
       </div>
 
@@ -223,6 +285,19 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
           personIdentifier={reciterData.reciter?.personIdentifier}
           pubSearchFilters={pubSearchFilters}
           handleUpdateSearchFilters={handleUpdateSearchFilters}
+        />
+      ) : key === 'External' ? (
+        <TabAddExternalPublication
+          personIdentifier={reciterData.reciter?.personIdentifier}
+          onAddViaPubMed={handleAddViaPubMed}
+          getPmidStatus={getPmidStatus}
+        />
+      ) : key === 'ScopusAuth' ? (
+        <TabScopusAuthorships
+          personIdentifier={reciterData.reciter?.personIdentifier}
+          fullName={fullName}
+          onAddViaPubMed={handleAddViaPubMed}
+          getPmidStatus={getPmidStatus}
         />
       ) : activeTabData ? (
         <ReciterTabContent

--- a/src/components/elements/CurateIndividual/TabAddExternalPublication.tsx
+++ b/src/components/elements/CurateIndividual/TabAddExternalPublication.tsx
@@ -1,0 +1,275 @@
+import React, { FunctionComponent, useCallback, useEffect, useState } from "react"
+import { toast } from "react-toastify"
+import { reciterConfig } from "../../../../config/local"
+import ExternalPublicationCard, { AddState } from "./ExternalPublicationCard"
+import ToastContainerWrapper from "../ToastContainerWrapper/ToastContainerWrapper"
+
+// PM#771 — add publications from an external source (OpenAlex in v1) to a person's
+// record. Self-contained (AAR-tab precedent): local state + fetch, no redux. OpenAlex
+// search is proxied server-side; adds go through the ReCiter external-article API
+// (admin-key proxied) which enforces the BLOCKED (no override) / WARNING (Add anyway)
+// duplicate rules. Added pubs are listed here, visually separate from scored PubMed
+// suggestions, with a Delete (= revoke) affordance.
+
+interface FuncProps {
+    personIdentifier: string,
+    // Steer an in-PubMed work to the scored PubMed add path (switches to the PubMed tab).
+    onAddViaPubMed: (pmid: number, item: any) => void,
+    // Current status of a PMID in this person's record, to annotate search results.
+    getPmidStatus: (pmid: number) => 'ACCEPTED' | 'REJECTED' | 'PENDING' | null,
+}
+
+const apiHeaders = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    Authorization: reciterConfig.backendApiKey,
+}
+
+const wrap: React.CSSProperties = { padding: "8px 0 24px" }
+const searchPanel: React.CSSProperties = {
+    display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap",
+    background: "#f7f8fa", border: "1px solid #e3e8ef", borderRadius: 8, padding: "12px 14px", marginBottom: 16,
+}
+const inputStyle: React.CSSProperties = {
+    flex: 1, minWidth: 220, height: 36, borderRadius: 6, border: "1px solid #cbd3e0", padding: "0 12px", fontSize: 13,
+}
+const searchBtn: React.CSSProperties = {
+    height: 36, border: "none", background: "#1f4e79", color: "#fff", fontSize: 13, fontWeight: 600,
+    padding: "0 18px", borderRadius: 6, cursor: "pointer",
+}
+const sectionLabel: React.CSSProperties = {
+    fontSize: 12, fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase",
+    color: "#8a94a6", margin: "18px 0 8px",
+}
+const helpText: React.CSSProperties = { fontSize: 12.5, color: "#8a94a6", marginBottom: 8 }
+const emptyText: React.CSSProperties = { fontSize: 13, color: "#8a94a6", padding: "8px 0" }
+
+const TabAddExternalPublication: FunctionComponent<FuncProps> = (props) => {
+    const uid = props.personIdentifier
+
+    const source = "OPENALEX" // v1: OpenAlex only. Scopus/WoS join the tab-bar Add menu later.
+    const [query, setQuery] = useState<string>("")
+    const [searching, setSearching] = useState<boolean>(false)
+    const [results, setResults] = useState<any[]>([])
+    const [addStates, setAddStates] = useState<Record<string, AddState>>({})
+
+    const [externalList, setExternalList] = useState<any[]>([])
+    const [loadingList, setLoadingList] = useState<boolean>(false)
+
+    const setAddState = (articleId: string, next: AddState) => {
+        setAddStates(prev => ({ ...prev, [articleId]: next }))
+    }
+
+    const fetchExternalList = useCallback(() => {
+        if (!uid) return
+        setLoadingList(true)
+        fetch(`/api/reciter/external-article/${encodeURIComponent(uid)}`, {
+            credentials: "same-origin", method: "GET", headers: apiHeaders,
+        })
+            .then(async (r) => {
+                const body = await r.json().catch(() => ({}))
+                if (!r.ok) throw new Error((body && body.message) || `HTTP ${r.status}`)
+                return body
+            })
+            .then((body) => {
+                const rows = Array.isArray(body.external) ? body.external : []
+                setExternalList(rows)
+            })
+            .catch(() => {
+                setExternalList([])
+            })
+            .finally(() => setLoadingList(false))
+    }, [uid])
+
+    useEffect(() => {
+        fetchExternalList()
+    }, [fetchExternalList])
+
+    const runSearch = (e?: React.FormEvent) => {
+        if (e) e.preventDefault()
+        const q = query.trim()
+        if (!q) {
+            toast.error("Enter a title or DOI to search.", { position: "top-right", autoClose: 2000, theme: "colored" })
+            return
+        }
+        setSearching(true)
+        setResults([])
+        setAddStates({})
+        fetch(`/api/reciter/search/openalex`, {
+            credentials: "same-origin", method: "POST", headers: apiHeaders,
+            body: JSON.stringify({ query: q, source }),
+        })
+            .then(async (r) => {
+                const body = await r.json().catch(() => ({}))
+                if (!r.ok) throw new Error((body && body.message && body.message.message) || (body && body.message) || `HTTP ${r.status}`)
+                return body
+            })
+            .then((body) => {
+                const rows = Array.isArray(body.results) ? body.results : []
+                setResults(rows)
+                if (rows.length === 0) {
+                    toast.info("No results found in OpenAlex.", { position: "top-right", autoClose: 2000 })
+                }
+            })
+            .catch((err) => {
+                toast.error("OpenAlex search failed: " + (err.message || err), { position: "top-right", autoClose: 3000, theme: "colored" })
+            })
+            .finally(() => setSearching(false))
+    }
+
+    // Ask PubMed whether a DOI is indexed there (returns the PMID, or null).
+    const checkPubmedByDoi = async (doiVal: string): Promise<number | null> => {
+        const r = await fetch(`/api/reciter/search/pubmed-by-doi`, {
+            credentials: "same-origin", method: "POST", headers: apiHeaders,
+            body: JSON.stringify({ doi: doiVal }),
+        })
+        const body = await r.json().catch(() => ({}))
+        if (!r.ok) throw new Error((body && body.message) || `HTTP ${r.status}`)
+        return (body && body.pmid) != null ? Number(body.pmid) : null
+    }
+
+    const doAdd = async (item: any, force: boolean) => {
+        if (!uid) { toast.error("Person is still loading — try again in a moment.", { position: "top-right", autoClose: 2500, theme: "colored" }); return }
+        const articleId = item.articleId
+        // If the work is in PubMed, steer to the scored PubMed path instead of adding an
+        // unscored external record. OpenAlex's PMID is best-effort, so for no-PMID results
+        // we confirm by DOI. Fail-open: a lookup error still allows the external add.
+        if (!force && !item.pmid && item.doi) {
+            setAddState(articleId, { status: "checking" })
+            try {
+                const found = await checkPubmedByDoi(item.doi)
+                if (found) {
+                    setAddState(articleId, { status: "inPubmed", pmid: found })
+                    return
+                }
+            } catch (e) { /* fail-open: fall through to the external add */ }
+        }
+        setAddState(articleId, { status: "adding" })
+        let url = `/api/reciter/external-article/${encodeURIComponent(uid)}`
+        if (force) url += `?force=true`
+        fetch(url, {
+            credentials: "same-origin", method: "POST", headers: apiHeaders,
+            body: JSON.stringify(item),
+        })
+            .then(async (r) => {
+                const body = await r.json().catch(() => ({}))
+                return { status: r.status, body }
+            })
+            .then(({ status, body }) => {
+                if (status === 201 || status === 200) {
+                    setAddState(articleId, { status: "added" })
+                    toast.success("Publication added.", { position: "top-right", autoClose: 2000, theme: "colored" })
+                    fetchExternalList()
+                    return
+                }
+                if (status === 409) {
+                    // body.message = { status: BLOCKED|WARNING, message, matches }
+                    const payload = (body && body.message) || {}
+                    const kind = payload.status
+                    if (kind === "WARNING") {
+                        setAddState(articleId, { status: "warning", message: payload.message, matches: payload.matches })
+                    } else {
+                        setAddState(articleId, { status: "blocked", message: payload.message, matches: payload.matches })
+                    }
+                    return
+                }
+                // 400 INVALID / 404 / other
+                const payload = (body && body.message) || {}
+                const msg = payload.message || (typeof payload === "string" ? payload : `HTTP ${status}`)
+                setAddState(articleId, { status: "idle" })
+                toast.error("Could not add: " + msg, { position: "top-right", autoClose: 3000, theme: "colored" })
+            })
+            .catch((err) => {
+                setAddState(articleId, { status: "idle" })
+                toast.error("Could not add: " + (err.message || err), { position: "top-right", autoClose: 3000, theme: "colored" })
+            })
+    }
+
+    const doDelete = (articleId: string) => {
+        fetch(`/api/reciter/external-article/${encodeURIComponent(uid)}?articleId=${encodeURIComponent(articleId)}`, {
+            credentials: "same-origin", method: "DELETE", headers: apiHeaders,
+        })
+            .then(async (r) => {
+                const body = await r.json().catch(() => ({}))
+                if (!r.ok) throw new Error((body && body.message) || `HTTP ${r.status}`)
+                return body
+            })
+            .then(() => {
+                toast.success("Publication removed.", { position: "top-right", autoClose: 2000, theme: "colored" })
+                fetchExternalList()
+            })
+            .catch((err) => {
+                toast.error("Could not remove: " + (err.message || err), { position: "top-right", autoClose: 3000, theme: "colored" })
+            })
+    }
+
+    // Suppressed rows (superseded by a PubMed record) are hidden by default.
+    const visibleExternal = externalList.filter((row) => !row.suppressed)
+
+    return (
+        <div style={wrap}>
+            <p style={helpText}>
+                Add a publication from an external source when it is not indexed in PubMed. External
+                publications are not scored by ReCiter and are listed separately below.
+            </p>
+
+            {/* Search OpenAlex (source is chosen from the tab-bar "+ Add publication" menu) */}
+            <form style={searchPanel} onSubmit={runSearch}>
+                <input
+                    type="text"
+                    style={inputStyle}
+                    placeholder="Search by title or DOI…"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                />
+                <button type="submit" style={searchBtn} disabled={searching}>
+                    {searching ? "Searching…" : "Search OpenAlex"}
+                </button>
+            </form>
+
+            {/* Search results */}
+            {(searching || results.length > 0) && (
+                <>
+                    <div style={sectionLabel}>Search results</div>
+                    {searching ? (
+                        <div style={emptyText}>Searching OpenAlex…</div>
+                    ) : (
+                        results.map((item) => (
+                            <ExternalPublicationCard
+                                key={item.articleId}
+                                item={item}
+                                mode="preview"
+                                addState={addStates[item.articleId]}
+                                onAdd={(it) => doAdd(it, false)}
+                                onAddAnyway={(it) => doAdd(it, true)}
+                                onAddViaPubMed={(pmid, it) => props.onAddViaPubMed(pmid, it)}
+                                recordStatusOf={props.getPmidStatus}
+                            />
+                        ))
+                    )}
+                </>
+            )}
+
+            {/* Already-added external publications */}
+            <div style={sectionLabel}>External publications on this record</div>
+            {loadingList ? (
+                <div style={emptyText}>Loading…</div>
+            ) : visibleExternal.length === 0 ? (
+                <div style={emptyText}>No external publications have been added.</div>
+            ) : (
+                visibleExternal.map((row) => (
+                    <ExternalPublicationCard
+                        key={row.articleId}
+                        item={row}
+                        mode="list"
+                        onDelete={doDelete}
+                    />
+                ))
+            )}
+
+            <ToastContainerWrapper />
+        </div>
+    )
+}
+
+export default TabAddExternalPublication

--- a/src/components/elements/CurateIndividual/TabScopusAuthorships.tsx
+++ b/src/components/elements/CurateIndividual/TabScopusAuthorships.tsx
@@ -1,0 +1,311 @@
+import React, { FunctionComponent, useEffect, useState } from "react"
+import { toast } from "react-toastify"
+import { reciterConfig } from "../../../../config/local"
+import ExternalPublicationCard, { AddState } from "./ExternalPublicationCard"
+import ToastContainerWrapper from "../ToastContainerWrapper/ToastContainerWrapper"
+
+// PM#772 — Scopus Authorships tab. A high-level Scopus search (by Author ID, keyword,
+// or DOI) surfacing documents not already in the person's record. On open it resolves
+// the person's Scopus Author ID from their name and runs the author-id search, but the
+// curator can switch to a keyword or DOI search. Accept routing is handled by
+// ExternalPublicationCard: a doc with a PMID (or one a DOI lookup finds in PubMed) is
+// steered to the scored PubMed path; a Scopus-native doc is added as an ExternalArticle
+// (method=scopus-authorships-tab). Reject = local dismissal, never GoldStandard.
+
+interface FuncProps {
+    personIdentifier: string,
+    fullName: string,
+    onAddViaPubMed: (pmid: number, item: any) => void,
+    getPmidStatus: (pmid: number) => 'ACCEPTED' | 'REJECTED' | 'PENDING' | null,
+}
+
+const apiHeaders = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    Authorization: reciterConfig.backendApiKey,
+}
+
+const wrap: React.CSSProperties = { padding: "8px 0 24px" }
+const panel: React.CSSProperties = {
+    display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap",
+    background: "#f7f8fa", border: "1px solid #e3e8ef", borderRadius: 8, padding: "12px 14px", marginBottom: 16,
+}
+const selectStyle: React.CSSProperties = {
+    height: 36, borderRadius: 6, border: "1px solid #cbd3e0", padding: "0 10px", fontSize: 13, background: "#fff", color: "#1f2733", maxWidth: "100%",
+}
+const inputStyle: React.CSSProperties = {
+    flex: 1, minWidth: 200, height: 36, borderRadius: 6, border: "1px solid #cbd3e0", padding: "0 12px", fontSize: 13,
+}
+const searchBtn: React.CSSProperties = {
+    height: 36, border: "none", background: "#1f4e79", color: "#fff", fontSize: 13, fontWeight: 600,
+    padding: "0 18px", borderRadius: 6, cursor: "pointer",
+}
+const sectionLabel: React.CSSProperties = {
+    fontSize: 12, fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase",
+    color: "#8a94a6", margin: "18px 0 8px",
+}
+const helpText: React.CSSProperties = { fontSize: 12.5, color: "#8a94a6", marginBottom: 8 }
+const emptyText: React.CSSProperties = { fontSize: 13, color: "#8a94a6", padding: "8px 0" }
+const labelStyle: React.CSSProperties = { fontSize: 12, fontWeight: 600, color: "#55607a" }
+const noteStyle: React.CSSProperties = {
+    fontSize: 12.5, color: "#92400e", background: "#fffbeb", border: "1px solid #fde68a",
+    borderRadius: 6, padding: "8px 10px", marginBottom: 10,
+}
+
+const PLACEHOLDER: Record<string, string> = {
+    author: "Scopus Author ID (e.g. 12797673000)",
+    keyword: "Title, abstract or keyword terms",
+    doi: "10.xxxx/…",
+}
+
+function splitName(fullName: string) {
+    const parts = (fullName || "").trim().split(/\s+/).filter(Boolean)
+    if (parts.length === 0) return { firstName: "", lastName: "" }
+    return { firstName: parts[0], lastName: parts[parts.length - 1] }
+}
+
+const dismissKey = (uid: string) => `pm772_dismissed_${uid}`
+function loadDismissed(uid: string): Set<string> {
+    try { return new Set(JSON.parse(window.localStorage.getItem(dismissKey(uid)) || "[]")) } catch (e) { return new Set() }
+}
+function saveDismissed(uid: string, set: Set<string>) {
+    try { window.localStorage.setItem(dismissKey(uid), JSON.stringify(Array.from(set))) } catch (e) { /* ignore */ }
+}
+
+const TabScopusAuthorships: FunctionComponent<FuncProps> = (props) => {
+    const uid = props.personIdentifier
+
+    const [resolving, setResolving] = useState<boolean>(true)
+    const [candidates, setCandidates] = useState<any[]>([])
+    const [searchBy, setSearchBy] = useState<string>("author")
+    const [term, setTerm] = useState<string>("")
+
+    const [loadingDocs, setLoadingDocs] = useState<boolean>(false)
+    const [docs, setDocs] = useState<any[]>([])
+    const [total, setTotal] = useState<number>(0)
+    const [searched, setSearched] = useState<boolean>(false)
+    const [addStates, setAddStates] = useState<Record<string, AddState>>({})
+    const [dismissed, setDismissed] = useState<Set<string>>(new Set())
+
+    const setAddState = (articleId: string, next: AddState) => {
+        setAddStates(prev => ({ ...prev, [articleId]: next }))
+    }
+
+    const runSearch = (byArg?: string, termArg?: string) => {
+        const by = byArg || searchBy
+        const t = (termArg !== undefined ? termArg : term).trim()
+        if (!t) {
+            toast.error("Enter a search term.", { position: "top-right", autoClose: 2000, theme: "colored" })
+            return
+        }
+        setLoadingDocs(true); setSearched(true); setDocs([]); setTotal(0); setAddStates({})
+        fetch(`/api/reciter/search/scopus`, {
+            credentials: "same-origin", method: "POST", headers: apiHeaders,
+            body: JSON.stringify({ mode: "documents", by, term: t }),
+        })
+            .then(async (r) => {
+                const body = await r.json().catch(() => ({}))
+                if (!r.ok) throw new Error(r.status === 503
+                    ? "Scopus is not configured on this server."
+                    : (body && body.message) || `Scopus search failed (HTTP ${r.status})`)
+                return body
+            })
+            .then((body) => {
+                setDocs(Array.isArray(body.results) ? body.results : [])
+                setTotal(Number(body.total || 0))
+            })
+            .catch((e) => toast.error((e && e.message) || "Scopus search failed.", { position: "top-right", autoClose: 3000, theme: "colored" }))
+            .finally(() => setLoadingDocs(false))
+    }
+
+    // On open: resolve the person's Scopus Author ID from their name, then auto-run
+    // the author-id search. Curator can switch to keyword / DOI afterwards.
+    useEffect(() => {
+        setDismissed(loadDismissed(uid))
+        const { firstName, lastName } = splitName(props.fullName)
+        if (!lastName) { setResolving(false); return }
+        setResolving(true)
+        fetch(`/api/reciter/search/scopus`, {
+            credentials: "same-origin", method: "POST", headers: apiHeaders,
+            body: JSON.stringify({ mode: "authors", lastName, firstName }),
+        })
+            .then(async (r) => {
+                const body = await r.json().catch(() => ({}))
+                if (!r.ok) throw new Error((body && body.message) || `HTTP ${r.status}`)
+                return body
+            })
+            .then((body) => {
+                const list = Array.isArray(body.authors) ? body.authors : []
+                setCandidates(list)
+                if (list.length) {
+                    setSearchBy("author")
+                    setTerm(list[0].authorId)
+                    runSearch("author", list[0].authorId)
+                }
+            })
+            .catch(() => { /* leave empty; manual search available */ })
+            .finally(() => setResolving(false))
+    }, [uid, props.fullName])
+
+    const checkPubmedByDoi = async (doiVal: string): Promise<number | null> => {
+        const r = await fetch(`/api/reciter/search/pubmed-by-doi`, {
+            credentials: "same-origin", method: "POST", headers: apiHeaders,
+            body: JSON.stringify({ doi: doiVal }),
+        })
+        const body = await r.json().catch(() => ({}))
+        if (!r.ok) throw new Error((body && body.message) || `HTTP ${r.status}`)
+        return (body && body.pmid) != null ? Number(body.pmid) : null
+    }
+
+    // Accept a Scopus-native suggestion -> external-article POST. In-PubMed docs never
+    // reach here: the card renders "Add via PubMed →" (onAddViaPubMed) for them.
+    // ponytail: mirrors TabAddExternalPublication.doAdd; extract a shared hook if a
+    // third source appears.
+    const doAdd = async (item: any, force: boolean) => {
+        if (!uid) { toast.error("Person is still loading — try again in a moment.", { position: "top-right", autoClose: 2500, theme: "colored" }); return }
+        const articleId = item.articleId
+        if (!force && !item.pmid && item.doi) {
+            setAddState(articleId, { status: "checking" })
+            try {
+                const found = await checkPubmedByDoi(item.doi)
+                if (found) { setAddState(articleId, { status: "inPubmed", pmid: found }); return }
+            } catch (e) { /* fail-open */ }
+        }
+        setAddState(articleId, { status: "adding" })
+        let url = `/api/reciter/external-article/${encodeURIComponent(uid)}`
+        if (force) url += `?force=true`
+        fetch(url, {
+            credentials: "same-origin", method: "POST", headers: apiHeaders,
+            body: JSON.stringify(item),
+        })
+            .then(async (r) => ({ status: r.status, body: await r.json().catch(() => ({})) }))
+            .then(({ status, body }) => {
+                if (status === 201 || status === 200) {
+                    setAddState(articleId, { status: "added" })
+                    toast.success("Accepted as an external publication.", { position: "top-right", autoClose: 2000, theme: "colored" })
+                    return
+                }
+                if (status === 409) {
+                    const payload = (body && body.message) || {}
+                    setAddState(articleId, { status: payload.status === "WARNING" ? "warning" : "blocked", message: payload.message, matches: payload.matches })
+                    return
+                }
+                const payload = (body && body.message) || {}
+                const msg = payload.message || (typeof payload === "string" ? payload : `HTTP ${status}`)
+                setAddState(articleId, { status: "idle" })
+                toast.error("Could not accept: " + msg, { position: "top-right", autoClose: 3000, theme: "colored" })
+            })
+            .catch((err) => {
+                setAddState(articleId, { status: "idle" })
+                toast.error("Could not accept: " + (err.message || err), { position: "top-right", autoClose: 3000, theme: "colored" })
+            })
+    }
+
+    const doReject = (item: any) => {
+        if (!uid) return
+        const next = new Set(dismissed)
+        next.add(item.articleId)
+        setDismissed(next)
+        saveDismissed(uid, next)
+    }
+
+    // Feed = fetched docs not dismissed and not already in the person's record (by PMID).
+    const feed = docs.filter((d) => !dismissed.has(d.articleId) && !(d.pmid && props.getPmidStatus(d.pmid)))
+    const hiddenCount = docs.length - feed.length
+    const moreThanFetched = total > docs.length
+
+    return (
+        <div style={wrap}>
+            <p style={helpText}>
+                Search Scopus for documents attributed to this person. Accept a PubMed-indexed item to add it as
+                scored evidence; accept a Scopus-only item to add it as an external publication. Reject to dismiss
+                it (kept out of the feed, not written to the gold standard).
+            </p>
+
+            {/* High-level Scopus search: by Author ID, Keyword, or DOI */}
+            <form style={panel} onSubmit={(e) => { e.preventDefault(); runSearch() }}>
+                <span style={labelStyle}>Search Scopus by</span>
+                <select
+                    style={selectStyle}
+                    value={searchBy}
+                    onChange={(e) => {
+                        const by = e.target.value
+                        setSearchBy(by)
+                        setTerm(by === "author" && candidates[0] ? candidates[0].authorId : "")
+                    }}
+                >
+                    <option value="author">Author ID</option>
+                    <option value="keyword">Keyword</option>
+                    <option value="doi">DOI</option>
+                </select>
+                {searchBy === "author" && candidates.length > 1 && (
+                    <select style={selectStyle} value={term} onChange={(e) => setTerm(e.target.value)}>
+                        {candidates.map((c) => (
+                            <option key={c.authorId} value={c.authorId}>
+                                {c.surname}, {c.givenName} — AU-ID {c.authorId}{c.docCount ? ` · ${c.docCount} docs` : ""}
+                            </option>
+                        ))}
+                    </select>
+                )}
+                <input
+                    type="text"
+                    style={inputStyle}
+                    placeholder={PLACEHOLDER[searchBy]}
+                    value={term}
+                    onChange={(e) => setTerm(e.target.value)}
+                />
+                <button type="submit" style={searchBtn} disabled={loadingDocs}>
+                    {loadingDocs ? "Searching…" : "Search Scopus"}
+                </button>
+            </form>
+            {resolving && <div style={emptyText}>Resolving Scopus author…</div>}
+
+            {/* Results */}
+            <div style={sectionLabel}>
+                Scopus results{!loadingDocs && searched ? ` (${feed.length})` : ""}
+            </div>
+            {loadingDocs ? (
+                <div style={emptyText}>Searching Scopus…</div>
+            ) : !searched ? (
+                <div style={emptyText}>Run a search to see Scopus documents.</div>
+            ) : docs.length === 0 ? (
+                <div style={emptyText}>No Scopus documents matched.</div>
+            ) : (
+                <>
+                    {moreThanFetched && (
+                        <div style={noteStyle}>
+                            Showing the first {docs.length} of {total.toLocaleString()} Scopus results — refine your search
+                            {searchBy === "keyword" ? " (add more specific terms)" : " (try a keyword or DOI)"} to narrow it down.
+                        </div>
+                    )}
+                    {feed.length === 0 ? (
+                        <div style={emptyText}>
+                            All {docs.length} fetched result(s) are already in the record or dismissed.
+                        </div>
+                    ) : (
+                        feed.map((item) => (
+                            <ExternalPublicationCard
+                                key={item.articleId}
+                                item={item}
+                                mode="preview"
+                                addState={addStates[item.articleId]}
+                                onAdd={(it) => doAdd(it, false)}
+                                onAddAnyway={(it) => doAdd(it, true)}
+                                onAddViaPubMed={(pmid, it) => props.onAddViaPubMed(pmid, it)}
+                                recordStatusOf={props.getPmidStatus}
+                                onReject={(it) => doReject(it)}
+                            />
+                        ))
+                    )}
+                    {feed.length > 0 && hiddenCount > 0 && (
+                        <div style={emptyText}>{hiddenCount} result(s) hidden (already in the record or dismissed).</div>
+                    )}
+                </>
+            )}
+
+            <ToastContainerWrapper />
+        </div>
+    )
+}
+
+export default TabScopusAuthorships

--- a/src/pages/api/reciter/external-article/[uid].ts
+++ b/src/pages/api/reciter/external-article/[uid].ts
@@ -1,0 +1,94 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getToken } from 'next-auth/jwt'
+import {
+    getExternalArticles,
+    addExternalArticle,
+    deleteExternalArticle,
+} from '../../../../../controllers/externalArticle.controller'
+import { reciterConfig } from '../../../../../config/local'
+
+// PM#771 — external-source (OpenAlex) manual-add publications for a person.
+//   GET    ?uid=<uid>                       -> all external rows (incl suppressed)
+//   POST   ?uid=<uid>[&force=true]  body    -> add one (201, or 409 BLOCKED/WARNING)
+//   DELETE ?uid=<uid>&articleId=<id>        -> revoke one
+// Gated on the app backendApiKey, matching every other /api/reciter route on this
+// branch. addedBy (curator CWID) is resolved best-effort from the JWT server-side and
+// never trusted from the client. (Per-person curation-scope authz is an AAR-line
+// feature not present on this branch — see the PR notes.)
+
+type Error = {
+    statusCode: number,
+    message: any,
+}
+
+type Data = {
+    statusCode: number,
+    external?: any,
+}
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<Error | Data>
+) {
+    const method = req.method || ''
+    if (method !== 'GET' && method !== 'POST' && method !== 'DELETE') {
+        return res.status(400).send({ statusCode: 400, message: 'HTTP Methods supported are GET, POST, DELETE' })
+    }
+
+    if (req.headers.authorization === undefined) {
+        return res.status(400).send({ statusCode: 400, message: 'Authorization header is needed' })
+    }
+    if (req.headers.authorization !== reciterConfig.backendApiKey) {
+        return res.status(401).send({ statusCode: 401, message: 'Authorization header is incorrect' })
+    }
+
+    const uidParam = req.query.uid
+    const uid = Array.isArray(uidParam) ? uidParam[0] : uidParam
+    if (!uid) {
+        return res.status(400).send({ statusCode: 400, message: 'uid is required' })
+    }
+
+    try {
+        if (method === 'GET') {
+            const apiResponse = await getExternalArticles(uid)
+            if (apiResponse.statusCode === 200) {
+                return res.status(200).send({ statusCode: 200, external: apiResponse.statusText })
+            }
+            return res.status(apiResponse.statusCode || 502).send({ statusCode: apiResponse.statusCode || 502, message: apiResponse.statusText })
+        }
+
+        if (method === 'DELETE') {
+            const articleIdParam = req.query.articleId
+            const articleId = Array.isArray(articleIdParam) ? articleIdParam[0] : articleIdParam
+            if (!articleId) {
+                return res.status(400).send({ statusCode: 400, message: 'articleId is required for delete' })
+            }
+            const apiResponse = await deleteExternalArticle(uid, articleId)
+            if (apiResponse.statusCode === 200) {
+                return res.status(200).send({ statusCode: 200, external: apiResponse.statusText })
+            }
+            return res.status(apiResponse.statusCode || 502).send({ statusCode: apiResponse.statusCode || 502, message: apiResponse.statusText })
+        }
+
+        // POST — resolve the curating user's CWID from the JWT for addedBy.
+        let addedBy: string | undefined = undefined
+        try {
+            const token: any = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+            if (token && token.username) addedBy = String(token.username)
+        } catch (e) {
+            // Leave addedBy undefined -> ReCiter records it as unknown.
+        }
+
+        const force = String(req.query.force) === 'true'
+        const apiResponse = await addExternalArticle(uid, req.body, addedBy, force)
+        if (apiResponse.statusCode === 201 || apiResponse.statusCode === 200) {
+            return res.status(apiResponse.statusCode).send({ statusCode: apiResponse.statusCode, external: apiResponse.statusText })
+        }
+        // 400 INVALID / 404 uid / 409 BLOCKED|WARNING — pass the payload straight through
+        // so the UI can distinguish BLOCKED (no override) from WARNING (retry with force).
+        return res.status(apiResponse.statusCode || 502).send({ statusCode: apiResponse.statusCode || 502, message: apiResponse.statusText })
+    } catch (err) {
+        console.error('[external-article] Unhandled error:', err)
+        return res.status(500).send({ statusCode: 500, message: 'Internal server error' })
+    }
+}

--- a/src/pages/api/reciter/search/openalex.ts
+++ b/src/pages/api/reciter/search/openalex.ts
@@ -1,0 +1,50 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { searchOpenAlex } from '../../../../../controllers/openalex.controller'
+import { reciterConfig } from '../../../../../config/local'
+
+type Error = {
+    statusCode: number,
+    message: any,
+}
+
+type Data = {
+    statusCode: number,
+    results: any,
+}
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<Error | Data>
+) {
+    if (req.method === "POST") {
+        if (req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            const apiResponse = await searchOpenAlex(req)
+            if (apiResponse.statusCode === 200) {
+                res.status(200).send({
+                    statusCode: 200,
+                    results: apiResponse.statusText,
+                })
+            } else {
+                res.status(apiResponse.statusCode || 502).send({
+                    statusCode: apiResponse.statusCode || 502,
+                    message: apiResponse.statusText,
+                })
+            }
+        } else if (req.headers.authorization === undefined) {
+            res.status(400).send({
+                statusCode: 400,
+                message: "Authorization header is needed"
+            })
+        } else {
+            res.status(401).send({
+                statusCode: 401,
+                message: "Authorization header is incorrect"
+            })
+        }
+    } else {
+        res.status(400).send({
+            statusCode: 400,
+            message: "HTTP Method supported is POST"
+        })
+    }
+}

--- a/src/pages/api/reciter/search/pubmed-by-doi.ts
+++ b/src/pages/api/reciter/search/pubmed-by-doi.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { findPubmedByDoi } from '../../../../../controllers/pubmedLookup.controller'
+import { reciterConfig } from '../../../../../config/local'
+
+type Resp = {
+    statusCode: number,
+    pmid?: number | null,
+    message?: any,
+}
+
+// PM#771 — POST { doi } -> { pmid } (null if the DOI is not in PubMed). Used to steer
+// external adds to the scored PubMed path when the work is actually PubMed-indexed.
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<Resp>
+) {
+    if (req.method === "POST") {
+        if (req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            const doi = req.body && req.body.doi
+            if (!doi) {
+                res.status(400).send({ statusCode: 400, message: "doi is required" })
+                return
+            }
+            try {
+                const pmid = await findPubmedByDoi(String(doi))
+                res.status(200).send({ statusCode: 200, pmid })
+            } catch (err: any) {
+                res.status(502).send({ statusCode: 502, message: "PubMed lookup failed" })
+            }
+        } else if (req.headers.authorization === undefined) {
+            res.status(400).send({ statusCode: 400, message: "Authorization header is needed" })
+        } else {
+            res.status(401).send({ statusCode: 401, message: "Authorization header is incorrect" })
+        }
+    } else {
+        res.status(400).send({ statusCode: 400, message: "HTTP Method supported is POST" })
+    }
+}

--- a/src/pages/api/reciter/search/scopus.ts
+++ b/src/pages/api/reciter/search/scopus.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { searchScopusAuthors, searchScopusDocuments, scopusConfigured } from '../../../../../controllers/scopusSearch.controller'
+import { reciterConfig } from '../../../../../config/local'
+
+type Resp = {
+    statusCode: number,
+    authors?: any,
+    results?: any,
+    total?: number,
+    message?: any,
+}
+
+// PM#772 — POST { mode:'authors', lastName, firstName }        -> candidate Scopus Author IDs
+//          POST { mode:'documents', by:'author'|'keyword'|'doi', term } -> matching documents + total
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<Resp>
+) {
+    if (req.method !== "POST") {
+        res.status(400).send({ statusCode: 400, message: "HTTP Method supported is POST" })
+        return
+    }
+    if (req.headers.authorization === undefined) {
+        res.status(400).send({ statusCode: 400, message: "Authorization header is needed" })
+        return
+    }
+    if (req.headers.authorization !== reciterConfig.backendApiKey) {
+        res.status(401).send({ statusCode: 401, message: "Authorization header is incorrect" })
+        return
+    }
+    if (!scopusConfigured()) {
+        res.status(503).send({ statusCode: 503, message: "Scopus credentials are not configured on this server." })
+        return
+    }
+    const { mode, lastName, firstName, by, term } = req.body || {}
+    try {
+        if (mode === "authors") {
+            const authors = await searchScopusAuthors(lastName, firstName)
+            res.status(200).send({ statusCode: 200, authors })
+        } else {
+            const { results, total } = await searchScopusDocuments(by, term)
+            res.status(200).send({ statusCode: 200, results, total })
+        }
+    } catch (err: any) {
+        res.status(502).send({ statusCode: 502, message: "Scopus search is temporarily unavailable." })
+    }
+}


### PR DESCRIPTION
## Summary

Re-ports the external-source add-publication feature (PM#771 + PM#772) onto the **Next14 / React18 / next-auth v4** `dev` line. It was originally built on the `dev_Upd_NextJS14SNode18` line (Next12 / React16 / next-auth v3), which can't be merged forward cleanly — so this is a clean re-implementation on `dev`'s framework, adapting the auth to this branch's conventions.

Lets a curator attach **non-PubMed publications** to a person's record from external sources. External articles are stored via the ReCiter external-article API and **never enter feature generation or scoring**.

## What it adds

- **`+ Add publication ▾` dropdown** (PubMed / OpenAlex / Scopus) replacing the single PubMed button — keeps the tab bar compact as sources grow.
- **OpenAlex** search by title/DOI (server-side proxy). In-PubMed results steer to the scored PubMed path ("Add via PubMed →"); results annotated with the person's record status (accepted/rejected/pending). 409 dup handling: BLOCKED (state-specific) vs WARNING + "Add anyway".
- **Scopus authorships tab**: search by Author ID / keyword / DOI, author auto-resolve from the person's name, 200-result cap with an overflow message, and local per-uid dismissal (never GoldStandard).

## Auth (please note)

The three new `/api/reciter/search/*` routes and the external-article route are gated on **`backendApiKey` only** — matching every existing `/api/reciter/*` route on this branch (including the `goldstandard`/`userfeedback` writes). The per-person curation-scope authz from the AAR line isn't present on `dev`, so it's deliberately not used here.

Known posture note (not a regression): the Scopus search route spends WCM's **licensed, metered Scopus entitlement** behind `backendApiKey`-only — i.e. the same exposure as the existing write routes. If we want to harden it (require a session/curate capability), that's a **dev-wide** auth change, not something to bolt onto this one feature.

Includes two small robustness fixes carried over from review: the Scopus tab checks `r.ok` (a 503/502 shows an error instead of a silent "no results"), and the external add guards an unloaded person.

## Verification

- `tsc --noEmit` — clean (0 errors) on the Next14/v4 base.
- `next build` — ✓ compiled successfully, 21/21 pages; all four new API routes present in the manifest.
- **Not yet exercised at runtime** — needs a smoke test on reciter-pm-dev after deploy: OpenAlex add, Scopus author-resolve + search, the external-article POST, and the "Add via PubMed →" steer.

## Notes

- Backend prefix allowlist (`ExternalArticleController`) already accepts `OPENALEX`/`SCOPUS` and is deployed on reciter-dev — no backend change needed.
- 14 files (12 new + `config/local.js` and `ReciterTabs.tsx` modified). No new dependencies.
