### PR TITLE
fix(ci): repair k8-buildspec build guard (trailing space broke line continuation)

### DIFF
--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -71,7 +71,7 @@ phases:
       - |
         if expr "${BRANCH}" : ".*master" >/dev/null || \
            expr "${BRANCH}" : ".*dev" >/dev/null || \
-           expr "${BRANCH}" : ".*dev_Upd_NextJS14SNode18" >/dev/null || \ 
+           expr "${BRANCH}" : ".*dev_Upd_NextJS14SNode18" >/dev/null || \
            expr "${BRANCH}" : ".*master_Next14" >/dev/null;then
           docker build --build-arg NEXT_PUBLIC_RECITER_API_KEY=$ADMIN_API_KEY --build-arg NEXT_PUBLIC_RECITER_TOKEN_SECRET=$TOKEN_SECRET --tag $REPOSITORY_URI:$TAG .
         fi


### PR DESCRIPTION
Line 74 of `k8-buildspec.yml` ended with `\ ` (backslash + trailing space), breaking the multi-line `if` continuation on the docker-build guard. The guard collapsed to effectively `master_Next14` only, so **docker build was silently skipped for `dev`, `master`, and `dev_Upd`** (BUILD phase finishing in ~8ms), `docker push` found no local image, and the deployment was pointed at a never-built tag → `ErrImagePull`.

This is why there are no recent `dev-*`/`master-*` images in ECR and reciter-pm-dev never rolled out #774 or #776 (the 26h pod kept serving).

**Fix:** remove the trailing space on line 74 → restores the intended `master|dev|dev_Upd|master_Next14` build guard. Verified: with the fix, the guard evaluates BUILD for dev/master/dev_Upd and skip for unknown branches.

Also repairs the **prod/master** deploy path — cc @Mahender.