### PR TITLE
fix(ci): repair k8-buildspec build guard (trailing space broke line continuation)

### DIFF
--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -71,7 +71,7 @@ phases:
       - |
         if expr "${BRANCH}" : ".*master" >/dev/null || \
            expr "${BRANCH}" : ".*dev" >/dev/null || \
-           expr "${BRANCH}" : ".*dev_Upd_NextJS14SNode18" >/dev/null || \ 
+           expr "${BRANCH}" : ".*dev_Upd_NextJS14SNode18" >/dev/null || \
            expr "${BRANCH}" : ".*master_Next14" >/dev/null;then
           docker build --build-arg NEXT_PUBLIC_RECITER_API_KEY=$ADMIN_API_KEY --build-arg NEXT_PUBLIC_RECITER_TOKEN_SECRET=$TOKEN_SECRET --tag $REPOSITORY_URI:$TAG .
         fi


### PR DESCRIPTION
@mrj4001 — flagging a latent CI bug on `master_Next14`.

**Bug:** `k8-buildspec.yml` line 74 ends with `\ ` (backslash + **trailing space**) instead of `\`, which breaks the multi-line `if` continuation on the docker-build guard. The guard collapses to effectively `master_Next14`-only.

**Impact:** `master_Next14` itself builds fine (it matches the collapsed guard — that's why prod deploys work), but **any other branch routed through this buildspec (dev, master, dev_Upd) has its `docker build` silently skipped** (BUILD phase ~8ms), `docker push` finds no local image, and the deploy is pointed at a never-built tag → `ErrImagePull`. This exact bug blocked every `dev` deploy until fixed on dev (PR #777) — reciter-pm-dev had been stuck on a stale pod for days.

**Fix:** remove the trailing space on line 74 → restores the intended `master|dev|dev_Upd|master_Next14` guard. One character. Verified the guard evaluates BUILD for master/dev/dev_Upd and skip for unknown branches.

Not urgent for current prod (prod deploys from `master_Next14`, which is self-favorable), but worth landing so the guard is correct for any future consolidation. `master` itself is already clean (different, single-line guard).