### PR TITLE
WP3: curator-action layer on the Authorships tab (PM#775, PR-1)

### DIFF
--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -1,31 +1,64 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op, fn, col } from "sequelize";
+import { getToken } from "next-auth/jwt";
 import models from "../../src/db/sequelize";
+import { reciterConfig } from "../../config/local";
+import { updatePendingArticleCount } from "./person.controller";
+import { addExternalArticle, deleteExternalArticle } from "../externalArticle.controller";
 
 // Columns returned to the Authorships tab (one row per unassigned WCM authorship).
+// Multi-source: `source`/`external_id`/`pub_type`/`container_id` drive the Scopus lane
+// (documents not in PubMed → curators Accept them as ExternalArticle, no PMID).
 const LIST_ATTRIBUTES = [
-  "id", "pmid", "author_key", "wcm_author", "author_position_label",
-  "entrez_date", "title", "journal", "doi", "classification",
+  "id", "source", "pmid", "external_id", "author_key", "wcm_author", "author_position_label", "author_affiliation",
+  "entrez_date", "title", "journal", "doi", "pub_type", "container_id", "classification",
   "top_cwid", "top_name", "top_person_type", "top_dept",
   "top_fg_score", "top_io_score", "top_confidence", "top_cohort_size",
   "top_given_match", "top_affil_match", "n_candidates", "single_candidate",
-  "candidate_cwids_json", "status",
+  "candidate_cwids_json", "status", "snooze_until", "reviewer", "resolved_at",
 ];
 
+const todayStr = () => new Date().toISOString().slice(0, 10);
+
 const SORTS: Record<string, any[]> = {
-  // default: single-candidate (high-precision) first, then identity-only score desc
-  precision: [["single_candidate", "DESC"], ["top_io_score", "DESC"]],
-  io: [["top_io_score", "DESC"]],
-  fg: [["top_fg_score", "DESC"]],
-  date: [["entrez_date", "DESC"]],
+  // default: single-candidate (high-precision) first, then identity-only score desc.
+  // ["pmid","DESC"] is a secondary key so same-paper pubmed authorships land adjacent.
+  precision: [["single_candidate", "DESC"], ["top_io_score", "DESC"], ["pmid", "DESC"]],
+  confidence: [["top_confidence", "DESC"], ["pmid", "DESC"]],
+  io: [["top_io_score", "DESC"], ["pmid", "DESC"]],
+  fg: [["top_fg_score", "DESC"], ["pmid", "DESC"]],
+  date: [["entrez_date", "DESC"], ["pmid", "DESC"]],
 };
+
+// Status-view predicate for the current view ("open" | "snoozed" | "dismissed"), or null
+// when feed="all". Factored out so the per-paper sibling count respects the same view.
+function openStatusWhere(body: any): any {
+  if (body.feed === "all") return null;
+  const view = body.statusView || "open";
+  const today = todayStr();
+  if (view === "snoozed") {
+    return { status: "snoozed", snooze_until: { [Op.gt]: today } };
+  } else if (view === "dismissed") {
+    return { status: "dismissed" };
+  }
+  // open queue: truly open, plus snoozes whose timer has lapsed (or has no wake date)
+  return {
+    [Op.or]: [
+      { status: "open" },
+      { status: "snoozed", snooze_until: { [Op.lte]: today } },
+      { status: "snoozed", snooze_until: null as any },
+    ],
+  };
+}
 
 function buildWhere(body: any): any {
   const and: any[] = [];
 
-  // feed: unassigned (open/snoozed) is the default; "all" drops the status filter
-  if (body.feed !== "all") {
-    and.push({ status: { [Op.in]: ["open", "snoozed"] } });
+  const status = openStatusWhere(body);
+  if (status) and.push(status);
+  // source segment: "all" (default) | "pubmed" | "scopus"
+  if (body.source && body.source !== "all") {
+    and.push({ source: body.source });
   }
   // classification lane: buried | suggested | absent
   if (body.classification && body.classification !== "all") {
@@ -35,7 +68,15 @@ function buildWhere(body: any): any {
   if (body.precision === "single") {
     and.push({ single_candidate: true });
   }
-  // free-text search across author name, proposed identity, and pmid
+  // publication-type filter (multiselect): Scopus subtypeDescription
+  if (Array.isArray(body.pubTypes) && body.pubTypes.length > 0) {
+    and.push({ pub_type: { [Op.in]: body.pubTypes } });
+  }
+  // person-type filter (multiselect): the proposed identity's person type(s)
+  if (Array.isArray(body.personTypes) && body.personTypes.length > 0) {
+    and.push({ top_person_type: { [Op.in]: body.personTypes } });
+  }
+  // free-text search across author name, proposed identity, pmid, doi, and Scopus id
   const search = (body.searchTextInput || "").trim();
   if (search) {
     const like = `%${search}%`;
@@ -43,13 +84,29 @@ function buildWhere(body: any): any {
       { wcm_author: { [Op.like]: like } },
       { top_name: { [Op.like]: like } },
       { top_cwid: { [Op.like]: like } },
+      { doi: { [Op.like]: like } },
+      { external_id: { [Op.like]: like } },
     ];
     if (/^\d+$/.test(search)) or.push({ pmid: Number(search) });
     and.push({ [Op.or]: or });
   }
+  // publication-date range (entrez_date is DATEONLY → compare YYYY-MM-DD strings)
+  const dateFrom = (body.dateFrom || "").trim();
+  const dateTo = (body.dateTo || "").trim();
+  if (dateFrom && dateTo) {
+    and.push({ entrez_date: { [Op.between]: [dateFrom, dateTo] } });
+  } else if (dateFrom) {
+    and.push({ entrez_date: { [Op.gte]: dateFrom } });
+  } else if (dateTo) {
+    and.push({ entrez_date: { [Op.lte]: dateTo } });
+  }
 
   return and.length ? { [Op.and]: and } : {};
 }
+
+// same-document sibling key: pubmed → pmid, scopus → external_id (co-authorships on one doc).
+const siblingKey = (r: any) =>
+  r.source === "scopus" ? String(r.external_id || "") : String(r.pmid ?? "");
 
 // POST /api/db/authorships — paginated, filtered list of unassigned WCM authorships.
 export const listAuthorships = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -67,38 +124,259 @@ export const listAuthorships = async (req: NextApiRequest, res: NextApiResponse)
       limit,
     });
 
-    res.send({ rows, count, limit, offset });
+    // Per-document sibling count, scoped to the active status-view. Two grouped COUNTs —
+    // pubmed by pmid, scopus by external_id — so mixed-source pages stay accurate even
+    // when siblings are off-page. (Book-level "N chapters" is a separate tab feature.)
+    const status = openStatusWhere(body);
+    const scope = (w: any) => (status ? { [Op.and]: [w, status] } : w);
+    const pmids = [...new Set(rows.filter((r: any) => r.source !== "scopus" && r.pmid != null).map((r: any) => Number(r.pmid)))];
+    const scopusIds = [...new Set(rows.filter((r: any) => r.source === "scopus" && r.external_id).map((r: any) => String(r.external_id)))];
+    let pmidSib: Record<string, number> = {};
+    let scopusSib: Record<string, number> = {};
+    if (pmids.length) {
+      const sib: any[] = await models.AuthorshipReview.findAll({
+        attributes: ["pmid", [fn("COUNT", col("id")), "n"]],
+        where: scope({ source: "pubmed", pmid: { [Op.in]: pmids } }),
+        group: ["pmid"], raw: true,
+      });
+      pmidSib = Object.fromEntries(sib.map((s) => [String(s.pmid), Number(s.n)]));
+    }
+    if (scopusIds.length) {
+      const sib: any[] = await models.AuthorshipReview.findAll({
+        attributes: ["external_id", [fn("COUNT", col("id")), "n"]],
+        where: scope({ source: "scopus", external_id: { [Op.in]: scopusIds } }),
+        group: ["external_id"], raw: true,
+      });
+      scopusSib = Object.fromEntries(sib.map((s) => [String(s.external_id), Number(s.n)]));
+    }
+    const out = rows.map((r: any) => {
+      const map = r.source === "scopus" ? scopusSib : pmidSib;
+      return { ...r.toJSON(), pmid_sibling_count: map[siblingKey(r)] || 1 };
+    });
+
+    res.send({ rows: out, count, limit, offset });
   } catch (e) {
     console.log(e);
-    res.status(500).send(e);
+    res.status(500).send(String(e));
   }
 };
 
-// POST /api/db/authorships/summary — counts per classification + precision lane, for the
-// tab headers. Honours the same feed/search filters but ignores classification/precision so
-// each lane shows its own total.
+// POST /api/db/authorships/summary — counts for the tab headers. Ignores the
+// segment/classification/precision/person-type filters so each facet shows its own total.
 export const authorshipSummary = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const body = { ...(req.body || {}), classification: "all", precision: "all" };
+    const body = { ...(req.body || {}), source: "all", classification: "all", precision: "all", personTypes: [], pubTypes: [] };
     const where = buildWhere(body);
-    const [total, single, byClass] = await Promise.all([
+    const [total, single, byClass, byType, bySrc, byPub] = await Promise.all([
       models.AuthorshipReview.count({ where }),
       models.AuthorshipReview.count({ where: { [Op.and]: [where, { single_candidate: true }] } }),
-      models.AuthorshipReview.findAll({
-        attributes: [
-          "classification",
-          [fn("COUNT", col("id")), "n"],
-        ],
-        where,
-        group: ["classification"],
-        raw: true,
-      }),
+      models.AuthorshipReview.findAll({ attributes: ["classification", [fn("COUNT", col("id")), "n"]], where, group: ["classification"], raw: true }),
+      models.AuthorshipReview.findAll({ attributes: ["top_person_type", [fn("COUNT", col("id")), "n"]], where, group: ["top_person_type"], raw: true }),
+      models.AuthorshipReview.findAll({ attributes: ["source", [fn("COUNT", col("id")), "n"]], where, group: ["source"], raw: true }),
+      models.AuthorshipReview.findAll({ attributes: ["pub_type", [fn("COUNT", col("id")), "n"]], where: { [Op.and]: [where, { source: "scopus" }] }, group: ["pub_type"], raw: true }),
     ]);
     const classes: Record<string, number> = {};
     (byClass as any[]).forEach((r) => { classes[r.classification] = Number(r.n); });
-    res.send({ total, single_candidate: single, classes });
+    const bySource: Record<string, number> = {};
+    (bySrc as any[]).forEach((r) => { bySource[r.source] = Number(r.n); });
+    const personTypes = (byType as any[]).filter((r) => r.top_person_type).map((r) => ({ type: r.top_person_type as string, n: Number(r.n) })).sort((a, b) => b.n - a.n);
+    const pubTypes = (byPub as any[]).filter((r) => r.pub_type).map((r) => ({ type: r.pub_type as string, n: Number(r.n) })).sort((a, b) => b.n - a.n);
+    res.send({ total, single_candidate: single, classes, personTypes, bySource, pubTypes });
   } catch (e) {
     console.log(e);
-    res.status(500).send(e);
+    res.status(500).send(String(e));
+  }
+};
+
+// ---- Phase C: curator actions -------------------------------------------------
+// Resolve the curator's identity server-side from the next-auth JWT. On dev the /api
+// routes are gated by the shared backendApiKey and the page by middleware; the per-route
+// Superuser/Curator_All authz (getEffectiveRolesScope) is a dev_Upd-only feature not on
+// this branch, so we match dev's backendApiKey-only convention and stamp the audit
+// identity (curatedBy / reviewer / addedBy) from the real signed-in AdminUser.
+// ponytail: no in-endpoint role gate — page middleware + backendApiKey + a resolvable
+// active AdminUser are the trust boundary here; add a role check if dev is hardened.
+async function resolveCurator(req: NextApiRequest): Promise<{ userID?: number; cwid?: string }> {
+  const token: any = await getToken({ req: req as any, secret: process.env.NEXTAUTH_SECRET });
+  if (!token) return {};
+  const cwid: string | undefined = token.username ? String(token.username) : undefined;
+  let userID: number | undefined = token.databaseUser?.userID;
+  if (!userID && cwid) {
+    const au: any = await models.AdminUser.findOne({ where: { personIdentifier: cwid }, attributes: ["userID"] });
+    userID = au?.userID;
+  }
+  return { userID, cwid };
+}
+
+// Gold-standard MERGE/DELETE via the ReCiter Java endpoint (pubmed rows only), tagged with
+// the AAR source and the curator's numeric userID. Returns the upstream HTTP status.
+async function writeGoldStandard(
+  uid: string, pmid: number, kind: "known" | "rejected", flag: "UPDATE" | "DELETE", curatedBy?: number,
+): Promise<number> {
+  const body: any = { uid };
+  if (kind === "known") body.knownPmids = [pmid]; else body.rejectedPmids = [pmid];
+  const curatedByQ = curatedBy != null ? `&curatedBy=${curatedBy}` : "";
+  try {
+    const resp = await fetch(
+      `${reciterConfig.reciter.reciterUpdateGoldStandardEndpoint}?goldStandardUpdateFlag=${flag}&source=adversarial-attribution-review&entryPath=PM_AUTHOR${curatedByQ}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "api-key": reciterConfig.reciter.adminApiKey,
+          "User-Agent": "reciter-pub-manager-server",
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    return resp.status;
+  } catch (e) {
+    console.log("[authorships] gold-standard write failed:", e);
+    return 500;
+  }
+}
+
+// Append an AdminFeedbackLog row (pubmed accept/reject/assign only — PMID-keyed).
+async function appendFeedbackLog(userID: number, personIdentifier: string, pmid: number, feedback: "ACCEPTED" | "REJECTED") {
+  const active: any = await models.AdminUser.findOne({ where: { userID, status: 1 }, attributes: ["userID"] });
+  if (!active) throw new Error(`userID ${userID} is not an active AdminUser`);
+  await models.AdminFeedbackLog.create({
+    userID, personIdentifier, articleIdentifier: pmid, feedback, createTimestamp: new Date(),
+  });
+  await updatePendingArticleCount(personIdentifier, feedback);
+}
+
+// ExternalArticle payload for a scopus row (no PMID → not gold standard). articleId is
+// "SCOPUS:<numericId>" where numericId = external_id (dc:identifier minus SCOPUS_ID:).
+function scopusExternalPayload(row: any) {
+  return {
+    articleId: `SCOPUS:${row.external_id}`,
+    sourceType: "SCOPUS",
+    method: "scopus-authorships-tab",
+    doi: row.doi || undefined,
+    title: row.title || undefined,
+    venue: row.journal || undefined,
+    pubDate: row.entrez_date || undefined,
+    publicationType: row.pub_type || undefined,
+  };
+}
+
+// POST /api/db/authorships/action — single-row curator action.
+// body: { id, action: "accept"|"reject"|"snooze"|"dismiss"|"assign"|"reopen", cwid?, force? }
+// cwid is required only for "assign"; force retries a scopus Accept past a 409 WARNING.
+export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse) => {
+  try {
+    const curator = await resolveCurator(req);
+    if (!curator.userID) return res.status(401).send("Could not resolve curator identity");
+
+    const body = req.body || {};
+    const id = Number(body.id);
+    const action = String(body.action || "");
+    if (!id || !action) return res.status(400).send("id and action are required");
+
+    const row: any = await models.AuthorshipReview.findByPk(id);
+    if (!row) return res.status(404).send("Authorship not found");
+
+    const isScopus = row.source === "scopus";
+    const pmid = row.pmid != null ? Number(row.pmid) : null;
+    const cwid = row.top_cwid as string | undefined;
+    const reviewer = curator.cwid || String(curator.userID);
+    const force = String(body.force) === "true";
+
+    switch (action) {
+      case "accept": {
+        if (!cwid) return res.status(409).send("No proposed identity to accept");
+        if (!row.single_candidate) return res.status(409).send("Multiple candidates — use \"Pick one\" to assign");
+        if (isScopus) {
+          const resp = await addExternalArticle(cwid, scopusExternalPayload(row), reviewer, force);
+          if (resp.statusCode === 409) return res.status(409).send(resp.statusText);
+          if (resp.statusCode !== 201 && resp.statusCode !== 200) return res.status(502).send(`ExternalArticle add failed (${resp.statusCode})`);
+          await models.AuthorshipReview.update({ status: "accepted", resolution_cwid: cwid, reviewer, resolved_at: new Date() }, { where: { id } });
+          break; // no AdminFeedbackLog / pending-count for scopus (PMID-keyed)
+        }
+        const gs = await writeGoldStandard(cwid, pmid as number, "known", "UPDATE", curator.userID);
+        if (gs !== 200) return res.status(502).send(`Gold-standard write failed (${gs})`);
+        await models.AuthorshipReview.update({ status: "accepted", resolution_cwid: cwid, reviewer, resolved_at: new Date() }, { where: { id } });
+        try { await appendFeedbackLog(curator.userID, cwid, pmid as number, "ACCEPTED"); }
+        catch (e) { console.log("[authorships] feedbacklog (accept) non-fatal:", e); }
+        break;
+      }
+      case "assign": {
+        const chosen = String(body.cwid || "");
+        if (!chosen) return res.status(400).send("cwid is required for assign");
+        // Integrity boundary: the server verifies the chosen cwid is a real candidate for
+        // this authorship before any authoritative write (client can't spoof an identity).
+        let candidateCwids: string[] = [];
+        try {
+          const parsed = JSON.parse(row.candidate_cwids_json || "[]");
+          if (Array.isArray(parsed)) candidateCwids = parsed.map((c: any) => (typeof c === "string" ? c : c?.cwid)).filter(Boolean).map(String);
+        } catch { candidateCwids = []; }
+        const allowed = new Set([row.top_cwid, ...candidateCwids].filter(Boolean).map(String));
+        if (!allowed.has(chosen)) return res.status(400).send("cwid is not a candidate for this authorship");
+        if (isScopus) {
+          const resp = await addExternalArticle(chosen, scopusExternalPayload(row), reviewer, force);
+          if (resp.statusCode === 409) return res.status(409).send(resp.statusText);
+          if (resp.statusCode !== 201 && resp.statusCode !== 200) return res.status(502).send(`ExternalArticle add failed (${resp.statusCode})`);
+          await models.AuthorshipReview.update({ status: "assigned", resolution_cwid: chosen, reviewer, resolved_at: new Date() }, { where: { id } });
+          break;
+        }
+        const gs = await writeGoldStandard(chosen, pmid as number, "known", "UPDATE", curator.userID);
+        if (gs !== 200) return res.status(502).send(`Gold-standard write failed (${gs})`);
+        await models.AuthorshipReview.update({ status: "assigned", resolution_cwid: chosen, reviewer, resolved_at: new Date() }, { where: { id } });
+        try { await appendFeedbackLog(curator.userID, chosen, pmid as number, "ACCEPTED"); }
+        catch (e) { console.log("[authorships] feedbacklog (assign) non-fatal:", e); }
+        break;
+      }
+      case "reject": {
+        if (!cwid) return res.status(409).send("No proposed identity to reject");
+        if (!row.single_candidate) return res.status(409).send("Multiple candidates — use \"Pick one\" to assign");
+        if (isScopus) {
+          // scopus reject = local dismissal, never gold standard (no PMID to reject).
+          await models.AuthorshipReview.update({ status: "rejected", reviewer, resolved_at: new Date() }, { where: { id } });
+          break;
+        }
+        const gs = await writeGoldStandard(cwid, pmid as number, "rejected", "UPDATE", curator.userID);
+        if (gs !== 200) return res.status(502).send(`Gold-standard write failed (${gs})`);
+        await models.AuthorshipReview.update({ status: "rejected", reviewer, resolved_at: new Date() }, { where: { id } });
+        try { await appendFeedbackLog(curator.userID, cwid, pmid as number, "REJECTED"); }
+        catch (e) { console.log("[authorships] feedbacklog (reject) non-fatal:", e); }
+        break;
+      }
+      case "snooze": {
+        const wake = new Date(Date.now() + 90 * 86400000).toISOString().slice(0, 10);
+        await models.AuthorshipReview.update({ status: "snoozed", snooze_until: wake, reviewer }, { where: { id } });
+        break;
+      }
+      case "dismiss": {
+        await models.AuthorshipReview.update({ status: "dismissed", reviewer, resolved_at: new Date() }, { where: { id } });
+        break;
+      }
+      case "reopen": {
+        const reverseCwid = row.resolution_cwid || cwid;
+        if (isScopus) {
+          // undo a scopus accept/assign = revoke the ExternalArticle (reject/dismiss wrote none).
+          if ((row.status === "accepted" || row.status === "assigned") && reverseCwid) {
+            const resp = await deleteExternalArticle(reverseCwid, `SCOPUS:${row.external_id}`);
+            if (resp.statusCode !== 200) return res.status(502).send(`ExternalArticle revoke failed (${resp.statusCode})`);
+          }
+        } else if ((row.status === "accepted" || row.status === "assigned") && reverseCwid) {
+          const gs = await writeGoldStandard(reverseCwid, pmid as number, "known", "DELETE", curator.userID);
+          if (gs !== 200) return res.status(502).send(`Gold-standard undo failed (${gs})`);
+        } else if (row.status === "rejected" && reverseCwid) {
+          const gs = await writeGoldStandard(reverseCwid, pmid as number, "rejected", "DELETE", curator.userID);
+          if (gs !== 200) return res.status(502).send(`Gold-standard undo failed (${gs})`);
+        }
+        await models.AuthorshipReview.update({ status: "open", snooze_until: null, resolved_at: null, resolution_cwid: null, reviewer }, { where: { id } });
+        break;
+      }
+      default:
+        return res.status(400).send(`Unknown action: ${action}`);
+    }
+
+    const updated = await models.AuthorshipReview.findByPk(id, { attributes: LIST_ATTRIBUTES });
+    return res.send({ ok: true, row: updated });
+  } catch (e) {
+    console.log(e);
+    return res.status(500).send(String(e));
   }
 };

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -26,15 +26,25 @@ interface AuthorshipRow {
   single_candidate?: boolean;
   candidate_cwids_json?: string;
   status?: string;
+  snooze_until?: string;
+  reviewer?: string;
+  resolved_at?: string;
 }
 
 interface Summary { total: number; single_candidate: number; classes: Record<string, number>; }
+
+type StatusView = "open" | "snoozed" | "dismissed";
 
 const PAGE_SIZE = 25;
 const apiHeaders = {
   Accept: "application/json",
   "Content-Type": "application/json",
   Authorization: reciterConfig.backendApiKey,
+};
+
+// curator-action -> undo-bar label
+const ACTION_LABEL: Record<string, string> = {
+  accept: "Accepted", reject: "Rejected", snooze: "Snoozed for 90 days", dismiss: "Dismissed",
 };
 
 const CLASS_META: Record<string, { label: string; color: string; hint: string }> = {
@@ -61,6 +71,24 @@ const Score = ({ value, kind }: { value?: number; kind: "fg" | "io" }) => {
   return <span style={{ color, fontWeight: 600 }}>{value.toFixed(1)}</span>;
 };
 
+// ---- action-control styles -----------------------------------------------
+const acceptBtn = (busy: boolean): React.CSSProperties => ({
+  border: "1px solid #067647", background: busy ? "#f2f4f7" : "#067647", color: busy ? "#98a2b3" : "#fff",
+  borderRadius: 6, padding: "3px 10px", fontSize: 12, fontWeight: 600, cursor: busy ? "default" : "pointer",
+});
+const ghostBtn = (busy: boolean): React.CSSProperties => ({
+  border: "1px solid #d0d5dd", background: "#fff", color: "#344054", borderRadius: 6,
+  padding: "3px 10px", fontSize: 12, fontWeight: 600, cursor: busy ? "default" : "pointer", opacity: busy ? 0.5 : 1,
+});
+const kebabBtn: React.CSSProperties = {
+  border: "1px solid #d0d5dd", background: "#fff", color: "#475467", borderRadius: 6,
+  padding: "3px 8px", fontSize: 14, lineHeight: 1, cursor: "pointer",
+};
+const menuItem = (color = "#344054"): React.CSSProperties => ({
+  display: "block", width: "100%", textAlign: "left", border: "none", background: "#fff", color,
+  padding: "7px 12px", fontSize: 12, fontWeight: 600, cursor: "pointer", whiteSpace: "nowrap",
+});
+
 // ---- main component ------------------------------------------------------
 const AuthorshipsTabs = () => {
   const [rows, setRows] = useState<AuthorshipRow[]>([]);
@@ -68,19 +96,26 @@ const AuthorshipsTabs = () => {
   const [summary, setSummary] = useState<Summary | null>(null);
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(0);
+  const [statusView, setStatusView] = useState<StatusView>("open");
   const [lane, setLane] = useState<"single" | "all">("single");
   const [classification, setClassification] = useState<"all" | "buried" | "absent" | "suggested">("all");
   const [search, setSearch] = useState("");
   const [searchInput, setSearchInput] = useState("");
   const [expanded, setExpanded] = useState<number | null>(null);
+  // curator-action state
+  const [actingId, setActingId] = useState<number | null>(null);
+  const [menuId, setMenuId] = useState<number | null>(null);
+  const [undo, setUndo] = useState<{ row: AuthorshipRow; label: string } | null>(null);
+  const [errorMsg, setErrorMsg] = useState("");
 
   const filterBody = useCallback(() => ({
     feed: "unassigned",
+    statusView,
     precision: lane === "single" ? "single" : "all",
     classification,
     searchTextInput: search,
     sort: "precision",
-  }), [lane, classification, search]);
+  }), [statusView, lane, classification, search]);
 
   const fetchData = useCallback(() => {
     setLoading(true);
@@ -97,18 +132,49 @@ const AuthorshipsTabs = () => {
   const fetchSummary = useCallback(() => {
     fetch("/api/db/authorships/summary", {
       credentials: "same-origin", method: "POST", headers: apiHeaders,
-      body: JSON.stringify({ feed: "unassigned", searchTextInput: search }),
+      body: JSON.stringify({ feed: "unassigned", statusView, searchTextInput: search }),
     })
       .then((r) => r.json()).then(setSummary).catch(() => setSummary(null));
-  }, [search]);
+  }, [statusView, search]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
   useEffect(() => { fetchSummary(); }, [fetchSummary]);
   // reset to first page when filters change
-  useEffect(() => { setPage(0); }, [lane, classification, search]);
+  useEffect(() => { setPage(0); }, [statusView, lane, classification, search]);
+  // auto-dismiss the undo bar and error toast
+  useEffect(() => { if (!undo) return; const t = setTimeout(() => setUndo(null), 6000); return () => clearTimeout(t); }, [undo]);
+  useEffect(() => { if (!errorMsg) return; const t = setTimeout(() => setErrorMsg(""), 6000); return () => clearTimeout(t); }, [errorMsg]);
+
+  // ---- curator action: POST, then refetch the current view -----------------
+  // Resolved rows (accepted/rejected) appear in no view, so the undo bar is the only
+  // reversal path for accept/reject — reopen is also reachable in Snoozed/Dismissed.
+  const act = useCallback((row: AuthorshipRow, action: string, extra?: Record<string, any>) => {
+    setMenuId(null);
+    setActingId(row.id);
+    fetch("/api/db/authorships/action", {
+      credentials: "same-origin", method: "POST", headers: apiHeaders,
+      body: JSON.stringify({ id: row.id, action, ...extra }),
+    })
+      .then(async (r) => { if (!r.ok) throw new Error((await r.text()) || `HTTP ${r.status}`); })
+      .then(() => {
+        setUndo(action === "reopen" ? null : { row, label: ACTION_LABEL[action] || "Done" });
+        fetchData();
+        fetchSummary();
+      })
+      .catch((e) => setErrorMsg(`Couldn't ${action} — ${String(e?.message || e)}`))
+      .finally(() => setActingId(null));
+  }, [fetchData, fetchSummary]);
+
+  const doUndo = useCallback(() => {
+    if (!undo) return;
+    const row = undo.row;
+    setUndo(null);
+    act(row, "reopen");
+  }, [undo, act]);
 
   const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
   const classChips: Array<typeof classification> = ["all", "buried", "absent", "suggested"];
+  const statusTabs: Array<[StatusView, string]> = [["open", "Open"], ["snoozed", "Snoozed"], ["dismissed", "Dismissed"]];
 
   return (
     <div style={{ padding: "24px 28px", fontFamily: "inherit" }}>
@@ -119,10 +185,23 @@ const AuthorshipsTabs = () => {
         <strong> FG</strong> is the production score; <strong> IO</strong> is the identity-only score.
       </p>
 
+      {/* status view */}
+      <div style={{ display: "inline-flex", background: "#eef2f7", borderRadius: 8, padding: 2, margin: "14px 0 6px" }}>
+        {statusTabs.map(([key, label]) => (
+          <button key={key} onClick={() => setStatusView(key)} style={{
+            border: "none", padding: "6px 14px", font: "inherit", fontSize: 13, fontWeight: 600,
+            borderRadius: 6, cursor: "pointer",
+            background: statusView === key ? "#fff" : "transparent",
+            color: statusView === key ? "#101828" : "#475467",
+            boxShadow: statusView === key ? "0 1px 2px rgba(16,24,40,.1)" : "none",
+          }}>{label}</button>
+        ))}
+      </div>
+
       {/* summary */}
       {summary && (
         <div style={{ display: "flex", gap: 18, margin: "12px 0 18px", color: "#475467", fontSize: 13 }}>
-          <span><strong style={{ color: "#101828" }}>{summary.total.toLocaleString()}</strong> unassigned</span>
+          <span><strong style={{ color: "#101828" }}>{summary.total.toLocaleString()}</strong> {statusView}</span>
           <span><strong style={{ color: "#101828" }}>{summary.single_candidate.toLocaleString()}</strong> single-candidate</span>
           {Object.entries(summary.classes).map(([k, v]) => (
             <span key={k}>{CLASS_META[k]?.label || k}: <strong style={{ color: "#101828" }}>{v.toLocaleString()}</strong></span>
@@ -158,25 +237,26 @@ const AuthorshipsTabs = () => {
       </div>
 
       {/* table */}
-      <div style={{ border: "1px solid #eaecf0", borderRadius: 10, overflow: "hidden" }}>
+      <div style={{ border: "1px solid #eaecf0", borderRadius: 10, overflow: "visible" }}>
         <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
           <thead>
             <tr style={{ background: "#f9fafb", textAlign: "left", color: "#475467" }}>
-              {["WCM author", "Proposed identity", "FG", "IO", "Class", "Cand.", "Conf.", "Article", ""].map((h, i) => (
+              {["WCM author", "Proposed identity", "FG", "IO", "Class", "Cand.", "Conf.", "Article", "", "Actions"].map((h, i) => (
                 <th key={i} style={{ padding: "10px 12px", fontWeight: 600, borderBottom: "1px solid #eaecf0", whiteSpace: "nowrap" }}>{h}</th>
               ))}
             </tr>
           </thead>
           <tbody>
             {loading && (
-              <tr><td colSpan={9} style={{ padding: 24, textAlign: "center", color: "#98a2b3" }}>Loading…</td></tr>
+              <tr><td colSpan={10} style={{ padding: 24, textAlign: "center", color: "#98a2b3" }}>Loading…</td></tr>
             )}
             {!loading && rows.length === 0 && (
-              <tr><td colSpan={9} style={{ padding: 24, textAlign: "center", color: "#98a2b3" }}>No authorships match these filters.</td></tr>
+              <tr><td colSpan={10} style={{ padding: 24, textAlign: "center", color: "#98a2b3" }}>No authorships match these filters.</td></tr>
             )}
             {!loading && rows.map((r) => {
               const meta = CLASS_META[r.classification || "absent"];
               const isOpen = expanded === r.id;
+              const acting = actingId === r.id;
               let alternates: any[] = [];
               if (isOpen && r.candidate_cwids_json) {
                 try { alternates = JSON.parse(r.candidate_cwids_json); } catch { alternates = []; }
@@ -207,15 +287,47 @@ const AuthorshipsTabs = () => {
                     <td style={{ padding: "10px 12px", maxWidth: 360 }}>
                       <div style={{ color: "#101828", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", maxWidth: 360 }} title={r.title}>{r.title}</div>
                       <div style={{ color: "#667085", fontSize: 11 }}>{r.journal}{r.entrez_date ? ` · ${r.entrez_date}` : ""}</div>
+                      {r.status === "snoozed" && r.snooze_until && (
+                        <div style={{ color: "#98a2b3", fontSize: 11 }}>Wakes {r.snooze_until}</div>
+                      )}
                     </td>
                     <td style={{ padding: "10px 12px" }}>
                       <a href={`https://pubmed.ncbi.nlm.nih.gov/${r.pmid}/`} target="_blank" rel="noreferrer"
                         style={{ color: "#1570ef", textDecoration: "none", fontSize: 12 }}>{r.pmid} ↗</a>
                     </td>
+                    {/* curator actions */}
+                    <td style={{ padding: "10px 12px", whiteSpace: "nowrap" }}>
+                      {statusView === "open" ? (
+                        <div style={{ display: "flex", gap: 6, alignItems: "center", position: "relative" }}>
+                          {r.single_candidate && (
+                            <button disabled={acting} onClick={() => act(r, "accept")} style={acceptBtn(acting)}>Accept</button>
+                          )}
+                          <button onClick={() => setMenuId(menuId === r.id ? null : r.id)} style={kebabBtn} title="More actions">⋯</button>
+                          {menuId === r.id && (
+                            <>
+                              <div onClick={() => setMenuId(null)} style={{ position: "fixed", inset: 0, zIndex: 10 }} />
+                              <div style={{
+                                position: "absolute", top: "100%", right: 0, marginTop: 4, zIndex: 11,
+                                background: "#fff", border: "1px solid #eaecf0", borderRadius: 8,
+                                boxShadow: "0 4px 12px rgba(16,24,40,.12)", overflow: "hidden", minWidth: 150,
+                              }}>
+                                {r.single_candidate && (
+                                  <button style={menuItem("#b42318")} onClick={() => act(r, "reject")}>Reject</button>
+                                )}
+                                <button style={menuItem()} onClick={() => act(r, "snooze")}>Snooze 90 days</button>
+                                <button style={menuItem()} onClick={() => act(r, "dismiss")}>Dismiss</button>
+                              </div>
+                            </>
+                          )}
+                        </div>
+                      ) : (
+                        <button disabled={acting} onClick={() => act(r, "reopen")} style={ghostBtn(acting)}>Reopen</button>
+                      )}
+                    </td>
                   </tr>
                   {isOpen && alternates.length > 0 && (
                     <tr key={`${r.id}-exp`} style={{ background: "#fcfcfd" }}>
-                      <td colSpan={9} style={{ padding: "8px 12px 12px 24px" }}>
+                      <td colSpan={10} style={{ padding: "8px 12px 12px 24px" }}>
                         <div style={{ color: "#475467", fontSize: 12, marginBottom: 4 }}>Candidate identities (pick one when assigning):</div>
                         <table style={{ fontSize: 12, borderCollapse: "collapse" }}>
                           <tbody>
@@ -250,6 +362,30 @@ const AuthorshipsTabs = () => {
             style={{ padding: "6px 12px", borderRadius: 8, border: "1px solid #d0d5dd", background: "#fff", cursor: page + 1 >= totalPages ? "default" : "pointer", opacity: page + 1 >= totalPages ? 0.5 : 1 }}>Next</button>
         </span>
       </div>
+
+      {/* undo bar */}
+      {undo && (
+        <div style={{
+          position: "fixed", bottom: 24, left: 24, zIndex: 20, display: "flex", alignItems: "center", gap: 14,
+          background: "#101828", color: "#fff", borderRadius: 10, padding: "10px 16px",
+          boxShadow: "0 8px 24px rgba(16,24,40,.22)", fontSize: 13,
+        }}>
+          <span>{undo.label}</span>
+          <button onClick={doUndo} style={{ background: "none", border: "none", color: "#7cc4ff", fontWeight: 700, fontSize: 13, cursor: "pointer" }}>UNDO</button>
+        </div>
+      )}
+
+      {/* error toast */}
+      {errorMsg && (
+        <div style={{
+          position: "fixed", bottom: 24, right: 24, zIndex: 20, display: "flex", alignItems: "center", gap: 14,
+          background: "#b42318", color: "#fff", borderRadius: 10, padding: "10px 16px",
+          boxShadow: "0 8px 24px rgba(16,24,40,.22)", fontSize: 13, maxWidth: 420,
+        }}>
+          <span>{errorMsg}</span>
+          <button onClick={() => setErrorMsg("")} style={{ background: "none", border: "none", color: "#fecdca", fontWeight: 700, fontSize: 14, cursor: "pointer" }}>✕</button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/db/models/AuthorshipReview.ts
+++ b/src/db/models/AuthorshipReview.ts
@@ -6,8 +6,12 @@ import { DataTypes, Model, Optional } from 'sequelize';
 // adversarial-attribution-review producer. Column names are snake_case to match that table.
 export interface AuthorshipReviewAttributes {
   id: number;
-  pmid: number;
+  source: 'pubmed' | 'scopus';
+  pmid?: number;                 // NULL for scopus rows (no PMID)
+  external_id?: string;          // numeric Scopus record ID (scopus rows)
   author_key: string;
+  pub_type?: string;             // Scopus subtypeDescription (Article / Book Chapter / …)
+  container_id?: string;         // book base DOI (scopus book chapters)
   author_position?: number;
   author_position_label?: string;
   wcm_author?: string;
@@ -43,13 +47,17 @@ export interface AuthorshipReviewAttributes {
 
 export type AuthorshipReviewPk = "id";
 export type AuthorshipReviewId = AuthorshipReview[AuthorshipReviewPk];
-export type AuthorshipReviewOptionalAttributes = "id" | "author_position" | "author_position_label" | "wcm_author" | "author_affiliation" | "entrez_date" | "title" | "journal" | "doi" | "classification" | "top_cwid" | "top_name" | "top_person_type" | "top_dept" | "top_fg_score" | "top_io_score" | "top_confidence" | "top_cohort_size" | "top_given_match" | "top_affil_match" | "n_candidates" | "single_candidate" | "candidate_cwids_json" | "status" | "resolution_cwid" | "reviewer" | "note" | "snooze_until" | "resolved_at" | "first_seen" | "last_refreshed" | "last_checked";
+export type AuthorshipReviewOptionalAttributes = "id" | "source" | "pmid" | "external_id" | "pub_type" | "container_id" | "author_position" | "author_position_label" | "wcm_author" | "author_affiliation" | "entrez_date" | "title" | "journal" | "doi" | "classification" | "top_cwid" | "top_name" | "top_person_type" | "top_dept" | "top_fg_score" | "top_io_score" | "top_confidence" | "top_cohort_size" | "top_given_match" | "top_affil_match" | "n_candidates" | "single_candidate" | "candidate_cwids_json" | "status" | "resolution_cwid" | "reviewer" | "note" | "snooze_until" | "resolved_at" | "first_seen" | "last_refreshed" | "last_checked";
 export type AuthorshipReviewCreationAttributes = Optional<AuthorshipReviewAttributes, AuthorshipReviewOptionalAttributes>;
 
 export class AuthorshipReview extends Model<AuthorshipReviewAttributes, AuthorshipReviewCreationAttributes> implements AuthorshipReviewAttributes {
   id!: number;
-  pmid!: number;
+  source!: 'pubmed' | 'scopus';
+  pmid?: number;
+  external_id?: string;
   author_key!: string;
+  pub_type?: string;
+  container_id?: string;
   author_position?: number;
   author_position_label?: string;
   wcm_author?: string;
@@ -85,8 +93,12 @@ export class AuthorshipReview extends Model<AuthorshipReviewAttributes, Authorsh
   static initModel(sequelize: Sequelize.Sequelize): typeof AuthorshipReview {
     AuthorshipReview.init({
       id: { autoIncrement: true, type: DataTypes.BIGINT, allowNull: false, primaryKey: true },
-      pmid: { type: DataTypes.BIGINT, allowNull: false },
-      author_key: { type: DataTypes.STRING(32), allowNull: false },
+      source: { type: DataTypes.ENUM('pubmed', 'scopus'), allowNull: false, defaultValue: 'pubmed' },
+      pmid: { type: DataTypes.BIGINT, allowNull: true },
+      external_id: { type: DataTypes.STRING(96), allowNull: true },
+      author_key: { type: DataTypes.STRING(160), allowNull: false },
+      pub_type: { type: DataTypes.STRING(40), allowNull: true },
+      container_id: { type: DataTypes.STRING(96), allowNull: true },
       author_position: { type: DataTypes.INTEGER, allowNull: true },
       author_position_label: { type: DataTypes.STRING(8), allowNull: true },
       wcm_author: { type: DataTypes.STRING(255), allowNull: true },
@@ -125,6 +137,7 @@ export class AuthorshipReview extends Model<AuthorshipReviewAttributes, Authorsh
       indexes: [
         { name: "PRIMARY", unique: true, using: "BTREE", fields: [{ name: "id" }] },
         { name: "uq_author_key", unique: true, using: "BTREE", fields: [{ name: "author_key" }] },
+        { name: "ix_source", using: "BTREE", fields: [{ name: "source" }] },
         { name: "ix_pmid", using: "BTREE", fields: [{ name: "pmid" }] },
         { name: "ix_classification", using: "BTREE", fields: [{ name: "classification" }] },
         { name: "ix_status", using: "BTREE", fields: [{ name: "status" }] },

--- a/src/pages/api/db/authorships/action.ts
+++ b/src/pages/api/db/authorships/action.ts
@@ -1,0 +1,21 @@
+import { authorshipAction } from "../../../../../controllers/db/authorships.controller"
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { reciterConfig } from '../../../../../config/local'
+
+// POST /api/db/authorships/action — single-row curator action
+// (accept/reject/assign/snooze/dismiss/reopen). App-level gate via backendApiKey; the
+// controller additionally resolves the curator identity from the next-auth JWT (middleware
+// does not cover /api). PubMed rows write GoldStandard; Scopus rows write ExternalArticle.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method === "POST") {
+        if (req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            await authorshipAction(req, res)
+        } else if (req.headers.authorization === undefined) {
+            res.status(400).send("Authorization header is needed")
+        } else {
+            res.status(401).send("Authorization header is incorrect")
+        }
+    } else {
+        res.status(400).send('HTTP Method supported is POST')
+    }
+}


### PR DESCRIPTION
First increment of the WP3 Scopus Authorships lane (PM#775): the **curator-action layer** on the Authorships tab. Ports the Phase C action layer from `dev_Upd_NextJS14SNode18` onto `dev`, adapted to dev's auth (backendApiKey + next-auth JWT identity — no `getEffectiveRolesScope`).

Sequenced incrementally per plan: **PR-1 = curator actions** (this), then card redesign, then the Scopus-lane UI.

## What's in this PR
**Backend (commit `656f170`, multi-source):** `AuthorshipReview` model + `authorships.controller.ts` action handler + `statusView` filtering + `/api/db/authorships/action` route. PubMed accept/reject writes GoldStandard (+ best-effort AdminFeedbackLog); Scopus accept writes ExternalArticle. Source/pub_type filters and per-source summary are present but dormant until the Scopus UI lands.

**Frontend (PR-1):** extend the read-only 257-line tab into an action queue:
- **Open / Snoozed / Dismissed** status views (segmented control → `statusView`).
- **Per-row actions**: Accept (single-candidate), Reject / Snooze 90d / Dismiss (overflow menu), Reopen (from Snoozed/Dismissed). Accept & Reject are shown **only for single-candidate rows**, so they never hit the backend's multi-candidate 409.
- **Undo bar** after each action (calls `reopen`) — the only reversal path for accept/reject, since resolved rows appear in no view. Reopen is also directly available in the Snoozed/Dismissed views.
- **Error toast** on failure; refetch after each action.

## Scope / deferred
- **Multi-candidate "Pick one" / Assign**, bulk-accept, keyboard nav, and the rolling-queue refill are **PR-2** (card redesign), not here — multi-candidate rows in PR-1 offer only Snooze/Dismiss.
- **Scopus-lane UI** (source segment, SCOPUS badge, pub-type chips, scopus rail) is **PR-3**.
- Frontend matches the file's inline-style idiom (no MUI Snackbar/Menu) to keep the diff focused.

## Verification
- `npx tsc --noEmit` — **clean** (exit 0, 0 errors).
- Action semantics reviewed against the backend contract (accept requires single-candidate + top_cwid; snooze/dismiss need no cwid; reopen reverses the GS/ExternalArticle write).
- **Live curator smoke test still pending** the shared WP3 gate: needs the v1.6 `authorship_review` DDL + real rows in the `reciter-pm-dev` DB (Mahender), and the tab is SAML-walled. An Accept writes a real GoldStandard/ExternalArticle to the shared dev/prod DynamoDB.