### PR TITLE
feat(authorships): default to Last-2-years window + Confidence sort

### DIFF
--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -277,10 +277,13 @@ const AuthorshipsTabs = () => {
   const [classification, setClassification] = useState<"all" | "buried" | "absent" | "suggested">("all");
   const [search, setSearch] = useState("");
   const [searchInput, setSearchInput] = useState("");
-  const [sort, setSort] = useState("io"); // F3: default sort = IO
+  const [sort, setSort] = useState("confidence"); // default sort = Confidence (desc)
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
-  const [datePreset, setDatePreset] = useState("any"); // "any" | "30d" | "90d" | "6m" | "12m" | "custom"
+  const [datePreset, setDatePreset] = useState("24m"); // default = Last 2 years; "any"|"30d"|"90d"|"6m"|"12m"|"24m"|"custom"
+  // The default window is applied on mount (client-side, below) so the statically-prerendered
+  // initial render stays date-free and hydrates cleanly; the first list fetch waits on this.
+  const [datesReady, setDatesReady] = useState(false);
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
   const [typeAnchor, setTypeAnchor] = useState<HTMLElement | null>(null);
   const [expanded, setExpanded] = useState<number | null>(null);
@@ -417,9 +420,10 @@ const AuthorshipsTabs = () => {
   }, [filterBody]);
 
   useEffect(() => {
+    if (!datesReady) return;                                                    // hold the first fetch for the default window
     if (pendingPageReset.current) { pendingPageReset.current = false; return; } // offset-0 fetch follows
     fetchData();
-  }, [fetchData]);
+  }, [fetchData, datesReady]);
   useEffect(() => { fetchSummary(); }, [fetchSummary]);
   // clear transient per-page UI state on deliberate navigation only (filter/sort/status/page) —
   // NOT on every `rows` change, so a silent rolling-queue refill (topUp) after a single action
@@ -561,9 +565,15 @@ const AuthorshipsTabs = () => {
     // February, not rolls forward into March (setMonth/setFullYear overflow on short target months).
     else if (preset === "6m") { const day = from.getDate(); from.setDate(1); from.setMonth(from.getMonth() - 6); from.setDate(Math.min(day, daysInMonth(from.getFullYear(), from.getMonth()))); }
     else if (preset === "12m") { const day = from.getDate(); from.setDate(1); from.setFullYear(from.getFullYear() - 1); from.setDate(Math.min(day, daysInMonth(from.getFullYear(), from.getMonth()))); }
+    else if (preset === "24m") { const day = from.getDate(); from.setDate(1); from.setFullYear(from.getFullYear() - 2); from.setDate(Math.min(day, daysInMonth(from.getFullYear(), from.getMonth()))); }
     setDateFrom(fmt(from));
     setDateTo(fmt(today));
   }, []);
+
+  // Apply the default "recent" window (Last 2 years) on mount — client-only so the statically
+  // prerendered initial render (empty dates) hydrates cleanly. datesReady then releases the first
+  // list fetch, so curators land on the windowed view instead of flashing the full backlog.
+  useEffect(() => { applyDatePreset("24m"); setDatesReady(true); }, [applyDatePreset]);
 
   // F13: keyboard nav — J/K move, Y accept (single), N reject, S snooze, X select, Enter open PubMed.
   // Registered ONCE: it reads the latest rows/focus/view/handlers from refs, so an optimistic action
@@ -733,6 +743,7 @@ const AuthorshipsTabs = () => {
               <option value="90d">Last 90 days</option>
               <option value="6m">Last 6 months</option>
               <option value="12m">Last 12 months</option>
+              <option value="24m">Last 2 years</option>
               <option value="custom">Custom…</option>
             </select>
           </label>


### PR DESCRIPTION
## What

After the 10-year Scopus backfill, the Authorships tab defaults dumped curators into the
full unassigned backlog (~10k scopus + ~17k pubmed, oldest-inclusive). This defaults the tab
to a **recent, high-confidence** view — the triage default we want — while keeping everything
adjustable.

- **Default sort:** IO → **Confidence (desc)** (`SORTS.confidence` already existed server-side).
- **Default date window:** Any time → **Last 2 years** (adds a `24m` "Last 2 years" preset).
  **"Any time" still removes the threshold**, so curators can widen to the full backlog anytime.

## How (hydration-safe, no backlog flash)

`/authorships` is statically prerendered (no `getServerSideProps`), so computing the window in a
`useState` initializer would bake a build-time date into the HTML and mismatch on hydration.
Instead the default window is applied in a **client-only mount effect**, and the first list fetch
is held behind a `datesReady` flag — so the initial render is date-free (clean hydration) and
curators land directly on the windowed view instead of flashing the full backlog first.

## Scope

Client-only; **no backend change** (the controller already supports the confidence sort,
`entrez_date` range, and pagination). `tsc --noEmit` clean. Live smoke is SAML-walled — needs a
curator session on reciter-pm-dev after deploy.
