### PR TITLE
fix(search): restore Find People + Search UI regressions; route DOI check via PubMed tool

### DIFF
--- a/config/local.js
+++ b/config/local.js
@@ -119,10 +119,16 @@ export const reciterConfig = {
     /**
      * This endpoint is used to search pubmed. You need to have ReCiter-Pubmed-Retrieval tool conifgured. See https://github.com/wcmc-its/ReCiter-PubMed-Retrieval-Tool.git
      * for details.
+     *
+     * On prod these /pubmed/query-* routes live behind the same ingress as the
+     * ReCiter Spring Boot service, so RECITER_API_BASE_URL is sufficient. On
+     * dev the two services are separate (reciter-dev vs reciter-pubmed-dev),
+     * so RECITER_PUBMED_API_URL can override just these routes. Falls back to
+     * RECITER_API_BASE_URL when unset.
      */
     reciterPubmed: {
-        searchPubmedEndpoint: process.env.RECITER_API_BASE_URL + '/pubmed/query-complex/',
-        searchPubmedCountEndpoint: process.env.RECITER_API_BASE_URL + '/pubmed/query-number-pubmed-articles/',
+        searchPubmedEndpoint: (process.env.RECITER_PUBMED_API_URL || process.env.RECITER_API_BASE_URL) + '/pubmed/query-complex/',
+        searchPubmedCountEndpoint: (process.env.RECITER_PUBMED_API_URL || process.env.RECITER_API_BASE_URL) + '/pubmed/query-number-pubmed-articles/',
     },
     /**
      * PM#771 — OpenAlex is a free, keyless public API. It is queried ONLY server-side

--- a/controllers/pubmedLookup.controller.ts
+++ b/controllers/pubmedLookup.controller.ts
@@ -3,18 +3,31 @@
 // PubMed; if it is, the curator is steered to the PubMed accept path so the article
 // becomes scored evidence. OpenAlex's own PMID field is incomplete (~21% of
 // PubMed-indexed works lack it), so we ask PubMed directly by DOI.
-// ponytail: keyless eutils, fine at per-click volume; add an NCBI key if rate-limited.
+//
+// Routed through the ReCiter PubMed Retrieval Tool (query-complex) rather than a raw
+// eutils call: the tool holds PUBMED_API_KEY and the retry/backoff, so this DOI check
+// no longer risks unkeyed 429s from PM's server. The matching term is still `<doi>[AID]`
+// (Article Identifier), identical to the previous direct query.
 
-const EUTILS = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi'
+import { reciterConfig } from '../config/local'
 
 // Returns the PMID if the DOI resolves to a PubMed record, else null.
 export async function findPubmedByDoi(doi: string): Promise<number | null> {
     if (!doi) return null
-    const term = encodeURIComponent(`${doi}[AID]`)
-    const url = `${EUTILS}?db=pubmed&retmode=json&term=${term}`
-    const res = await fetch(url, { headers: { 'User-Agent': 'reciter-pub-manager-server' } })
-    if (!res.ok) throw new Error(`eutils HTTP ${res.status}`)
+    // strategy-query is concatenated raw into the PubMed term by the tool's PubMedQuery,
+    // so the [AID] tag survives the POST body unchanged.
+    const res = await fetch(reciterConfig.reciterPubmed.searchPubmedEndpoint, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': 'reciter-pub-manager-server',
+        },
+        body: JSON.stringify({ 'strategy-query': `${doi}[AID]` }),
+    })
+    if (!res.ok) throw new Error(`pubmed retrieval tool HTTP ${res.status}`)
     const data: any = await res.json()
-    const idlist = (data && data.esearchresult && data.esearchresult.idlist) || []
-    return idlist.length ? Number(idlist[0]) : null
+    // query-complex returns an array of PubMedArticle; PMID lives at
+    // medlinecitation.medlinecitationpmid.pmid.
+    const pmid = data?.[0]?.medlinecitation?.medlinecitationpmid?.pmid
+    return pmid ? Number(pmid) : null
 }

--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -782,7 +782,6 @@ const Search = () => {
                           <tr>
                             <th key="0">Name</th>
                             <th key="1">Affiliation</th>
-                            <th key="2">Institution</th>
                             {isCuratorAll || isSuperUser  ? <th key="3">Pending</th> : null}
                             <th key="4">Actions</th>
                           </tr>

--- a/src/components/elements/Search/SearchBar.tsx
+++ b/src/components/elements/Search/SearchBar.tsx
@@ -136,11 +136,10 @@ useEffect(() => {
                 onLoadMore={() => {}}
                 value=""
               />
+              <span style={{ flex: 1 }} />
+              <Button className="primary" type="submit" style={{ padding: '6px 20px', background: '#1a2133', borderColor: '#1a2133', borderRadius: '6px', fontSize: '14px', fontWeight: 600, fontFamily: 'inherit', whiteSpace: 'nowrap' }}>Search</Button>
+              <button type="button" className={styles.textButton} onClick={clearFilters} style={{ background: 'none', border: 'none', padding: 0, fontFamily: 'inherit', fontSize: '13px', color: '#a09a92', cursor: 'pointer', whiteSpace: 'nowrap' }}>Reset</button>
             </div>
-          </div>
-          <div className="d-flex flex-row align-items-center" style={{ gap: '10px' }}>
-            <Button className="primary" type="submit" style={{ padding: '8px 24px', background: '#c0392b', borderColor: '#c0392b', borderRadius: '5px', fontSize: '13px', fontWeight: 600, fontFamily: '"DM Sans", sans-serif' }}>Search</Button>
-            <div className={styles.textButton} onClick={clearFilters}>Reset</div>
           </div>
         </Form.Group>
       </Form>


### PR DESCRIPTION
Restores three Find People / Search UI regressions that were dropped when the Authorships + external-source work was re-ported onto `dev`, and routes the PubMed DOI check through the Retrieval Tool.

## Fixes

**1. Find People — column mismatch.** The results `<thead>` still carried a separate `Institution` column, but the body folds institution into the Affiliation cell (`primaryOrganizationalUnit` + `primaryInstitution`). Five headers against four cells shifted `Pending` and `Actions` under the wrong headings. Dropped the orphaned `<th>`; the header now matches the body (4 cells for curators/superusers, 3 otherwise), consistent with the existing `colSpan={... ? 4 : 3}` empty state.

**2. Search button — restore the navy CTA.** The button had been rebuilt as `#c0392b` (the reject-red) with a hardcoded DM Sans stack. STYLEGUIDE.md lists Search among the navy CTAs (`#1a2133`) and reserves WCM red for brand chrome. Reset is now a real `<button>` so it is keyboard-reachable.

**3. PubMed routing on dev.** Restored the `RECITER_PUBMED_API_URL` override in `config/local.js`. On dev the ReCiter service and the PubMed Retrieval Tool are separate deployments (`reciter-dev` vs `reciter-pubmed-dev`); without the override the `/pubmed/query-*` routes pointed at a service that does not serve them.

**4. DOI presence check via the Retrieval Tool.** `findPubmedByDoi` called eutils directly with no NCBI key, so under load PM's own server could be throttled (429). It now POSTs to the tool's `/pubmed/query-complex/`, reusing the same pattern `searchPubmed` already uses. The matching term stays `<doi>[AID]`, so results are identical; the tool supplies the API key and retry.

## Verification
- `tsc --noEmit`: touched files clean.
- Dev server boots clean; `/login` 200, `/search` 307 → login (SAML gate).
- PMID-extraction unit self-check passes (hit / miss / malformed / undefined).
- Not yet exercised end-to-end against a live PubMed tool, or visually with an authenticated session.
