### PR TITLE
fix(k8s): reconcile PM dev manifest with the live reciter-pm-dev deployment

### DIFF
--- a/kubernetes/k8-deployment.yaml
+++ b/kubernetes/k8-deployment.yaml
@@ -1,176 +1,218 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: reciter-pm
+  name: reciter-pm-dev
   namespace: reciter
   labels:
-    app: reciter-pm
-    environment: prod
+    app: reciter-pm-dev
+    environment: dev
     owner: szd2013
     tier: frontend
 spec:
   selector:
     matchLabels:
-      app: reciter-pm
+      app: reciter-pm-dev
       tier: frontend
   strategy:
+    type: RollingUpdate
     rollingUpdate:
+      maxSurge: 25%
       maxUnavailable: 0
   replicas: 1
   template:
     metadata:
       labels:
-        app: reciter-pm
-        environment: prod
+        app: reciter-pm-dev
+        environment: dev
         tier: frontend
         owner: szd2013
     spec:
       containers:
-      - image: reciter-publication-manager:prod
-        name: reciter-pm-prod
-        imagePullPolicy: IfNotPresent
-        env:
-          - name: NEXTAUTH_URL_INTERNAL
-            valueFrom: 
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key: NEXTAUTH_URL_INTERNAL
-          - name: NEXTAUTH_URL
-            valueFrom: 
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key: NEXTAUTH_URL
-          - name: RECITER_DB_NAME
-            valueFrom: 
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key: RECITER_DB_NAME
-          - name: RECITER_DB_USERNAME
-            valueFrom: 
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key: RECITER_DB_USERNAME
-          - name: RECITER_DB_PASSWORD
-            valueFrom: 
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key: RECITER_DB_PASSWORD
-          - name: RECITER_DB_HOST
-            valueFrom: 
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key: RECITER_DB_HOST
-           - name: RECITER_API_BASE_URL
-            valueFrom: 
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key: RECITER_API_BASE_URL                           
-         - name: LOGIN_PROVIDER
-            value: SAML
-          - name : ENTITY_ID
-            valueFrom:
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key: ENTITY_ID
-          - name: ASSERT_ENDPOINT
-            valueFrom:
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key:  ASSERT_ENDPOINT
-          - name: SSO_LOGIN_URL
-            valueFrom:
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key : SSO_LOGIN_URL
-          - name: SSO_LOGOUT_URL
-            valueFrom:
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key : SSO_LOGOUT_URL   
-          - name: SMTP_HOST_NAME
-            valueFrom:
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key : SMTP_HOST_NAME
-          - name: SMTP_USER
-            valueFrom:
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key : SMTP_USER 
-          - name: SMTP_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key : SMTP_PASSWORD 
-          - name: SMTP_ADMIN_EMAIL
-            valueFrom:
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key : SMTP_ADMIN_EMAIL 
-           - name: ASMS_API_BASE_URL
-            valueFrom: 
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key: ASMS_API_BASE_URL        
-          - name: ASMS_USER_TRACKING_API_AUTHORIZATON
-            valueFrom:
-              secretKeyRef:
-                name: reciter-pm-secrets
-                key : ASMS_USER_TRACKING_API_AUTHORIZATON           
-        ports:
-          - containerPort: 3000
-            name: reciter-pm
-        resources:
-          requests:
-            memory: 1500m
-            cpu: '0.7'
-          limits:
-            memory: 2G
-            cpu: '0.8'
-        livenessProbe:
-          httpGet:
-            path: "/api/healthcheck"
-            port: 3000
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          failureThreshold: 3
-          timeoutSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: "/api/healthcheck"
-            port: 3000
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          failureThreshold: 3
-          timeoutSeconds: 5
-      nodeSelector:
-          lifecycle: Ec2Spot
+        # ponytail: the pipeline owns the real tag via `kubectl set image`; ":dev" is a
+        # placeholder so a deliberate `kubectl apply` doesn't clobber the running image.
+        - image: 665083158573.dkr.ecr.us-east-1.amazonaws.com/wcmc/reciter/reciter-publication-manager:dev
+          name: reciter-pm
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NEXTAUTH_URL_INTERNAL
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: NEXTAUTH_URL_INTERNAL
+            - name: NEXTAUTH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: NEXTAUTH_URL
+            - name: NEXTAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: NEXTAUTH_SECRET
+            - name: RECITER_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: RECITER_DB_NAME
+            - name: RECITER_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: RECITER_DB_USERNAME
+            - name: RECITER_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: RECITER_DB_PASSWORD
+            - name: RECITER_DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: RECITER_DB_HOST
+            - name: RECITER_API_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: RECITER_API_BASE_URL
+            - name: NEXT_PUBLIC_LOGIN_PROVIDER
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: NEXT_PUBLIC_LOGIN_PROVIDER
+            - name: ENTITY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: ENTITY_ID
+            - name: ASSERT_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: ASSERT_ENDPOINT
+            - name: SSO_LOGIN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: SSO_LOGIN_URL
+            - name: SSO_LOGOUT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: SSO_LOGOUT_URL
+            - name: SMTP_HOST_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: SMTP_HOST_NAME
+            - name: SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: SMTP_USER
+            - name: SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: SMTP_PASSWORD
+            - name: SMTP_ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: SMTP_ADMIN_EMAIL
+            - name: ASMS_API_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: ASMS_API_BASE_URL
+            - name: ASMS_USER_TRACKING_API_AUTHORIZATON
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: ASMS_USER_TRACKING_API_AUTHORIZATON
+            - name: ACS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: ACS_URL
+            - name: NEXT_PUBLIC_RECITER_BACKEND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: NEXT_PUBLIC_RECITER_BACKEND_API_KEY
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=1792"
+            - name: RECITER_PUBMED_API_URL
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: RECITER_PUBMED_API_URL
+                  optional: true
+            - name: RECITER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: RECITER_API_KEY
+            - name: RECITER_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: reciter-pm-dev-secrets
+                  key: RECITER_TOKEN_SECRET
+            # ponytail: plain value (set imperatively on the live deployment); points PM's
+            # Scopus lookups at the Scopus Retrieval Tool. Prod value is http://reciter-scopus-prod.
+            - name: RECITER_SCOPUS_API_URL
+              value: http://reciter-scopus-dev
+          ports:
+            - containerPort: 3000
+              name: reciter-pm
+          resources:
+            requests:
+              memory: 1500Mi
+              cpu: 300m
+            limits:
+              memory: 2Gi
+              cpu: 800m
+          livenessProbe:
+            httpGet:
+              path: "/api/healthcheck"
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: "/api/healthcheck"
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 5
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: hpa-reciter-pm
+  name: hpa-reciter-pm-dev
   namespace: reciter
   labels:
-    app: reciter-pm
-    environment: prod
+    app: reciter-pm-dev
+    environment: dev
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: reciter-pm-dev
   minReplicas: 1
-  maxReplicas: 3
+  maxReplicas: 2
   metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 80
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: 85
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/kubernetes/k8-service.yaml
+++ b/kubernetes/k8-service.yaml
@@ -11,8 +11,8 @@ metadata:
     alb.ingress.kubernetes.io/healthcheck-port: traffic-port
     alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
   labels:
-    app: reciter-pm
-    environment: prod
+    app: reciter-pm-dev
+    environment: dev
     tier: frontend
     owner: szd2013
 spec:
@@ -22,6 +22,6 @@ spec:
       targetPort: 3000
       protocol: TCP
   selector:
-    app: reciter-pm
+    app: reciter-pm-dev
     tier: frontend
   type: NodePort


### PR DESCRIPTION
## Problem
`kubernetes/k8-deployment.yaml` is **invalid YAML** (inconsistent `env:` indentation at lines 63/68/110 — `python -c yaml.safe_load` and `kubectl apply` both reject it) and, structurally, an **orphan**: it declares a Deployment named `reciter-pm` labelled `environment: prod` that matches **no live object**. The live dev deployment is `reciter-pm-dev`. Because deploys only ever ran `kubectl set image` (never `kubectl apply`), this file silently rotted for 3+ years — it's missing ~10 env vars that are live, including `RECITER_PUBMED_API_URL` / `RECITER_SCOPUS_API_URL`, and still carries a dead `nodeSelector: lifecycle: Ec2Spot` (the same label that left scopus-dev Unschedulable).

Applying it as-is would have spawned a phantom `reciter-pm` pod behind the shared Service selector.

## Fix — reconcile to the running `reciter-pm-dev` (verified field-by-field with `kubectl diff`)
- **Valid YAML**; drop the dead `lifecycle: Ec2Spot` nodeSelector (live has none).
- name / labels / selector / container → `reciter-pm-dev`, `environment: dev`.
- **Full env list**, incl. `RECITER_PUBMED_API_URL` and `RECITER_SCOPUS_API_URL=http://reciter-scopus-dev` (were live-only via `kubectl set env`, now captured in git). Secret refs point at the real **`reciter-pm-dev-secrets`** (git file wrongly said `reciter-pm-secrets`). Vestigial `SCOPUS_API_KEY` / `SCOPUS_INST_TOKEN` dropped — unused since #797 removed PM's Elsevier creds, and the keys no longer exist in the secret.
- **HPA → `autoscaling/v2`** (`v2beta2` is removed on the cluster), `hpa-reciter-pm-dev` targeting `reciter-pm-dev`, `min 1 / max 2`.
- resources / probes / strategy matched to live.
- `k8-service.yaml` selector `app: reciter-pm` → `app: reciter-pm-dev` (git selector matched no live pods).

## Verification
`kubectl diff -f kubernetes/k8-deployment.yaml` against the live cluster shows the **only** remaining delta is the image tag (pipeline-managed via `set image`) and the auto-incremented `generation`. Every env var, resource, probe, label, selector, and the absent nodeSelector match live. Read-only; nothing was applied.

## Out of scope (deliberately deferred)
- **Buildspec still uses `kubectl set image`.** Wiring it to `kubectl apply` this manifest (the handoff's "real fix") needs per-env handling — prod deploys `reciter-pm-prod` from `master`/`master_Next14` with different name/labels/secret — plus a deliberate deploy window. Not safe to fold in here.
- **`k8-secrets.yaml` is still stale** (declares `reciter-pm-secrets`, missing several keys that live `reciter-pm-dev-secrets` carries). It uses `<<PLACEHOLDER>>` substitution; reconciling it is a separate careful pass.
- **Prod manifest** untouched (follow-up 5).