### PR TITLE
fix(deploy): apply the k8s manifest on dev deploys, not just set-image

### DIFF
--- a/k8-buildspec.yml
+++ b/k8-buildspec.yml
@@ -83,6 +83,12 @@ phases:
           kubectl set image deployment/reciter-pm-prod reciter-pm=$REPOSITORY_URI:$TAG -n $EKS_CLUSTER_NAME
         fi
         if expr "${BRANCH}" : ".*dev" >/dev/null ||  expr "${BRANCH}" : ".*dev_Upd_NextJS14" >/dev/null; then
+          # Reconcile the whole manifest (env/probes/HPA/service), not just the image, so config
+          # drift can't silently accumulate the way it did for years. Stamp the freshly-built tag
+          # into the manifest first so apply deploys the real image, not the ":dev" placeholder.
+          # Best-effort: if apply fails, the set-image below still ships the build (non-regressive).
+          sed -i.bak "s#reciter-publication-manager:dev#reciter-publication-manager:$TAG#" kubernetes/k8-deployment.yaml
+          kubectl apply -f kubernetes/k8-deployment.yaml -f kubernetes/k8-service.yaml -n $EKS_CLUSTER_NAME || echo "WARNING: kubectl apply failed; falling back to set-image"
           kubectl set image deployment/reciter-pm-dev reciter-pm=$REPOSITORY_URI:$TAG -n $EKS_CLUSTER_NAME
         fi
         if expr "${BRANCH}" : ".*master_Next14" >/dev/null; then


### PR DESCRIPTION
## Root cause this closes
The dev buildspec only ever ran `kubectl set image` — it **never `kubectl apply`d** `kubernetes/`. So the committed manifest was inert: env vars, probes, HPA, nodeSelector, and the Service selector all drifted from the live `reciter-pm-dev` for years with nobody noticing (that drift is exactly what #798 had to repair by hand). Same gap the Scopus Retrieval Tool hit — fixed there in its #32. This makes the PM dev pipeline actually reconcile its manifest.

## Change (dev arm only)
```sh
sed -i.bak "s#...reciter-publication-manager:dev#...:$TAG#" kubernetes/k8-deployment.yaml
kubectl apply -f kubernetes/k8-deployment.yaml -f kubernetes/k8-service.yaml -n $EKS_CLUSTER_NAME \
  || echo "WARNING: kubectl apply failed; falling back to set-image"
kubectl set image deployment/reciter-pm-dev reciter-pm=$REPOSITORY_URI:$TAG -n $EKS_CLUSTER_NAME
```
- Stamps the freshly-built tag into the manifest so `apply` ships the real image, not the `:dev` placeholder.
- **Non-regressive:** `apply` is best-effort; `set image` still runs unconditionally, so a manifest problem can never block a deploy.

## Why it's safe to land now
- #798 already made the dev manifest a **verified diff-clean mirror** of live `reciter-pm-dev` — `kubectl diff` shows only the image tag and `generation`. So the first-ever `apply` is a near-no-op adoption, not a surprise reconfiguration.
- Prod arm (`master_Next14`) deliberately untouched — wire it the same way after #799 lands.

## Verification done
- `k8-buildspec.yml` parses; the `sed` transform produces a valid, correctly-tagged image line and the post-sed manifest still parses (0 leftover placeholders).
- **Not** run against the cluster — this is the buildspec that *will* run on the next dev deploy.

## Deploy note for whoever merges
The first dev deploy after this is the first real `apply`. It's verified diff-clean, but do it in a low-traffic window and watch the rollout (`kubectl rollout status deployment/reciter-pm-dev -n reciter`).