### PR TITLE
feat(ui): switch typography from DM Sans/Space Grotesk to Inter

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -27,7 +27,7 @@ const theme = createTheme({
   },
   typography: {
     fontFamily: [
-      '"DM Sans"',
+      '"Inter"',
       '-apple-system',
       'BlinkMacSystemFont',
       '"Segoe UI"',
@@ -84,7 +84,7 @@ export default function App({ Component, pageProps: { session, ...pageProps } }:
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&family=Space+Grotesk:wght@500&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
       </Head>
       <ThemeProvider theme={theme}>
         <ReduxProvider store={store}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -63,8 +63,13 @@
   --radius-pill: 999px;
 
   /* Typography */
-  --font-sans: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  --font-serif: 'Space Grotesk', sans-serif;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-display: 'Inter', sans-serif;
+  /* --font-serif is a legacy alias of --font-display (kept so existing references resolve). */
+  --font-serif: var(--font-display);
+  /* Bootstrap's reboot is imported after globals.css and sets body font from this var;
+     point it at our stack so Inter actually reaches body text app-wide. */
+  --bs-body-font-family: var(--font-sans);
   --font-size-xs: 12px;
   --font-size-sm: 14px;
   --font-size-base: 16px;


### PR DESCRIPTION
Switches PM's typography from DM Sans / Space Grotesk / DM Mono to **Inter** (user-requested; the "robotic font" complaint). Ported in isolation from the calm-redesign navy work on origin/dev_Upd_NextJS14SNode18 (originates in e416dfe).

- globals.css: --font-sans → Inter; add --font-display: Inter; --font-serif aliases --font-display; add --bs-body-font-family so Bootstrap picks up Inter.
- _app.tsx: MUI theme → Inter; Google Fonts link loads only Inter.

Known residual (same as origin/dev_Upd_NextJS14SNode18 ships): ~12 files hard-code Space Grotesk/DM Mono without the CSS var and will fall back to system fonts — optional later polish. **Needs a quick visual check on reciter-dev after deploy.**