### PR TITLE
fix(curate): restore accept/reject persistence — drop invalid Content-Length, guard statusCode

### DIFF
--- a/controllers/goldstandard.controller.ts
+++ b/controllers/goldstandard.controller.ts
@@ -15,7 +15,6 @@ export async function updateGoldStandard(req: NextApiRequest)  {
         headers: {
             'Content-Type': 'application/json',
             'api-key': reciterConfig.reciter.adminApiKey,
-            'Content-Length': req.body.length,
             'User-Agent': 'reciter-pub-manager-server'
         },
         body: JSON.stringify(req.body)
@@ -39,7 +38,7 @@ export async function updateGoldStandard(req: NextApiRequest)  {
         .catch((error) => {
             console.log('ReCiter Update Goldstandard api is not reachable: ' + error)
             return {
-                statusCode: error.status,
+                statusCode: error.status || 500,
                 statusText: error
             }
         });

--- a/src/pages/api/reciter/update/goldstandard.ts
+++ b/src/pages/api/reciter/update/goldstandard.ts
@@ -18,6 +18,7 @@ export default async function handler(
 ) {
     if(req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+        try {
         const apiResponse = await updateGoldStandard(req);
         if(apiResponse.statusCode === 200) {
             res.status(apiResponse.statusCode).send({
@@ -25,10 +26,14 @@ export default async function handler(
                 goldStandard: apiResponse.statusText
             })
         } else{
-            res.status(apiResponse.statusCode).send({
-                statusCode: apiResponse.statusCode,
+            res.status(apiResponse.statusCode || 500).send({
+                statusCode: apiResponse.statusCode || 500,
                 message: apiResponse.statusText
             })
+        }
+        } catch (err) {
+            console.error('[goldstandard] Unhandled error:', err)
+            res.status(500).send({ statusCode: 500, message: 'Internal server error' })
         }
         } else if(req.headers.authorization === undefined) {
             res.status(400).send({


### PR DESCRIPTION
Restores accept/reject persistence dropped from Veer's dev rebuild (present on origin/dev_Upd_NextJS14SNode18, commits 51ed535 + 51f5377).

**Root cause:** dev's goldstandard.controller.ts sent `Content-Length: req.body.length` (req.body is an object → literal "undefined") and `statusCode: error.status` (undefined) in its catch. When ReCiter returns a non-JSON error, res.json() throws, statusCode is undefined, and `res.status(undefined)` corrupts the HTTP/2 stream (ERR_HTTP2_PROTOCOL_ERROR) — the accept silently fails to persist (matches Drew's report).

**Fix:** drop the invalid Content-Length header; guard statusCode with `|| 500`; wrap the endpoint in try/catch.

**Test:** accept pmid 42372714 for uid yrj9003 on reciter-dev, reload, confirm it sticks and there's no ERR_HTTP2_PROTOCOL_ERROR. Data-path fix (no visual change).