### PR TITLE
fix(reports): repair RTF export stored-proc argument counts

### DIFF
--- a/controllers/db/reports/publication.report.controller.ts
+++ b/controllers/db/reports/publication.report.controller.ts
@@ -45,10 +45,17 @@ export const generatePubsRtf = async (
     } else {
 
 																	   
+      // Stored procedure reciterdb.generatePubsNoPeopleRTF accepts a single
+      // arg (pmids); apiBody.limit is not honored here because the procedure
+      // signature was never updated to accept it. Caller applies a limit when
+      // staging the pmid list if it cares about cap.
+      const cappedPmids = typeof apiBody.limit === 'number' && apiBody.limit > 0
+        ? apiBody.pmids.slice(0, apiBody.limit)
+        : apiBody.pmids;
       generatePubsRtfOutput = await sequelize.query(
-        "CALL generatePubsNoPeopleRTF ( :pmids, :limit)",
+        "CALL generatePubsNoPeopleRTF ( :pmids )",
         {
-          replacements: { pmids: apiBody.pmids.join(','), limit: apiBody.limit },
+          replacements: { pmids: cappedPmids.join(',') },
           raw: true,
         }
       );

--- a/controllers/db/reports/publication.report.controller.ts
+++ b/controllers/db/reports/publication.report.controller.ts
@@ -34,9 +34,11 @@ export const generatePubsRtf = async (
 								
     if (apiBody.personIdentifiers && apiBody.personIdentifiers.length > 0) {
       generatePubsRtfOutput = await sequelize.query(
-        "CALL generatePubsRTF (:uids , :pmids, :limit)",
+        // generatePubsRTF takes 2 args (personIdentifierArray, pmidArray) — no limit.
+        // Passing :limit caused ER_SP_WRONG_NO_OF_ARGS (SequelizeDatabaseError).
+        "CALL generatePubsRTF (:uids , :pmids)",
         {
-          replacements: { uids: apiBody.personIdentifiers.join(','), pmids: apiBody.pmids.join(','), limit: apiBody.limit },
+          replacements: { uids: apiBody.personIdentifiers.join(','), pmids: apiBody.pmids.join(',') },
           raw: true,
         }
       );


### PR DESCRIPTION
Repairs RTF report export, which is actively broken on dev (present-and-fixed on origin/dev_Upd_NextJS14SNode18, PR #765 / commits 5dea011 + b1ac138).

**Bug:** publication.report.controller.ts calls generatePubsRTF with 3 args and generatePubsNoPeopleRTF with 2, but the deployed stored procedures take 2 and 1 → SequelizeDatabaseError on any person-filtered or no-people "Export to RTF".

**Fix:** match the call arg counts to the procedures.

NB: proc arity was verified 2/1 on the dev DB. Re-verify prod procedure signatures before any master_Next14 port.