### PR TITLE
fix(curate): retire Group Curation landing; gate the Curate Publications nav link

### DIFF
--- a/src/components/elements/Navbar/SideNavbar.tsx
+++ b/src/components/elements/Navbar/SideNavbar.tsx
@@ -203,6 +203,15 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
   const userPermissions = JSON.parse(session.data.userRoles);
   const isSuperuser = userPermissions.some((role: any) => role.roleLabel === "Superuser");
 
+  // A user "has their own profile" when they hold a Curator_Self role carrying a
+  // personIdentifier (faculty/postdoc who can curate themselves). Those users may open
+  // Curate Publications directly; everyone else (e.g. a Superuser with no profile of
+  // their own) must first pick a person from Find People, so the link stays disabled
+  // until a search is active.
+  const hasOwnProfile = userPermissions.some(
+    (role: any) => role.roleLabel === "Curator_Self" && role.personIdentifier
+  );
+
   const menuItems: Array<MenuItem> = [
     {
       title: 'Find People',
@@ -220,7 +229,10 @@ const SideNavbar: React.FC<SideNavBarProps> = () => {
       imgUrl: SettingsIconTools,
       imgUrlActive: settingsIconActive,
       muiIcon: <IconCurate />,
-      disabled: isSuperuser ? false : (Object.keys(filters).length === 0),
+      // Hidden-until-context: greyed out unless a Find People search is active, so a
+      // user with no profile of their own (e.g. Superuser) can't jump straight here.
+      // Users who have their own profile keep it enabled to curate themselves.
+      disabled: (Object.keys(filters).length === 0) && !hasOwnProfile,
       allowedRoleNames: ["Superuser", "Curator_All","Curator_Self"],
       isRequired:true
     },

--- a/src/pages/curate/index.js
+++ b/src/pages/curate/index.js
@@ -2,24 +2,21 @@ import CuratePublications from '../../components/elements/CuratePublications/Cur
 import { AppLayout } from "../../components/layouts/AppLayout"
 import { getSession } from "next-auth/react"
 
-/* export async function getServerSideProps(ctx) {
+// The group curation surface (the multi-person People/Org/Institution/Person-Type queue)
+// has been retired. A visitor who has their own profile (a Curator_Self role carrying a
+// personIdentifier) is sent straight to curate themselves; everyone else goes to Find
+// People to pick a person to curate.
+export async function getServerSideProps(ctx) {
     const session = await getSession(ctx);
-
-    if (!session || !session.data) {
-        return {
-            redirect: {
-                destination: "/login",
-                permanent: false,
-            },
-        };
-    }
-
+    const userRoles = session?.data?.userRoles ? JSON.parse(session.data.userRoles) : [];
+    const selfRole = userRoles.find((r) => r.roleLabel === "Curator_Self" && r.personIdentifier);
     return {
-        props: {
-            session: session,
+        redirect: {
+            destination: selfRole ? `/curate/${selfRole.personIdentifier}` : "/search",
+            permanent: false,
         },
     };
-} */
+}
 
 const PublicationsPage = () => {
     return (


### PR DESCRIPTION
Restores the curate-visibility behavior dropped from the dev rebuild (present on origin/dev_Upd_NextJS14SNode18, commits c434c13 + a55cdaa; also inside PR #769, which is not mergeable as-is because it's the whole 351-file rebuild).

- **curate/index.js:** the group-curation landing is retired. A self-curator with a profile is redirected to /curate/{their-id}; everyone else to /search. So the sidebar "Curate Publications" no longer dumps users into Group Curation.
- **SideNavbar.tsx:** the nav link is gated on having a search context or one's own profile.

Per-row curate gating in Search.js is already present on dev (unchanged). **Needs a visual/functional check on reciter-dev:** clicking Curate Publications routes to /search (no profile) or /curate/{id} (self), and /curate/[id] still works from the search Actions dropdown.