### PR TITLE
fix(reports): real download filename, Newest→Oldest sort label, sanitize inline HTML

### DIFF
--- a/src/components/elements/Report/ReportsResultPane.tsx
+++ b/src/components/elements/Report/ReportsResultPane.tsx
@@ -3,6 +3,7 @@ import styles from "./ReportsResultPane.module.css";
 import { AuthorsComponent } from "../Common/AuthorsComponent";
 import { Author } from "../../../../types/Author";
 import { setHelptextInfo, setReportFilterLabels, setReportFilterDisplayRank, setIsVisible } from "../../../utils/constants";
+import { sanitizeInlineHtml } from "../../../utils/htmlText";
 
 interface ReportsResultPaneProps {
   title: string
@@ -111,7 +112,7 @@ export const ReportsResultPane: React.FC<ReportsResultPaneProps> = ({
     <div className={styles.articleCard}>
       {/* Title + type badge */}
       <div className={styles.articleCardTop}>
-        <div className={styles.articleTitle} dangerouslySetInnerHTML={{ __html: title }} />
+        <div className={styles.articleTitle} dangerouslySetInnerHTML={{ __html: sanitizeInlineHtml(title) }} />
         <span className={styles.typeBadge}>{publicationTypeCanonical}</span>
       </div>
 

--- a/src/components/elements/Report/SearchSummary.tsx
+++ b/src/components/elements/Report/SearchSummary.tsx
@@ -16,6 +16,15 @@ import { ArrowLeft, ArrowRight } from "@mui/icons-material";
 import { setReportFilterDisplayRank, setReportFilterLabels,setIsVisible, setReportFilterKeyNames } from "../../../utils/constants";
 import { toast } from "react-toastify";
 import { reportError } from "../../../utils/reportError";
+import { stripHtml } from "../../../utils/htmlText";
+
+// Title/journal fields can carry PubMed inline markup (<i>, <sub>, …); strip to
+// plain text for spreadsheet cells, which can't render HTML.
+const HTML_BEARING_FIELDS = ['articleTitle', 'articleTitleRTF', 'journalTitleVerbose'];
+const stripHtmlFields = (row: any): any => {
+  HTML_BEARING_FIELDS.forEach((k) => { if (row && row[k]) row[k] = stripHtml(row[k]); });
+  return row;
+};
 
 
 const SearchSummary = ({
@@ -126,6 +135,7 @@ const SearchSummary = ({
       var link = document.createElement('a')  // once we have the file buffer BLOB from the post request we simply need to send a GET request to retrieve the file data
       link.href = window.URL.createObjectURL(fileBlob)
       link.download = fileName;
+      document.body.appendChild(link); // Chrome honors the download filename only for an anchor in the DOM; detached anchors save as a blob UUID.
       link.click()
       link.remove();
       setExportArticleLoading(false);
@@ -172,6 +182,7 @@ const SearchSummary = ({
       var link = document.createElement('a')  // once we have the file buffer BLOB from the post request we simply need to send a GET request to retrieve the file data
       link.href = window.URL.createObjectURL(fileBlob)
       link.download = fileName;
+      document.body.appendChild(link); // Chrome honors the download filename only for an anchor in the DOM; detached anchors save as a blob UUID.
       link.click()
       link.remove();
       setExportArticlePplLoading(false);
@@ -292,7 +303,7 @@ const SearchSummary = ({
         })
         itemRow = {...itemRow, authors: item.authors?.replace(/[\])}[{(]/g, '')};
         itemRow = {...itemRow, authorPosition: item.authorPosition?.replace(/[\])}[{(]/g, '')};
-        worksheet.addRow(itemRow);
+        worksheet.addRow(stripHtmlFields(itemRow));
       })
 
       // write the content using writeBuffer
@@ -302,6 +313,7 @@ const SearchSummary = ({
       var link = document.createElement('a')  // once we have the file buffer BLOB from the post request we simply need to send a GET request to retrieve the file data
       link.href = window.URL.createObjectURL(blobFromBuffer);
       link.download = fileName;
+      document.body.appendChild(link); // Chrome honors the download filename only for an anchor in the DOM; detached anchors save as a blob UUID.
       link.click()
       link.remove();
     } catch (error) {
@@ -390,7 +402,7 @@ const SearchSummary = ({
         })
         itemRow = {...itemRow, authors: item.authors?.replace(/[\])}[{(]/g, '')};
         itemRow = {...itemRow, authorPosition: item.authorPosition?.replace(/[\])}[{(]/g, '')};
-        worksheet.addRow(itemRow);
+        worksheet.addRow(stripHtmlFields(itemRow));
       })
 
       // write the content using writeBuffer
@@ -400,6 +412,7 @@ const SearchSummary = ({
       var link = document.createElement('a')  // once we have the file buffer BLOB from the post request we simply need to send a GET request to retrieve the file data
       link.href = window.URL.createObjectURL(blobFromBuffer);
       link.download = fileName;
+      document.body.appendChild(link); // Chrome honors the download filename only for an anchor in the DOM; detached anchors save as a blob UUID.
       link.click()
       link.remove();
     } catch (error) {
@@ -445,6 +458,8 @@ const SearchSummary = ({
             formattedSortOptions.map((sortOption, index) => {
               const {labelName, keyName} = sortOption || {};
               const isActive = selected.type === keyName;
+              // Date columns read oddly as "High → Low"; show newest/oldest instead.
+              const isDateSort = /date/i.test(keyName || '') || /date/i.test(labelName || '');
               return (
                 <div key={index} className={`${styles.sortItem} ${isActive ? styles.sortItemActive : ''}`}>
                   <span className={styles.sortLabel}>{labelName}</span>
@@ -452,11 +467,11 @@ const SearchSummary = ({
                     <button
                       className={`${styles.sortToggleBtn} ${isActive && selected.order === 'DESC' ? styles.sortToggleBtnActive : ''}`}
                       onClick={() => onClick(keyName, 'DESC')}
-                    >↓ High</button>
+                    >↓ {isDateSort ? 'Newest' : 'High'}</button>
                     <button
                       className={`${styles.sortToggleBtn} ${isActive && selected.order === 'ASC' ? styles.sortToggleBtnActive : ''}`}
                       onClick={() => onClick(keyName, 'ASC')}
-                    >↑ Low</button>
+                    >↑ {isDateSort ? 'Oldest' : 'Low'}</button>
                   </div>
                 </div>
               )


### PR DESCRIPTION
Three report-display fixes dropped from the dev rebuild (from origin/dev_Upd_NextJS14SNode18):
- **Real download filename** (#768 / 4a57b08): exports were saving under a blob UUID; appending the anchor to the DOM before click restores the ArticleReport-ReCiter-<date> name.
- **Date-sort label** (a322357): shows "Newest → Oldest" / "Oldest → Newest".
- **Sanitize inline HTML** (#750 / 36c55ce): ReportsResultPane rendered titles via unsanitized dangerouslySetInnerHTML (mild XSS surface) and let raw <i>/<sub> leak — now routed through the existing src/utils/htmlText.tsx sanitizer (as Authorships already does on dev).

**Needs a visual check** on report titles (italics/sub/sup render, not raw tags) and an export download (correct filename).