### PR TITLE
fix(ui): scrub hard-coded Space Grotesk/DM Sans to Inter

### DIFF
--- a/src/components/elements/AddUser/AddUser.module.css
+++ b/src/components/elements/AddUser/AddUser.module.css
@@ -21,7 +21,7 @@
 
 /* ── Page title ── */
 .pageTitle {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-weight: 500;
   font-size: 26px;
   letter-spacing: -0.02em;

--- a/src/components/elements/Manage/AdminSettings.module.css
+++ b/src/components/elements/Manage/AdminSettings.module.css
@@ -1,6 +1,6 @@
 /* ── Page header ── */
 .pageTitle {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-weight: 500;
   font-size: 28px;
   letter-spacing: -0.02em;

--- a/src/components/elements/Manage/ManageUsers.module.css
+++ b/src/components/elements/Manage/ManageUsers.module.css
@@ -7,7 +7,7 @@
 }
 
 .pageTitle {
-  font-family: 'Space Grotesk', var(--font-serif), sans-serif;
+  font-family: 'Inter', var(--font-serif), sans-serif;
   font-weight: 500;
   font-size: 28px;
   letter-spacing: -0.02em;

--- a/src/components/elements/ManageProfile/ManageProfile.module.css
+++ b/src/components/elements/ManageProfile/ManageProfile.module.css
@@ -1,6 +1,6 @@
 /* ── Page title ── */
 .pageTitle {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-weight: 500;
   font-size: 28px;
   letter-spacing: -0.02em;
@@ -54,7 +54,7 @@
   font-size: 18px;
   font-weight: 700;
   color: #fff;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: 'Inter', sans-serif;
   letter-spacing: -0.02em;
 }
 .orcidIntroTitle {
@@ -304,7 +304,7 @@
   border: 1px solid #ddd7ce;
   border-radius: 5px;
   font-size: 13px;
-  font-family: 'DM Sans', monospace;
+  font-family: 'Inter', monospace;
   background: #fff;
   color: #1a2133;
   outline: none;
@@ -320,7 +320,7 @@
 .fieldInput::placeholder {
   color: #8a94a6;
   letter-spacing: 0;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 
 /* ── Buttons ── */

--- a/src/components/elements/Navbar/SideNavbar.tsx
+++ b/src/components/elements/Navbar/SideNavbar.tsx
@@ -179,7 +179,7 @@ const StyledList = styled(List)({
   '& .MuiListItemText-primary': {
     fontSize: '13px',
     lineHeight: 'normal',
-    fontFamily: '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+    fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
   },
   '& .MuiBox-root': {
     '.MuiListItem-root': {

--- a/src/components/elements/Notifications/Notifications.module.css
+++ b/src/components/elements/Notifications/Notifications.module.css
@@ -1,6 +1,6 @@
 /* ── PAGE HEADER ── */
 .header {
-  font-family: 'Space Grotesk', var(--font-serif), sans-serif;
+  font-family: 'Inter', var(--font-serif), sans-serif;
   font-weight: 500;
   font-size: 28px;
   letter-spacing: -0.02em;
@@ -187,7 +187,7 @@
 }
 
 .sliderValueNum {
-  font-family: 'Space Grotesk', var(--font-serif), sans-serif;
+  font-family: 'Inter', var(--font-serif), sans-serif;
   font-weight: 500;
   font-size: 24px;
   color: #1a2133;
@@ -279,7 +279,7 @@
   border: 1px solid #ddd7ce;
   border-radius: 5px;
   font-size: 13px;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   background: #eeeae4;
   color: #1a2133;
   cursor: pointer;
@@ -345,7 +345,7 @@
   border-radius: 5px;
   font-size: 13px;
   font-weight: 600;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   cursor: pointer;
   transition: background 0.15s;
   display: flex;
@@ -374,7 +374,7 @@
   border: 1px solid #ddd7ce;
   border-radius: 5px;
   font-size: 13px;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   cursor: pointer;
   transition: all 0.15s;
 }

--- a/src/components/elements/Publication/Publication.module.css
+++ b/src/components/elements/Publication/Publication.module.css
@@ -518,7 +518,7 @@
 .chartVal {
   font-size: 12px;
   font-weight: 700;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: 'Inter', sans-serif;
   white-space: nowrap;
 }
 
@@ -812,7 +812,7 @@
 }
 
 .stVal {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-size: 13px;
   font-weight: 500;
   color: #fff;
@@ -834,7 +834,7 @@
 }
 
 .scoreInline {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-weight: 400;
   font-size: 16px;
   letter-spacing: -0.01em;
@@ -1330,7 +1330,7 @@
 }
 
 .pointsValue {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-weight: 500;
   font-size: 12px;
   color: var(--gray-600);
@@ -1464,7 +1464,7 @@
 }
 
 .stVal {
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-size: 13px;
   font-weight: 500;
   color: #fff;

--- a/src/components/elements/Report/ChecboxSelect.module.css
+++ b/src/components/elements/Report/ChecboxSelect.module.css
@@ -18,7 +18,7 @@
   border: none;
   background: transparent;
   font-size: 12.5px;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   color: #1a2133;
   outline: none;
 }
@@ -151,7 +151,7 @@
   cursor: pointer;
   background: none;
   border: none;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   transition: color 0.15s;
   padding: 0;
 }

--- a/src/components/elements/Report/DatePicker.module.css
+++ b/src/components/elements/Report/DatePicker.module.css
@@ -21,7 +21,7 @@
   color: #8a94a6;
   background: none;
   border: none;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   cursor: pointer;
   transition: color 0.15s;
   padding: 0;
@@ -58,7 +58,7 @@
   border: 1px solid #ddd7ce;
   border-radius: 5px;
   font-size: 12.5px;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   background: #eeeae4;
   color: #8a94a6;
   outline: none;
@@ -111,7 +111,7 @@
   font-size: 11.5px;
   font-weight: 500;
   color: #5a6478;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   cursor: pointer;
   transition: all 0.15s;
   text-align: center;

--- a/src/components/elements/Report/ExportModal.module.css
+++ b/src/components/elements/Report/ExportModal.module.css
@@ -60,7 +60,7 @@
 }
 
 .title {
-  font-family: 'Space Grotesk', var(--font-serif), sans-serif;
+  font-family: 'Inter', var(--font-serif), sans-serif;
   font-weight: 500;
   font-size: 17px;
   letter-spacing: -0.02em;
@@ -116,7 +116,7 @@
 }
 
 .statNum {
-  font-family: 'Space Grotesk', var(--font-serif), sans-serif;
+  font-family: 'Inter', var(--font-serif), sans-serif;
   font-weight: 500;
   font-size: 22px;
   letter-spacing: -0.02em;
@@ -217,7 +217,7 @@
   border-radius: 5px;
   font-size: 12.5px;
   font-weight: 600;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   cursor: pointer;
   transition: background 0.15s;
   white-space: nowrap;
@@ -264,7 +264,7 @@
   border: 1px solid #ddd7ce;
   border-radius: 5px;
   font-size: 12.5px;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   cursor: pointer;
   transition: all 0.15s;
   white-space: nowrap;

--- a/src/components/elements/Report/SearchSummary.module.css
+++ b/src/components/elements/Report/SearchSummary.module.css
@@ -111,7 +111,7 @@
   border: none;
   color: #8a94a6;
   cursor: pointer;
-  font-family: 'DM Sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   transition: all 0.12s;
   display: flex;
   align-items: center;

--- a/src/components/elements/Report/SliderFilter.tsx
+++ b/src/components/elements/Report/SliderFilter.tsx
@@ -80,7 +80,7 @@ export const SliderFilter: React.FC<SliderFilterProps> = ({ reportFiltersLabes, 
               value={currentValues[0] ?? min}
               style={{
                 width: '100%', padding: '6px 8px', border: '1px solid #ddd7ce', borderRadius: 5,
-                fontSize: 12, fontFamily: "'DM Sans', sans-serif", background: '#eeeae4', color: '#1a2133',
+                fontSize: 12, fontFamily: "'Inter', sans-serif", background: '#eeeae4', color: '#1a2133',
                 outline: 'none', textAlign: 'center'
               }}
             />
@@ -94,7 +94,7 @@ export const SliderFilter: React.FC<SliderFilterProps> = ({ reportFiltersLabes, 
               value={currentValues[1] ?? max}
               style={{
                 width: '100%', padding: '6px 8px', border: '1px solid #ddd7ce', borderRadius: 5,
-                fontSize: 12, fontFamily: "'DM Sans', sans-serif", background: '#eeeae4', color: '#1a2133',
+                fontSize: 12, fontFamily: "'Inter', sans-serif", background: '#eeeae4', color: '#1a2133',
                 outline: 'none', textAlign: 'center'
               }}
             />

--- a/src/components/elements/Search/FilterReview.tsx
+++ b/src/components/elements/Search/FilterReview.tsx
@@ -55,7 +55,7 @@ const FilterReview = ({
       borderRadius: '0 !important',
       fontSize: '12px',
       fontWeight: 600,
-      fontFamily: '"DM Sans", sans-serif',
+      fontFamily: '"Inter", sans-serif',
       padding: '5px 12px',
       minHeight: 'auto',
       lineHeight: 'normal',

--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -500,7 +500,7 @@ const Search = () => {
       borderRadius: '0 !important',
       fontSize: '12px',
       fontWeight: 600,
-      fontFamily: '"DM Sans", sans-serif',
+      fontFamily: '"Inter", sans-serif',
       padding: '5px 12px',
       minHeight: 'auto',
       lineHeight: 'normal',

--- a/src/components/elements/Search/Search.module.css
+++ b/src/components/elements/Search/Search.module.css
@@ -47,7 +47,7 @@
 }
 
 .resultsCountNumber {
-  font-family: 'Space Grotesk', var(--font-serif), sans-serif;
+  font-family: 'Inter', var(--font-serif), sans-serif;
   font-weight: 500;
   font-size: 22px;
   color: #c0392b;


### PR DESCRIPTION
Follow-up to #801. #801 flipped the CSS `--font-*` variables to Inter, but ~30 references across component CSS modules and inline styles **hard-code** `'Space Grotesk'`/`'DM Sans'` directly (Publication cards, Notifications, Report controls, nav), never going through the variable — so those elements kept rendering the old fonts. Space Grotesk in particular persists because the browser caches the font file even after it's no longer loaded.

Scrubs all 30 hard-coded `Space Grotesk`/`DM Sans` → `Inter` across 15 files. `DM Mono` (one field in Search) left as-is — it falls back to system monospace, not the robotic heading font.

Testers may need a hard refresh to clear the cached Space Grotesk font.