### PR TITLE
fix(nav): highlight sidebar item on its route and sub-routes

### DIFF
--- a/src/components/elements/Navbar/MenuListItem.tsx
+++ b/src/components/elements/Navbar/MenuListItem.tsx
@@ -17,7 +17,15 @@ const MenuListItem: React.FC<MenuItem> = ({ title, to, id, imgUrl, imgUrlActive,
   }
 
   const pathName = customRouterPathNames(router.pathname);
-  const selected = to.includes(pathName);
+  // Highlight this item only when the current route IS its route or a sub-route of it
+  // (e.g. Curate Publications stays lit on /curate/[id]). The last clause keeps the
+  // notifications/manageprofile items lit, whose `to` carries the username while
+  // pathName is normalized to the base. The trailing '/' guards against sibling
+  // prefixes (e.g. /report must not match /reportbuilder).
+  const selected =
+    to === pathName ||
+    pathName.startsWith(to + '/') ||
+    to.startsWith(pathName + '/');
 
   const renderIcon = () => {
     if (muiIcon) return muiIcon;


### PR DESCRIPTION
## What
`MenuListItem` computed `selected = to.includes(pathName)`. On a sub-route like `/curate/[id]`, the current `pathName` is *longer* than the item's `to` (`/curate`), so `includes()` returned false and **Curate Publications stopped highlighting** once you opened a person's curate page.

## Fix
Match when the current route **is** the item's route or a **sub-route** of it:
```ts
const selected =
  to === pathName ||
  pathName.startsWith(to + '/') ||   // /curate stays lit on /curate/[id]
  to.startsWith(pathName + '/');     // notifications/manageprofile: 'to' carries the username
```
The trailing `/` guards sibling prefixes (e.g. `/report` must not light up on `/reportbuilder`).

## Verification
Logic checked against all sidebar items and the bug case:
- `/curate` lit on both `/curate` and `/curate/[id]` ✓
- Find People lit on `/search` (Superuser landing) ✓
- `/report` **not** lit on a hypothetical `/reportbuilder` ✓
- notifications / manageprofile still lit (their `to` includes the username) ✓
- no item over-matches another

Follow-up to #804 (per the dev-recovery handoff, task 2). No local build (Dropbox worktree, no node_modules) — compile gate is the dev CodeBuild.