### PR TITLE
feat(curate): per-card History panel — provenance + curation history

### DIFF
--- a/config/local.js
+++ b/config/local.js
@@ -100,6 +100,11 @@ export const reciterConfig = {
         reciterUpdateGoldStandardEndpoint:
                 process.env.RECITER_API_BASE_URL + '/reciter/goldstandard',
         /**
+         * Read-only curation audit history (FeedbackLog + ArticleProvenance) by uid.
+         */
+        reciterFeedbackLogEndpoint:
+                process.env.RECITER_API_BASE_URL + '/reciter/feedback-log/',
+        /**
          * PM#771 — external-source (OpenAlex/Scopus/WoS) manual-add publications.
          * POST/GET/DELETE against the same Java ingress as the other /reciter/* calls,
          * so RECITER_API_BASE_URL + the admin api-key are sufficient (no new env var).

--- a/controllers/db/manage-users/user.controller.ts
+++ b/controllers/db/manage-users/user.controller.ts
@@ -8,6 +8,33 @@ models.AdminUser.hasMany(models.AdminUsersDepartment, {as:'AdminUserDept', const
 models.AdminUser.hasOne(models.Person, {as:'person', constraints: false,foreignKey:"personIdentifier" });
 models.AdminUser.hasMany(models.AdminDepartment, {as:'AdminDepartment', constraints: false,foreignKey:"departmentID" });
 
+/**
+ * Resolve a set of admin_users.userID values to display names, for the curation
+ * Audit History (FeedbackLog.curatedBy). Returns a { userID: name } map; ids that
+ * are missing/invalid (e.g. 0 = unknown) are simply absent from the map.
+ */
+export const findAdminUserNamesByIds = async (ids: number[]): Promise<{ [id: number]: string }> => {
+  const map: { [id: number]: string } = {};
+  const valid = (ids || []).filter((id) => Number.isInteger(id) && id > 0);
+  if (valid.length === 0) {
+    return map;
+  }
+  try {
+    const users: any[] = await models.AdminUser.findAll({
+      where: { userID: { [Op.in]: valid } },
+      attributes: ['userID', 'nameFirst', 'nameLast'],
+      raw: true,
+    });
+    users.forEach((u) => {
+      const name = [u.nameFirst, u.nameLast].filter(Boolean).join(' ').trim();
+      map[u.userID] = name || String(u.userID);
+    });
+  } catch (e) {
+    console.log('findAdminUserNamesByIds error', e);
+  }
+  return map;
+};
+
 export const listAllUsers = async (
   req: NextApiRequest,
   res: NextApiResponse

--- a/controllers/featuregenerator.controller.ts
+++ b/controllers/featuregenerator.controller.ts
@@ -3,6 +3,7 @@ import { NextApiRequest } from 'next'
 import httpBuildQuery from 'http-build-query'
 import url from 'url'
 import { deleteUserFeedback, findUserFeedback } from './userfeedback.controller'
+import { attachArticleProvenance } from '../src/lib/articleProvenance'
 
 export async function getPublications(uid: string | string[], req: NextApiRequest)  {
 
@@ -32,6 +33,10 @@ export async function getPublications(uid: string | string[], req: NextApiReques
                     }
                 } else {
                     let data: any = await res.json()
+                    // Enrich with first-retrieval date from DynamoDB ArticleProvenance
+                    // (on-the-fly, per (personIdentifier, pmid)). Non-fatal.
+                    const personIdentifier = Array.isArray(uid) ? uid[0] : uid
+                    await attachArticleProvenance(personIdentifier, data)
                     let finalData = await getPendingFeedback(uid, data)
                     return {
                         statusCode: res.status,

--- a/controllers/feedbacklog.controller.ts
+++ b/controllers/feedbacklog.controller.ts
@@ -1,0 +1,28 @@
+import { reciterConfig } from '../config/local'
+
+/**
+ * Phase 34: fetch curation audit history (FeedbackLog + ArticleProvenance) for a uid
+ * from the ReCiter engine. Returns { statusCode, data } on success or
+ * { statusCode, statusText } on error. Never throws.
+ */
+export async function getFeedbackLog(uid: string): Promise<{ statusCode: number; data?: any; statusText?: string }> {
+    return fetch(`${reciterConfig.reciter.reciterFeedbackLogEndpoint}${encodeURIComponent(uid)}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            'api-key': reciterConfig.reciter.adminApiKey,
+            'User-Agent': 'reciter-pub-manager-server'
+        }
+    })
+        .then(async (res) => {
+            if (res.status !== 200) {
+                return { statusCode: res.status, statusText: await res.text() }
+            }
+            const data: any = await res.json()
+            return { statusCode: 200, data }
+        })
+        .catch((error) => {
+            console.log('ReCiter feedback-log api is not reachable: ' + error)
+            return { statusCode: error.status || 500, statusText: String(error) }
+        })
+}

--- a/kubernetes/k8-deployment.yaml
+++ b/kubernetes/k8-deployment.yaml
@@ -27,6 +27,10 @@ spec:
         tier: frontend
         owner: szd2013
     spec:
+      # IRSA: grants read-only DynamoDB access to ArticleProvenance (PM #737).
+      # The reciter-pm service account is bound to an IAM role via eksctl; the
+      # buildspec's `kubectl apply` must keep this or the provenance read loses creds.
+      serviceAccountName: reciter-pm
       containers:
         # ponytail: the pipeline owns the real tag via `kubectl set image`; ":dev" is a
         # placeholder so a deliberate `kubectl apply` doesn't clobber the running image.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate-models": "node ./src/db/scripts/generateModels.js"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.726.0",
     "@babel/runtime": "^7.17.8",
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",

--- a/src/components/elements/Publication/Publication.module.css
+++ b/src/components/elements/Publication/Publication.module.css
@@ -1094,6 +1094,30 @@
   font-style: italic;
 }
 
+/* Provenance block (top section of the History popover) */
+.provBlock {
+  padding: 8px 14px;
+}
+
+.provRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 3px 0;
+  font-size: 12px;
+}
+
+.provLabel {
+  color: #8a94a6;
+  white-space: nowrap;
+}
+
+.provValue {
+  color: #1a2133;
+  font-weight: 600;
+  text-align: right;
+}
+
 /* ── Card right column (inline undo for actioned cards) ── */
 
 .cardRight {

--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -16,6 +16,50 @@ import { sanitizeInlineHtml } from "../../../utils/htmlText";
 const pubMedUrl = 'https://www.ncbi.nlm.nih.gov/pubmed/';
 const doiUrl = 'https://doi.org/';
 
+// Friendly labels for ReCiter ArticleProvenance fields (src = source, rs = retrieval strategy).
+// Unmapped values fall back to a cleaned raw value, so nothing is ever hidden.
+const PROV_SOURCE_LABELS: Record<string, string> = {
+  GS: 'Gold standard',
+  PM: 'Publication Manager',
+  CTSC: 'CTSC',
+  MAN: 'Manual',
+  MAN_FROM_PM: 'Manual (via Publication Manager)',
+  MAN_FROM_CTSC: 'Manual (via CTSC)',
+};
+// ArticleProvenance.rs stores either a legacy short code (FNI, EMAIL, …) or the
+// full retrieval-strategy class name (FirstNameInitialRetrievalStrategy, …),
+// depending on when the row was written. Map both forms to one spelled-out label.
+const PROV_STRATEGY_LABELS: Record<string, string> = {
+  // legacy short codes (production data)
+  FNI: 'First-name initial',
+  SI: 'Second initial',
+  FN: 'Full name',
+  EMAIL: 'Email',
+  ORC: 'ORCID',
+  AFF: 'Affiliation',
+  AFFD: 'Affiliation (in database)',
+  DEP: 'Department',
+  REL: 'Known relationship',
+  GR: 'Grant',
+  GS: 'Gold standard',
+  // full strategy class names (current ReCiter)
+  FirstNameInitialRetrievalStrategy: 'First-name initial',
+  SecondInitialRetrievalStrategy: 'Second initial',
+  FullNameRetrievalStrategy: 'Full name',
+  EmailRetrievalStrategy: 'Email',
+  OrcidRetrievalStrategy: 'ORCID',
+  AffiliationRetrievalStrategy: 'Affiliation',
+  AffiliationInDbRetrievalStrategy: 'Affiliation (in database)',
+  DepartmentRetrievalStrategy: 'Department',
+  KnownRelationshipRetrievalStrategy: 'Known relationship',
+  GrantRetrievalStrategy: 'Grant',
+  GoldStandardRetrievalStrategy: 'Gold standard',
+};
+const friendlyProvSource = (v?: string | null): string | null =>
+  v ? (PROV_SOURCE_LABELS[v] || v) : null;
+const friendlyProvStrategy = (v?: string | null): string | null =>
+  v ? (PROV_STRATEGY_LABELS[v] || v.replace(/RetrievalStrategy$/, '').replace(/([a-z0-9])([A-Z])/g, '$1 $2').trim()) : null;
+
 //TEMP: update to required
 interface FuncProps {
     onAccept?(pmid: number, id: number): void,
@@ -174,6 +218,7 @@ const Publication: FunctionComponent<FuncProps> = (props) => {
 
     const { reciterArticle } = props;
     const clogEntries = feedbacklog[reciterArticle.pmid] || [];
+    const hasProvenance = !!(reciterArticle.firstRetrievalDate || reciterArticle.retrievalStrategy || reciterArticle.retrievalSource);
 
     const CardFooter = ({pmid, userAssertion} : {
       pmid: number,
@@ -847,18 +892,34 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
                 <div className={styles.articleLinksLeft}>
                   <span>PMID: <a href={`${pubMedUrl}${reciterArticle.pmid}`} target="_blank" rel="noreferrer">{reciterArticle.pmid}</a></span>
                   {reciterArticle.doi && <span><a href={`${doiUrl}${reciterArticle.doi}`} target="_blank" rel="noreferrer">DOI ↗</a></span>}
-                  {Object.keys(feedbacklog).length > 0 && (
+                  {(hasProvenance || clogEntries.length > 0) && (
                     <span className={styles.curationWrap} ref={curationLogRef}>
-                      <button className={styles.evidenceBtn} onClick={(e) => { e.stopPropagation(); setShowCurationLog(!showCurationLog); }}>Curation log</button>
+                      <button className={styles.evidenceBtn} onClick={(e) => { e.stopPropagation(); setShowCurationLog(!showCurationLog); }}>History</button>
                       {showCurationLog && (
                         <div className={styles.curationLogPopover}>
+                          <div className={styles.clogHead}>Provenance</div>
+                          {hasProvenance ? (
+                            <div className={styles.provBlock}>
+                              {reciterArticle.firstRetrievalDate && (
+                                <div className={styles.provRow}><span className={styles.provLabel}>First retrieved</span><span className={styles.provValue}>{reciterArticle.firstRetrievalDate}</span></div>
+                              )}
+                              {reciterArticle.retrievalStrategy && (
+                                <div className={styles.provRow}><span className={styles.provLabel}>Strategy</span><span className={styles.provValue}>{friendlyProvStrategy(reciterArticle.retrievalStrategy)}</span></div>
+                              )}
+                              {reciterArticle.retrievalSource && (
+                                <div className={styles.provRow}><span className={styles.provLabel}>Source</span><span className={styles.provValue}>{friendlyProvSource(reciterArticle.retrievalSource)}</span></div>
+                              )}
+                            </div>
+                          ) : (
+                            <div className={styles.clogEmpty}>Retrieval details unavailable</div>
+                          )}
                           <div className={styles.clogHead}>Curation history</div>
                           {clogEntries.length > 0 ? (
                             clogEntries.map((entry: any, i: number) => {
                               const action = entry.feedback === 'ACCEPTED' ? 'accepted' : entry.feedback === 'REJECTED' ? 'rejected' : 'undone';
                               const verb = entry.feedback === 'ACCEPTED' ? 'Accepted' : entry.feedback === 'REJECTED' ? 'Rejected' : 'Suggested';
-                              const who = entry.AdminUser?.personIdentifier || '';
-                              const date = formatClogDate(entry.modifyTimestamp);
+                              const who = entry.curatorName || 'Unknown';
+                              const date = entry.modifyTimestamp ? formatClogDate(entry.modifyTimestamp) : '';
                               return (
                                 <div className={styles.clogEntry} key={entry.feedbackID || i}>
                                   <div className={styles.clogAction}>

--- a/src/lib/articleProvenance.ts
+++ b/src/lib/articleProvenance.ts
@@ -1,0 +1,139 @@
+// src/lib/articleProvenance.ts
+//
+// On-the-fly lookup of first-retrieval provenance from the ReCiter DynamoDB
+// `ArticleProvenance` table, for the "date a publication was first retrieved"
+// display on /curate (issue #737).
+//
+// ArticleProvenance has a composite key uid (HASH = personIdentifier/CWID) +
+// articleId (RANGE = PMID as a String). frd = first retrieval date (epoch
+// SECONDS, immutable), rs = retrieval strategy, src = source.
+//
+// We read on demand (BatchGetItem) for the publications on the page rather than
+// materializing the ~11M-row table into MySQL nightly: the access pattern is a
+// per-(person, article) point lookup, which is exactly this table's key.
+//
+// Auth: the DynamoDBClient uses the AWS SDK default credential provider chain —
+// the pod's IRSA role in prod (service account `reciter-pm`), and local AWS
+// env/SSO creds in dev. No static keys.
+
+import { DynamoDBClient, BatchGetItemCommand } from '@aws-sdk/client-dynamodb'
+
+const REGION = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1'
+const TABLE = 'ArticleProvenance'
+const BATCH_SIZE = 100 // BatchGetItem hard limit per request
+
+let client: DynamoDBClient | null = null
+function getClient(): DynamoDBClient {
+  if (!client) {
+    client = new DynamoDBClient({ region: REGION })
+  }
+  return client
+}
+
+export interface ArticleProvenanceRecord {
+  firstRetrievalDate: string | null // display date, e.g. "Jan 31, 2025" (UTC)
+  firstRetrievalEpoch: number | null // raw epoch seconds
+  retrievalStrategy: string | null
+  source: string | null
+}
+
+function formatUtcDate(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+/**
+ * Look up first-retrieval provenance for a set of (personIdentifier, pmid) pairs.
+ * Returns a map keyed `${personIdentifier}:${pmid}`. Best-effort: any AWS error
+ * propagates to the caller, which degrades gracefully (the field is absent).
+ */
+export async function getArticleProvenance(
+  keys: { personIdentifier: string; pmid: number | string }[]
+): Promise<Record<string, ArticleProvenanceRecord>> {
+  const out: Record<string, ArticleProvenanceRecord> = {}
+  if (!keys || keys.length === 0) return out
+
+  // Dedupe to unique (uid, articleId) string pairs.
+  const uniq = new Map<string, { uid: string; articleId: string }>()
+  for (const k of keys) {
+    if (!k || !k.personIdentifier || k.pmid === undefined || k.pmid === null) continue
+    const articleId = String(k.pmid)
+    if (!articleId) continue
+    uniq.set(`${k.personIdentifier}:${articleId}`, { uid: k.personIdentifier, articleId })
+  }
+  const all = Array.from(uniq.values())
+  if (all.length === 0) return out
+
+  const ddb = getClient()
+  for (let i = 0; i < all.length; i += BATCH_SIZE) {
+    let pending = all.slice(i, i + BATCH_SIZE)
+    let attempt = 0
+    while (pending.length > 0 && attempt < 4) {
+      attempt++
+      const Keys = pending.map((k) => ({ uid: { S: k.uid }, articleId: { S: k.articleId } }))
+      const resp = await ddb.send(
+        new BatchGetItemCommand({ RequestItems: { [TABLE]: { Keys } } })
+      )
+      const items: any[] = resp.Responses?.[TABLE] ?? []
+      for (const it of items) {
+        const uid: string | undefined = it.uid?.S
+        const articleId: string | undefined = it.articleId?.S
+        if (!uid || !articleId) continue
+        const epoch = it.frd?.N ? Number(it.frd.N) : null
+        const validEpoch = epoch !== null && Number.isFinite(epoch) ? epoch : null
+        out[`${uid}:${articleId}`] = {
+          firstRetrievalDate: validEpoch !== null ? formatUtcDate(validEpoch) : null,
+          firstRetrievalEpoch: validEpoch,
+          retrievalStrategy: it.rs?.S ?? null,
+          source: it.src?.S ?? null,
+        }
+      }
+      const unprocessed: any[] | undefined = resp.UnprocessedKeys?.[TABLE]?.Keys
+      if (unprocessed && unprocessed.length > 0) {
+        pending = unprocessed.map((k) => ({
+          uid: (k.uid?.S as string) ?? '',
+          articleId: (k.articleId?.S as string) ?? '',
+        }))
+        await new Promise((r) => setTimeout(r, 100 * attempt)) // backoff before retry
+      } else {
+        pending = []
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Attach `firstRetrievalDate` (+ epoch/strategy/source) onto each article in a
+ * ReCiter feature-generator response for ONE person. Mutates `data` in place.
+ * Never throws — provenance is a non-critical display enrichment, so a DynamoDB
+ * outage simply leaves the field absent and the page renders normally.
+ */
+export async function attachArticleProvenance(
+  personIdentifier: string | undefined,
+  data: any
+): Promise<void> {
+  try {
+    if (!personIdentifier || !data || !Array.isArray(data.reCiterArticleFeatures)) return
+    const keys = data.reCiterArticleFeatures
+      .filter((a: any) => a && a.pmid !== undefined && a.pmid !== null)
+      .map((a: any) => ({ personIdentifier, pmid: a.pmid }))
+    if (keys.length === 0) return
+    const map = await getArticleProvenance(keys)
+    for (const a of data.reCiterArticleFeatures) {
+      const rec = map[`${personIdentifier}:${a.pmid}`]
+      if (rec) {
+        a.firstRetrievalDate = rec.firstRetrievalDate
+        a.firstRetrievalEpoch = rec.firstRetrievalEpoch
+        a.retrievalStrategy = rec.retrievalStrategy
+        a.retrievalSource = rec.source
+      }
+    }
+  } catch (e) {
+    console.log('ArticleProvenance lookup failed (non-fatal): ' + e)
+  }
+}

--- a/src/pages/api/reciter/feedback-log/[uid].ts
+++ b/src/pages/api/reciter/feedback-log/[uid].ts
@@ -1,0 +1,55 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getFeedbackLog } from "../../../../../controllers/feedbacklog.controller"
+import { findAdminUserNamesByIds } from "../../../../../controllers/db/manage-users/user.controller"
+import { reciterConfig } from '../../../../../config/local'
+
+/**
+ * GET /api/reciter/feedback-log/[uid]
+ *
+ * Returns the curation audit history for a person, proxied from ReCiter's
+ * /reciter/feedback-log/{uid}. Gated on the backend api-key header — the same
+ * rule the goldstandard save route uses on this branch.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== "GET") {
+        return res.status(400).send({ statusCode: 400, message: "HTTP Method supported is GET" })
+    }
+    if (req.headers.authorization === undefined) {
+        return res.status(400).send({ statusCode: 400, message: "Authorization header is needed" })
+    }
+    if (req.headers.authorization !== reciterConfig.backendApiKey) {
+        return res.status(401).send({ statusCode: 401, message: "Authorization header is incorrect" })
+    }
+
+    const { uid } = req.query
+    const targetUid = Array.isArray(uid) ? uid[0] : uid
+    if (!targetUid) {
+        return res.status(400).send({ statusCode: 400, message: "uid is required" })
+    }
+
+    try {
+        const apiResponse = await getFeedbackLog(targetUid)
+        if (apiResponse.statusCode === 200) {
+            const data = apiResponse.data
+            // Resolve curatedBy (admin_users.userID) -> display name for the UI.
+            if (Array.isArray(data)) {
+                const ids: number[] = Array.from(
+                    new Set(data.map((e: any) => Number(e.curatedBy)).filter((n: number) => Number.isInteger(n) && n > 0))
+                )
+                const nameMap = await findAdminUserNamesByIds(ids)
+                data.forEach((e: any) => {
+                    const cb = Number(e.curatedBy)
+                    e.curatorName = (Number.isInteger(cb) && cb > 0 && nameMap[cb]) ? nameMap[cb] : null
+                })
+            }
+            return res.status(200).send(data)
+        }
+        return res.status(apiResponse.statusCode || 500).send({
+            statusCode: apiResponse.statusCode || 500,
+            message: apiResponse.statusText
+        })
+    } catch (err) {
+        console.error('[feedback-log] Unhandled error:', err)
+        return res.status(500).send({ statusCode: 500, message: 'Internal server error' })
+    }
+}

--- a/src/redux/actions/actions.js
+++ b/src/redux/actions/actions.js
@@ -1210,12 +1210,51 @@ export const publicationsFetchGroupData = (ids, updateData) => dispatch => {
         })
 }
 
+// The curation-history panel now reads the canonical ReCiter FeedbackLog
+// (DynamoDB) via /api/reciter/feedback-log/[uid] instead of the legacy PM MySQL
+// admin_feedback_log. The canonical endpoint returns a flat array of rows
+// { articleId, feedback, curatedBy, curatorName, createTimestamp(epoch s), sk, src,
+//   provenanceRs/Frd/Src }. Normalize each row so the per-card panel renders unchanged:
+// it reads canonical curatorName directly, plus a few legacy aliases — articleIdentifier
+// (bucketing key), feedbackID (React key), modifyTimestamp (formatted date) — so the
+// existing render code needs no field-by-field rewrite.
+const normalizeFeedbackRow = (row) => {
+    const epochSec = Number(row && row.createTimestamp) || 0;
+    return {
+        ...row,
+        articleIdentifier: row && row.articleId,
+        feedbackID: row && row.sk,
+        modifyTimestamp: epochSec ? new Date(epochSec * 1000).toISOString() : null,
+    };
+};
+
+// Bucket the flat canonical array by articleId (PMID) for per-card lookup, newest first.
+const groupFeedbackByArticle = (rows) => {
+    const data = {};
+    (Array.isArray(rows) ? rows : []).forEach((raw) => {
+        const row = normalizeFeedbackRow(raw);
+        const key = row.articleIdentifier;
+        if (key === undefined || key === null) return;
+        if (!data[key]) data[key] = [];
+        data[key].push(row);
+    });
+    Object.keys(data).forEach((k) => {
+        data[k].sort((a, b) => {
+            const at = Number(a.createTimestamp) || 0;
+            const bt = Number(b.createTimestamp) || 0;
+            if (bt !== at) return bt - at;
+            return String(b.sk || '').localeCompare(String(a.sk || ''));
+        });
+    });
+    return data;
+};
+
 export const fetchFeedbacklog = (id) => dispatch => {
     dispatch({
         type: methods.FEEDBACKLOG_FETCH_DATA
     })
 
-    fetch(`/api/db/admin/feedbacklog/${id}`, {
+    fetch(`/api/reciter/feedback-log/${id}`, {
         credentials: "same-origin",
         method: 'GET',
         headers: {
@@ -1235,13 +1274,7 @@ export const fetchFeedbacklog = (id) => dispatch => {
             }
         }
     }).then(data => {
-        let articleIds = data.map((feedback) => { return feedback.articleIdentifier })
-        articleIds = articleIds.filter((feedback, i) => { return articleIds.indexOf(feedback) === i });
-        let feedbacklogData = {};
-        articleIds.forEach((articleId) => {
-            let articleFeedbacks = data.filter((feedbackLog) => { if (feedbackLog.articleIdentifier === articleId) return feedbackLog });
-            feedbacklogData[articleId] = articleFeedbacks;
-        })
+        const feedbacklogData = groupFeedbackByArticle(data);
 
         dispatch({
             type: methods.FEEDBACKLOG_CHANGE_DATA,
@@ -1276,7 +1309,7 @@ export const fetchGroupFeedbacklog = (ids) => dispatch => {
 
     let feedbackLogs = [];
     for (let id of ids) {
-        fetch(`/api/db/admin/feedbacklog/${id}`, {
+        fetch(`/api/reciter/feedback-log/${id}`, {
             credentials: "same-origin",
             method: 'GET',
             headers: {
@@ -1288,13 +1321,7 @@ export const fetchGroupFeedbacklog = (ids) => dispatch => {
             return response.json()
         }).then(data => {
             if (data?.length) {
-                let articleIds = data.map((feedback) => { return feedback.articleIdentifier })
-                articleIds = articleIds.filter((feedback, i) => { return articleIds.indexOf(feedback) === i });
-                let feedbacklogData = {};
-                articleIds.forEach((articleId) => {
-                    let articleFeedbacks = data.filter((feedbackLog) => { if (feedbackLog.articleIdentifier === articleId) return feedbackLog });
-                    feedbacklogData[articleId] = articleFeedbacks;
-                })
+                const feedbacklogData = groupFeedbackByArticle(data);
                 feedbackLogs.push({ [id]: feedbacklogData });
             }
         }).catch(error => {


### PR DESCRIPTION
## What
Restores the per-card **History** panel that Veer's `dev` rebuild dropped, ported from `dev_Upd_NextJS14SNode18` (recovery handoff, task 3). Each `/curate` card's History popover now shows a **Provenance** block (first-retrieved date · strategy · source) above the existing **Curation history**. This is the direct fix for the tester feedback *"Provenance not shown (only Feedback log)."*

## How it works
**Provenance (#737)** — `src/lib/articleProvenance.ts` reads the DynamoDB `ArticleProvenance` table on the fly (BatchGetItem, chunked, best-effort, never throws); `featuregenerator.controller` enriches each by-uid article with `firstRetrievalDate / retrievalStrategy / retrievalSource`. The card reads those fields.

**Curation history (#747)** — the panel's READ source moves from the legacy PM MySQL `admin_feedback_log` to the canonical ReCiter FeedbackLog via a new `GET /api/reciter/feedback-log/[uid]` proxy (`feedbacklog.controller` + route), with curator-name resolution. Redux `fetchFeedbacklog`/`fetchGroupFeedbacklog` are repointed and normalized (bucketed by articleId, newest-first). The legacy write path is untouched.

## Adapted for this branch (not a straight copy)
- **checkCurationScope intentionally omitted.** dev has no scope/RBAC model; the route gates on the backend api-key header only — the same rule dev's goldstandard save route uses.
- **dev's click-toggle popover kept** (not the dev_Upd hover-CSS version) — smaller diff, dev's click-outside/Esc handler already works.
- Timestamp-less rows render a blank date (guarded), not the Unix epoch.

## Infra
- Adds `@aws-sdk/client-dynamodb`.
- Declares `serviceAccountName: reciter-pm` in `kubernetes/k8-deployment.yaml`. The pod already runs this IRSA SA (role `ReciterPM-ArticleProvenance-Read`); declaring it in the manifest stops #800's reconciling `kubectl apply` from stripping the DynamoDB read credentials. **Deploy-time check:** confirm the `reciter-pm` SA exists in the `reciter` namespace before/at deploy.

## Deferred (separate follow-ups)
- **goldstandard `curatedBy` capture on save** — held off deliberately so this PR doesn't touch the goldstandard write path that #802 just fixed. Existing FeedbackLog entries already carry `curatedBy`; new curations show "Unknown" curator until this lands.

## Verification
No local build (Dropbox worktree, no `node_modules`) — the compile gate is the dev CodeBuild. Before pushing, a 6-agent adversarial review checked JSX integrity, the redux graft, backend import resolution, the provenance dataflow, and the end-to-end field contract: all clean except one minor null-guard, now fixed. Files: 11 changed, +395/-19.