### PR TITLE
fix(ui): make Inter win the body font over Bootstrap's system stack

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -67,9 +67,11 @@
   --font-display: 'Inter', sans-serif;
   /* --font-serif is a legacy alias of --font-display (kept so existing references resolve). */
   --font-serif: var(--font-display);
-  /* Bootstrap's reboot is imported after globals.css and sets body font from this var;
-     point it at our stack so Inter actually reaches body text app-wide. */
-  --bs-body-font-family: var(--font-sans);
+  /* Bootstrap's reboot is imported AFTER globals.css and re-declares this var on :root,
+     so a plain override loses the cascade and body text (plus everything that inherits
+     it — keyword pills, etc.) falls back to Bootstrap's system-ui stack. !important wins
+     regardless of import order, so Inter actually reaches body text app-wide. */
+  --bs-body-font-family: var(--font-sans) !important;
   --font-size-xs: 12px;
   --font-size-sm: 14px;
   --font-size-base: 16px;


### PR DESCRIPTION
## What
Body text (and everything that inherits it — keyword pills on the curate page, plain paragraphs, Bootstrap components) was rendering in Bootstrap's default `system-ui, -apple-system, "Segoe UI", Roboto, …` stack instead of **Inter**.

## Root cause
`globals.css` already redirects Bootstrap's body-font variable to our stack:
```css
--bs-body-font-family: var(--font-sans);   /* Inter, … */
```
…but `src/pages/_app.tsx` imports `bootstrap/dist/css/bootstrap.min.css` **after** `globals.css`. Bootstrap's reboot re-declares `--bs-body-font-family` on `:root` with its system stack, and since both are `:root` at equal specificity, the **later import wins** — so `body { font-family: var(--bs-body-font-family) }` resolves back to system-ui. The component CSS modules that hard-code `'Inter'` (headings, cards) kept working, which is why only inherited/body text looked wrong.

## Fix
```css
--bs-body-font-family: var(--font-sans) !important;
```
`!important` wins the custom-property cascade regardless of import order, so `--bs-body-font-family` stays Inter and body text (plus keyword pills etc.) renders in Inter.

Chosen over reordering the imports in `_app.tsx` deliberately: this touches **only** the font-family variable, leaving every other globals-vs-Bootstrap cascade interaction unchanged (lower blast radius, no app-wide visual re-verification needed).

## Verification
CSS-cascade reasoning; `!important` on custom properties is spec-supported in all modern browsers. No local build (Dropbox worktree) — compile gate is the dev CodeBuild. **Runtime check on reciter-dev (hard-refresh — CSS is cached):** inspect `body` / a keyword pill, computed `font-family` should now start with `Inter`.
