### PR TITLE
fix(ui): restore the calm/mild design system (incl. Supporting Evidence panel)

### DIFF
--- a/src/components/elements/Common/Styles.module.css
+++ b/src/components/elements/Common/Styles.module.css
@@ -1,4 +1,4 @@
 .divider {
   opacity: 1;
-  background-color: var(--gray-200);
+  background-color: #e8e2d9;
 }

--- a/src/components/elements/Pagination/Pagination.module.css
+++ b/src/components/elements/Pagination/Pagination.module.css
@@ -16,10 +16,10 @@
   align-items: center;
   gap: 10px;
   font-family: var(--font-sans);
-  background: none;
-  border: none;
-  padding: 0;
-  margin-left: 12px;
+  background: #faf8f5;
+  border: 1px solid #e8e2d9;
+  border-radius: 6px;
+  padding: 9px 16px;
 }
 
 .showLabel {

--- a/src/components/elements/Publication/Publication.module.css
+++ b/src/components/elements/Publication/Publication.module.css
@@ -133,7 +133,7 @@
 }
 
 .publicationAuthorHighlighted {
-    background-color: #fef3c7;
+    background-color: #f5f0c8;
     border-radius: 3px;
     padding: 1px 3px;
 }
@@ -145,19 +145,19 @@
 
 .reciterType {
   display: inline-block;
-  background: var(--gray-200);
-  border-radius: var(--radius-pill);
+  background: #e6eef7;
+  border-radius: 20px;
   text-align: center;
-  padding: 4px 10px;
+  padding: 3px 10px;
   line-height: 1em;
   margin-top: 8px;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: 11px;
+  font-weight: 600;
   font-stretch: normal;
   font-style: normal;
   line-height: normal;
-  letter-spacing: .11px;
-  color: var(--gray-700);
+  letter-spacing: 0.03em;
+  color: #2c4a7c;
   margin-left: 6px;
 }
 
@@ -302,7 +302,7 @@
 }
 
 .highlightedAuthor {
-  color: #2563eb;
+  color: var(--color-accent, #2563a8);
   background-color: transparent;
   font-weight: 600;
 }
@@ -312,23 +312,19 @@
 /* ── Feedback bar chart ── */
 
 .sectionPanel {
-  background: #fff;
-  border: 1px solid #e8e2d9;
-  border-radius: 8px;
+  background: transparent;
+  border: none;
   overflow: visible;
   margin-bottom: 16px;
 }
 
 .sectionHeader {
   padding: 0 16px;
-  min-height: 38px;
-  border-bottom: 1px solid #e8e2d9;
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
   gap: 12px;
-  background: #1a2133;
-  border-radius: 8px 8px 0 0;
+  margin-bottom: 6px;
 }
 
 .sectionTitleGroup {
@@ -338,20 +334,21 @@
 }
 
 .sectionTitle {
-  font-size: 13px;
+  font-size: 11px;
   font-weight: 600;
-  color: #fff;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #8a94a6;
 }
 
 .sectionSubtitle {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.35);
+  color: #8a94a6;
   font-weight: 400;
 }
 
 .sectionBody {
   padding: 6px 16px 8px;
-  border-radius: 0 0 8px 8px;
 }
 
 /* Learn more popover */
@@ -365,14 +362,15 @@
   align-items: center;
   gap: 5px;
   font-size: 12px;
-  font-weight: 500;
-  color: rgba(255, 255, 255, 0.55);
+  font-weight: 400;
+  color: #8a94a6;
   background: none;
   border: none;
   cursor: pointer;
   font-family: inherit;
   padding: 0;
-  transition: opacity 0.12s;
+  text-decoration: none;
+  transition: color 0.12s;
 }
 
 .learnMoreBtn:hover {
@@ -643,9 +641,9 @@
 
 .articleCard {
   background: #fff;
-  border: 1px solid #e8e2d9;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgb(0 0 0 / 0.04);
+  border: 0.5px solid #e8e2d9;
+  border-radius: 6px;
+  box-shadow: none;
   display: flex;
   flex-direction: row;
   transition: border-color 0.15s, box-shadow 0.15s;
@@ -658,19 +656,19 @@
 
 /* Status strip for accepted/rejected cards */
 .statusStrip {
-  width: 4px;
+  width: 3px;
   flex-shrink: 0;
-  border-radius: 8px 0 0 8px;
+  border-radius: 6px 0 0 6px;
 }
 
 .statusStripAccepted {
   composes: statusStrip;
-  background: #22c55e;
+  background: #1D9E75;
 }
 
 .statusStripRejected {
   composes: statusStrip;
-  background: #ef4444;
+  background: #c0392b;
 }
 
 .cardMain {
@@ -905,14 +903,14 @@
 .typeBadge {
   display: inline-block;
   background: #eeeae4;
-  border: 1px solid #ddd7ce;
-  border-radius: 3px;
-  padding: 1px 7px;
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #8a94a6;
+  border: none;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 11px;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: #5a6478;
   margin-left: 6px;
 }
 
@@ -1279,20 +1277,19 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.7);
-  background: #3a4a6b;
-  border-bottom: none;
-  border-radius: 0;
+  color: #8a94a6;
+  background: #faf8f5;
+  border-bottom: 0.5px solid #e8e2d9;
 }
 
 .identityHeaderRow div {
-  color: rgba(255, 255, 255, 0.6);
+  color: #8a94a6;
   padding-top: 7px;
   padding-bottom: 7px;
 }
 
 .identityHeaderRow:hover {
-  background: #3a4a6b;
+  background: #faf8f5;
 }
 
 .identityStrip {

--- a/src/components/elements/Report/ChecboxSelect.module.css
+++ b/src/components/elements/Report/ChecboxSelect.module.css
@@ -5,40 +5,40 @@
 
 /* ── SEARCH BAR ── */
 .ddSearch {
-  padding: 10px;
-  border-bottom: 1px solid #ddd7ce;
-  background: #eeeae4;
+  padding: 12px 16px;
+  border-bottom: 1px solid #eae6df;
+  background: #fff;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 10px;
 }
 
 .ddSearch input {
   flex: 1;
   border: none;
   background: transparent;
-  font-size: 12.5px;
-  font-family: 'Inter', sans-serif;
+  font-size: 15px;
+  font-family: inherit;
   color: #1a2133;
   outline: none;
 }
 
 .ddSearch input::placeholder {
-  color: #8a94a6;
+  color: #b0aca4;
 }
 
 .ddSearch svg {
   width: 14px;
   height: 14px;
-  color: #8a94a6;
+  color: #a09a92;
   flex-shrink: 0;
 }
 
 /* ── HEADER (match count + hints) ── */
 .ddHeader {
-  padding: 7px 12px;
-  background: #eeeae4;
-  border-bottom: 1px solid #ddd7ce;
+  padding: 7px 16px;
+  background: #fff;
+  border-bottom: 1px solid #eae6df;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -64,22 +64,22 @@
 .ddItem {
   display: flex;
   align-items: center;
-  gap: 9px;
-  padding: 8px 12px;
-  font-size: 12.5px;
-  color: #5a6478;
+  gap: 10px;
+  padding: 8px 16px;
+  font-size: 15px;
+  font-weight: 500;
+  color: #1a2133;
   cursor: pointer;
-  border-left: 2px solid transparent;
   transition: background 0.1s;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  border-bottom: 1px solid #eae6df;
 }
 
 .ddItem:hover {
-  background: #eeeae4;
+  background: #faf8f5;
   color: #1a2133;
-  border-left-color: #2563a8;
 }
 
 .ddItemChecked {
@@ -90,11 +90,11 @@
 
 /* ── CUSTOM CHECKBOX ── */
 .cb {
-  width: 14px;
-  height: 14px;
-  min-width: 14px;
-  border: 1.5px solid #ddd7ce;
-  border-radius: 3px;
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  border: 1.5px solid #d0cbc3;
+  border-radius: 5px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
@@ -104,14 +104,14 @@
 
 .cbOn {
   composes: cb;
-  background: #1a2133;
-  border-color: #1a2133;
+  background: #2563a8;
+  border-color: #2563a8;
 }
 
 .cbOn::after {
   content: '';
-  width: 8px;
-  height: 5px;
+  width: 10px;
+  height: 6px;
   border-left: 2px solid #fff;
   border-bottom: 2px solid #fff;
   transform: rotate(-45deg) translateY(-1px);
@@ -137,27 +137,27 @@
 
 /* ── FOOTER ── */
 .ddFooter {
-  padding: 7px 12px;
-  border-top: 1px solid #ddd7ce;
-  background: #eeeae4;
+  padding: 12px 16px;
+  border-top: 1px solid #eae6df;
+  background: #fff;
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
 .ddClear {
-  font-size: 11px;
-  color: #8a94a6;
+  font-size: 14px;
+  color: #2563a8;
   cursor: pointer;
   background: none;
   border: none;
-  font-family: 'Inter', sans-serif;
+  font-family: inherit;
   transition: color 0.15s;
   padding: 0;
 }
 
 .ddClear:hover {
-  color: #c0392b;
+  text-decoration: underline;
 }
 
 .ddSelectedCount {

--- a/src/components/elements/Report/DatePicker.module.css
+++ b/src/components/elements/Report/DatePicker.module.css
@@ -17,18 +17,18 @@
 }
 
 .ddClear {
-  font-size: 11px;
-  color: #8a94a6;
+  font-size: 13px;
+  color: var(--color-accent);
   background: none;
   border: none;
-  font-family: 'Inter', sans-serif;
+  font-family: inherit;
   cursor: pointer;
   transition: color 0.15s;
   padding: 0;
 }
 
 .ddClear:hover {
-  color: #c0392b;
+  text-decoration: underline;
 }
 
 /* ── DATE INPUTS ── */
@@ -97,21 +97,21 @@
 }
 
 .presets {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
   padding: 0 14px 14px;
 }
 
 .presetBtn {
-  padding: 6px 8px;
-  background: #eeeae4;
-  border: 1px solid #ddd7ce;
-  border-radius: 5px;
-  font-size: 11.5px;
+  padding: 6px 14px;
+  background: #f3f1ed;
+  border: 1px solid #d6d0c4;
+  border-radius: 20px;
+  font-size: 13px;
   font-weight: 500;
   color: #5a6478;
-  font-family: 'Inter', sans-serif;
+  font-family: inherit;
   cursor: pointer;
   transition: all 0.15s;
   text-align: center;

--- a/src/components/elements/Report/ExportModal.module.css
+++ b/src/components/elements/Report/ExportModal.module.css
@@ -106,10 +106,10 @@
 
 .statBlock {
   flex: 1;
-  padding: 12px 14px;
-  background: #eeeae4;
-  border: 1px solid #ddd7ce;
-  border-radius: 5px;
+  padding: 16px;
+  background: #f7f5f1;
+  border: none;
+  border-radius: 10px;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -146,12 +146,12 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 2px 7px;
-  border-radius: 4px;
-  font-size: 10.5px;
-  font-weight: 700;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.03em;
 }
 
 .badgeRtf {

--- a/src/components/elements/Report/ReportsResultPane.module.css
+++ b/src/components/elements/Report/ReportsResultPane.module.css
@@ -25,15 +25,15 @@
 }
 
 .typeBadge {
-  font-size: 10.5px;
+  font-size: 11px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 2px 7px;
-  border-radius: 3px;
-  background: #f0ece6;
-  border: 1px solid #ddd8d0;
-  color: #8a95a3;
+  text-transform: none;
+  letter-spacing: 0.03em;
+  padding: 3px 10px;
+  border-radius: 20px;
+  background: #eeeae4;
+  border: none;
+  color: #5a6478;
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -66,8 +66,8 @@
 }
 
 .articleIds a {
-  color: var(--link-blue);
-  text-decoration: none;
+  color: #2563a8;
+  text-decoration: underline;
 }
 
 .articleIds a:hover {

--- a/src/components/elements/Report/SearchSummary.module.css
+++ b/src/components/elements/Report/SearchSummary.module.css
@@ -60,10 +60,22 @@
 }
 
 .exportBtn {
-  font-size: 13px !important;
-  padding: 4px 14px !important;
-  margin: 0 2px !important;
-  margin-left: 2px !important;
+  font-size: 14px !important;
+  padding: 6px 14px !important;
+  margin: 0 !important;
+  background-color: #1a2133 !important;
+  border: 1px solid #1a2133 !important;
+  color: #fff !important;
+  font-weight: 600 !important;
+  border-radius: var(--radius-md) !important;
+}
+
+.exportBtn:hover,
+.exportBtn:focus,
+.exportBtn:active {
+  background-color: #11172a !important;
+  border-color: #11172a !important;
+  color: #fff !important;
 }
 
 /* ── SORT BY ── */
@@ -87,9 +99,9 @@
 }
 
 .sortItemActive {
-  color: #1a2133;
-  font-weight: 600;
-  background: #eef3fb;
+  color: #2c2a27;
+  font-weight: 500;
+  background: #f7f5f1;
   border-left-color: #2563a8;
 }
 
@@ -99,8 +111,8 @@
 
 .sortToggle {
   display: flex;
-  border: 1px solid #ddd7ce;
-  border-radius: 4px;
+  border: 1px solid #d6d0c4;
+  border-radius: 20px;
   overflow: hidden;
 }
 
@@ -124,7 +136,7 @@
 }
 
 .sortToggleBtnActive {
-  background: #1a2133;
+  background: #2563a8;
   color: #fff;
 }
 
@@ -147,9 +159,9 @@
 }
 
 .showItemActive {
-  color: #1a2133 !important;
-  font-weight: 600;
-  background: #eef3fb !important;
+  color: #2c2a27 !important;
+  font-weight: 500;
+  background: #f7f5f1 !important;
   border-left-color: #2563a8;
 }
 

--- a/src/components/elements/Search/Search.module.css
+++ b/src/components/elements/Search/Search.module.css
@@ -47,10 +47,10 @@
 }
 
 .resultsCountNumber {
-  font-family: 'Inter', var(--font-serif), sans-serif;
-  font-weight: 500;
-  font-size: 22px;
-  color: #c0392b;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 20px;
+  color: #2c2a27;
   letter-spacing: -0.02em;
 }
 
@@ -213,24 +213,24 @@
 
 /* ── TABLE ── */
 .table {
-  border: 1px solid #e8e2d9;
-  border-radius: 8px;
+  border: 1px solid #eae6df;
+  border-radius: 6px;
   overflow: hidden;
   font-family: var(--font-sans);
 }
 
 .table > thead {
-  background-color: #f0ece5;
-  border-bottom: 2px solid #e8e2d9;
+  background-color: #faf8f5;
+  border-bottom: 1px solid #eae6df;
 }
 
 .table > thead th {
   font-size: 11px !important;
-  font-weight: 700 !important;
+  font-weight: 600 !important;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #8a94a6 !important;
-  padding: 10px 16px !important;
+  letter-spacing: 0.04em;
+  color: #8a847c !important;
+  padding: 8px 14px !important;
   background: transparent;
 }
 
@@ -247,7 +247,7 @@
 }
 
 .table tbody tr {
-  border-color: #ddd7ce;
+  border-color: #eae6df;
   transition: background 0.12s;
 }
 
@@ -256,10 +256,10 @@
 }
 
 .table tbody td {
-  padding: 14px 16px;
+  padding: 12px 14px;
   vertical-align: middle;
-  font-size: 12.5px;
-  color: #5a6478;
+  font-size: 13px;
+  color: #6b6560;
 }
 
 .table tr td p {
@@ -271,22 +271,22 @@
 .table tr a {
   text-decoration: none;
   color: #2563a8;
-  font-weight: 600;
+  font-weight: 500;
   font-size: 14px;
 }
 
 .table tr a:hover {
-  color: #c0392b;
+  text-decoration: underline;
 }
 
 /* Person name button link in table */
 .btnLink {
   text-decoration: none;
-  color: #2563a8;
+  color: #1a2133;
   background: none;
   border: none;
   padding: 0px;
-  font-weight: 700;
+  font-weight: 600;
   font-size: 14px;
   font-family: var(--font-sans);
   cursor: pointer;
@@ -297,7 +297,8 @@
 }
 
 .btnLink:hover {
-  color: #c0392b;
+  text-decoration: underline;
+  color: #2563a8;
 }
 
 /* Person role / title */
@@ -310,9 +311,10 @@
 
 /* CWID line */
 .personCwid {
-  font-size: 11.5px;
+  font-size: 11px;
   color: #8a94a6;
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
 }
 
 .cwidLabel {
@@ -340,30 +342,20 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 28px;
-  height: 24px;
-  padding: 0 8px;
-  border-radius: 20px;
-  font-size: 12px;
-  font-weight: 700;
-  background: #fdf0ee;
-  color: #c0392b;
-  border: 1px solid #f0c8c4;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 11px;
+  font-size: 11px;
+  font-weight: 600;
+  background: #eeeae4;
+  color: #1a2133;
+  border: none;
 }
 
 .pendingBadgeNone {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 28px;
-  height: 24px;
-  padding: 0 8px;
-  border-radius: 20px;
   font-size: 12px;
-  font-weight: 700;
-  background: #eeeae4;
-  color: #c0c8d4;
-  border: 1px solid #ddd7ce;
+  color: #8a94a6;
 }
 
 .noitemsList {

--- a/src/components/layouts/AppLayout.module.css
+++ b/src/components/layouts/AppLayout.module.css
@@ -17,11 +17,11 @@
 
 .expandedSideBarContent{
   margin-left: 220px;
-  padding: 32px 36px !important;
+  padding: 24px 40px !important;
   min-height: calc(100vh - 52px);
 }
 .nonExpandedSideBarContent{
   margin-left: 73px;
-  padding: 16px 12px !important;
+  padding: 24px 40px !important;
   min-height: calc(100vh - 52px);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -37,6 +37,11 @@
   --color-chrome-text: #a0aec0;
   --color-chrome-text-bright: #e2e8f0;
 
+  /* Accent blue — canonical accent token (reconciles STYLEGUIDE drift #4).
+     Use for content/curator links, focus rings, selected state, ProxyBadge.
+     The global <a> color uses this accent token; WCM red is reserved for brand chrome. */
+  --color-accent: #2563a8;
+
   /* Warm content */
   --color-warm-bg: #f5f2ee;
   --color-warm-surface: #ffffff;
@@ -99,15 +104,15 @@ body {
 
 .btn-warning {
   background-color: #ffffff !important;
-  color: var(--gray-700) !important;
-  border: 1px solid var(--gray-300) !important;
+  color: #5a6478 !important;
+  border: 1px solid #ddd7ce !important;
   border-radius: var(--radius-md) !important;
   font-size: 14px !important;
 }
 .btn-warning:hover {
-  background-color: var(--gray-50) !important;
-  border-color: var(--gray-400) !important;
-  color: var(--gray-800) !important;
+  background-color: #faf8f5 !important;
+  border-color: #bbb5aa !important;
+  color: #1a2133 !important;
 }
 
 /* Form controls — warm input style */
@@ -150,13 +155,14 @@ h3 strong {
 }
 
 a {
-  color: var(--wcm-red);
+  color: var(--color-accent);
   text-decoration: none;
   transition: color 0.15s ease;
 }
 
 a:hover {
-  color: var(--wcm-red-dark);
+  color: var(--color-accent);
+  text-decoration: underline;
 }
 
 * {
@@ -242,7 +248,7 @@ h1 {
 .table {
   vertical-align: middle !important;
   border-radius: var(--radius-md);
-  border-color: var(--gray-200);
+  border-color: var(--color-warm-border);
 }
 
 .wcm-primary-lg.btn {
@@ -327,7 +333,7 @@ h1 {
 }
 
 .border-grey {
-  border: 1px solid #ced4da;
+  border: 1px solid #ddd7ce;
 }
 
 .rounded-right {
@@ -337,11 +343,12 @@ h1 {
 
 .search-summary-buttons .dropdown .btn-primary,
 .d-inline-block.dropdown .btn-primary {
-  background-color: var(--color-chrome) !important;
-  border-color: var(--color-chrome) !important;
+  background-color: #e8e4dc !important;
+  border-color: #b0aca4 !important;
   border-radius: var(--radius-pill) !important;
-  font-size: 12.5px;
-  padding: 5px 12px;
+  color: #2c2a27 !important;
+  font-size: 14px;
+  padding: 6px 12px 6px 14px;
 }
 
 .search-summary-buttons .dropdown .btn-primary:hover,
@@ -350,8 +357,8 @@ h1 {
 .d-inline-block.dropdown .btn-primary:hover,
 .d-inline-block.dropdown .btn-primary:focus,
 .d-inline-block.dropdown .btn-primary:active {
-  background-color: var(--color-chrome-hover) !important;
-  border-color: var(--color-chrome-hover) !important;
+  background-color: #e0dcd4 !important;
+  border-color: #a09c94 !important;
 }
 
 .dropdown .btn-white {
@@ -359,11 +366,11 @@ h1 {
 }
 
 .dropdown .btn-white {
-  background-color: #eeeae4 !important;
-  border: 1px solid #ddd7ce !important;
-  color: var(--gray-700) !important;
-  font-size: 12.5px;
-  padding: 5px 12px;
+  background-color: #f3f1ed !important;
+  border: 1px solid #d6d0c4 !important;
+  color: #2c2a27 !important;
+  font-size: 14px;
+  padding: 6px 12px 6px 14px;
 }
 
 .btn-danger {
@@ -389,13 +396,13 @@ h1 {
 }
 
 .btn-outline-secondary:hover {
-  background-color: var(--gray-100) !important;
-  border-color: var(--gray-400) !important;
-  color: var(--gray-800) !important;
+  background-color: #faf8f5 !important;
+  border-color: #bbb5aa !important;
+  color: #1a2133 !important;
 }
 
 .dropdown-menu {
-  border: 1px solid var(--gray-200);
+  border: 1px solid var(--color-warm-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   padding: 12px 0;


### PR DESCRIPTION
## What
The deployed `dev` (Veer's rebuild) had drifted away from the calm/mild redesign (`feature/calm-redesign` — "Inter typeface + navy button system"). A 7-surface audit found ~27 visual discrepancies clustering into 5 patterns; this PR restores the calm values across **11 CSS files** (surgical value reverts only — dev-only structure like the provenance/History panel is preserved).

## The 5 patterns restored
1. **Accent token** — re-add `--color-accent: #2563a8` and repoint content links to navy (hover underline) instead of WCM red. Also fixes **Reports PMID/DOI/PMCID links**, which referenced an **undefined** `--link-blue` and rendered as grey plain text (nearly a functional bug).
2. **Warm palette** — cool `--gray-*`/`#ced4da` → warm `#e8e2d9`/`#ddd7ce`/`#faf8f5` across buttons, tables, dropdowns, divider, pagination bar. *(Biggest driver of the "cooler/generic" feel.)*
3. **Soft pills** — type badges, date presets, format badge, sort toggle, filter checkboxes back to rounded borderless chips (no boxy uppercase).
4. **Red intrusion removed** — Search pending badge + result-count back to neutral/charcoal; link hovers back to calm-blue underline.
5. **Louder chrome quieted — incl. Supporting Evidence** — the dark solid section-header bars (`#1a2133`/`#3a4a6b` white text) become quiet uppercase gray labels on transparent/warm backgrounds; "Learn more" recolored off the removed dark bar; article card loses its drop shadow; status strips back to brand green/red.

Plus: `.personCwid` → Inter+tabular-nums (was unloaded `DM Mono`); Reports export CTA → navy fill; main-content padding restored to the calm generous value.

## ⚠️ One decision for you (reversible)
**Links default to calm navy.** If WCM red is the intended institutional brand for content links, flip `--color-accent` + the `a{}`/`a:hover` rules to `--wcm-red` — it's a single-token change. I defaulted to navy because that's the calm look you're restoring.

## Notable care taken
- Kept dev's header-aware `min-height: calc(100vh - 52px)` (a restore agent had reverted it to calm's `100vh`, which would overflow given dev's 52px header — reverted that back).
- The Supporting Evidence panel is partly structural on dev (`.sectionPanel`/`.sectionSubtitle` don't exist on calm) — those were restyled quiet, not deleted, so the JSX still works.

## Verification
Built via audit → per-file restore → per-file verify (each diffed against the calm baseline). Then I spot-checked headline values, confirmed all files are brace-balanced, no `DM Mono`/`DM Sans`/`Space Grotesk` remain, and no dev-only classes (provenance/History) were touched. **No local build** (Dropbox worktree) — compile gate is the dev CodeBuild. **This is CSS and best-eyeballed in a browser** after deploy (hard-refresh) — treat as high-confidence but visually-unconfirmed.

**Merge/deploy note:** #810 (refresh) touches a disjoint file. #811 (font) also edits `globals.css` but at a non-overlapping hunk (the `--bs-body-font-family` line vs this PR's accent/link/border hunks), so the two auto-merge cleanly — verified with a trial merge (no conflict markers).

