### PR TITLE
Curate-page iteration: OpenAlex dedup, external-id links, lighter chips, honest history copy

### DIFF
--- a/controllers/openalex.controller.ts
+++ b/controllers/openalex.controller.ts
@@ -51,6 +51,40 @@ function normalizeWork(work: any) {
     }
 }
 
+// PM curate-iteration: OpenAlex often returns the same paper as two "works" — one
+// carrying a PMID (flagged "in PubMed") and one without (offered as a fresh "Add"),
+// which lets a curator add a duplicate of the PubMed record. Collapse siblings before
+// they reach the client: group by DOI, else by a distinctive normalized title, and keep
+// the copy that carries a PMID, merging the group's pmid/doi onto the survivor.
+const normalizeTitle = (t: string): string =>
+    String(t || '').toLowerCase().normalize('NFKD').replace(/[^\p{L}\p{N}]+/gu, ' ').trim()
+
+function dedupeWorks(rows: any[]): any[] {
+    const groups = new Map<string, any>()
+    const order: string[] = []
+    for (const row of rows) {
+        const title = normalizeTitle(row.title)
+        // ponytail: only collapse by title when it's distinctive (>=10 chars) so generic
+        // stubs ("Reply", "Correction") don't merge distinct works. DOI match is always safe.
+        const key = row.doi
+            ? 'doi:' + String(row.doi).toLowerCase().trim()
+            : (title.length >= 10 ? 'title:' + title : 'id:' + row.articleId)
+        const kept = groups.get(key)
+        if (!kept) {
+            groups.set(key, row)
+            order.push(key)
+            continue
+        }
+        // Prefer the sibling that carries a PMID as the base, then backfill the other's ids.
+        const base = kept.pmid !== undefined ? kept : (row.pmid !== undefined ? row : kept)
+        const other = base === kept ? row : kept
+        base.pmid = base.pmid !== undefined ? base.pmid : other.pmid
+        base.doi = base.doi || other.doi
+        groups.set(key, base)
+    }
+    return order.map((k) => groups.get(k))
+}
+
 export async function searchOpenAlex(req: NextApiRequest) {
     const rawQuery: string = (req.body && (req.body.query || req.body.search) || '').toString().trim()
     if (!rawQuery) {
@@ -77,9 +111,11 @@ export async function searchOpenAlex(req: NextApiRequest) {
                 return { statusCode: res.status, statusText: responseText }
             }
             const data: any = await res.json()
-            const results = (Array.isArray(data.results) ? data.results : [])
-                .map(normalizeWork)
-                .filter(Boolean)
+            const results = dedupeWorks(
+                (Array.isArray(data.results) ? data.results : [])
+                    .map(normalizeWork)
+                    .filter(Boolean)
+            )
             return { statusCode: 200, statusText: results }
         })
         .catch((error) => {

--- a/src/components/elements/CurateIndividual/CurateIndividual.module.css
+++ b/src/components/elements/CurateIndividual/CurateIndividual.module.css
@@ -233,7 +233,7 @@
 .kwTag {
   position: relative;
   display: inline-block;
-  background: #eeeae4;
+  background: #faf8f5;
   border: 1px solid #ddd7ce;
   border-radius: 20px;
   padding: 2px 8px;
@@ -245,7 +245,7 @@
 }
 
 .kwTag:hover {
-  background: #e4e0d8;
+  background: #f2ede6;
   border-color: #ccc6bc;
   color: #1a2133;
 }

--- a/src/components/elements/CurateIndividual/ExternalPublicationCard.tsx
+++ b/src/components/elements/CurateIndividual/ExternalPublicationCard.tsx
@@ -19,6 +19,23 @@ const SOURCE_LABELS: Record<string, string> = {
     WOS: 'Web of Science',
 }
 
+// The source id lives in the `SOURCE:<id>` prefix of articleId. Turn it into an outbound
+// link where we can build a stable URL: OpenAlex works always resolve; Scopus only when
+// the id is a 2-s2.0 EID. Otherwise leave it as plain text.
+const idLinkFor = (articleId?: string): string | undefined => {
+    if (!articleId) return undefined
+    const idx = articleId.indexOf(':')
+    if (idx < 0) return undefined
+    const src = articleId.slice(0, idx)
+    const id = articleId.slice(idx + 1)
+    if (!id) return undefined
+    if (src === 'OPENALEX') return `https://openalex.org/${id}`
+    if (src === 'SCOPUS' && /^2-s2\.0-/.test(id)) {
+        return `https://www.scopus.com/record/display.uri?eid=${encodeURIComponent(id)}&origin=resultslist`
+    }
+    return undefined
+}
+
 export type AddState = {
     status: 'idle' | 'adding' | 'checking' | 'blocked' | 'warning' | 'inPubmed' | 'added',
     message?: string,
@@ -112,7 +129,11 @@ const ExternalPublicationCard: FunctionComponent<FuncProps> = (props) => {
                 <div className={styles.links}>
                     {doi && <span><a href={`${doiUrl}${doi}`} target="_blank" rel="noreferrer">DOI &#8599;</a></span>}
                     {pmid && <span>PMID: <a href={`${pubMedUrl}${pmid}`} target="_blank" rel="noreferrer">{pmid}</a></span>}
-                    {item.articleId && <span>ID: {item.articleId}</span>}
+                    {item.articleId && (
+                        <span>ID: {idLinkFor(item.articleId)
+                            ? <a href={idLinkFor(item.articleId)} target="_blank" rel="noreferrer">{item.articleId} &#8599;</a>
+                            : item.articleId}</span>
+                    )}
                 </div>
 
                 {/* Already in this person's record — inform, no add */}

--- a/src/components/elements/Publication/Publication.tsx
+++ b/src/components/elements/Publication/Publication.tsx
@@ -932,7 +932,17 @@ const displayFeedbackEvidence = (feedbackEvidence: Record<string, number>): JSX.
                               );
                             })
                           ) : (
-                            <div className={styles.clogEmpty}>No curation events yet</div>
+                            // A curated article with no FeedbackLog rows was accepted/rejected
+                            // before per-action history was logged (rows only go back so far).
+                            // Say so honestly rather than imply it was never curated; the real
+                            // curator/date for those pre-logging actions was never recorded.
+                            <div className={styles.clogEmpty}>
+                              {userAssertion === 'ACCEPTED'
+                                ? 'Accepted before curation history was recorded'
+                                : userAssertion === 'REJECTED'
+                                ? 'Rejected before curation history was recorded'
+                                : 'No curation events yet'}
+                            </div>
                           )}
                         </div>
                       )}


### PR DESCRIPTION
Next batch from the curate-page iteration handoff. Four focused changes, all on the `/curate` surface.

### P1 — OpenAlex duplicate leak (`openalex.controller.ts`)
OpenAlex returns the same paper as two "works" — one with a PMID (flagged "in PubMed"), one without (offered as a fresh "✓ Add") — letting a curator add a duplicate of the PubMed record. Now collapsed server-side before results reach the client: group by DOI (else a distinctive normalized title ≥10 chars so generic stubs don't merge), keep the copy that carries a PMID, and merge the group's pmid/doi onto the survivor. Verified with a standalone logic check (reported case collapses; generic short titles and distinct DOIs stay separate).

### P2 — Outbound links on external result cards (`ExternalPublicationCard.tsx`)
`ID: OPENALEX:W…` was plain text. Now OpenAlex ids link to `openalex.org` and Scopus 2-s2.0 EIDs to `scopus.com` (↗, matching DOI). Non-resolvable ids stay plain text.

### P2 — Lighter keyword chips (`CurateIndividual.module.css`)
`.kwTag` background `#eeeae4` → `#faf8f5` (near-white), hover → `#f2ede6`. Only `.kwTag`; the other `#eeeae4` usages in the module are untouched.

### P0-adjacent — Honest History copy for pre-logging accepts (`Publication.tsx`)
A curated article with no FeedbackLog rows was accepted/rejected *before* per-action history was logged; "No curation events yet" implied it was never curated. Now shows "Accepted/Rejected before curation history was recorded" using the status the card already has. Pending suggestions keep the original copy. (The real curator/date for pre-logging actions was never recorded and can't be recovered — this is the honest UI fix, not an engine backfill of fabricated rows.)

### Not included / deferred
- **Loose OpenAlex search** — left as-is per product decision (accept OpenAlex's results rather than artificially constrain by name/ORCID/institution).
- **Person-set DOI/title dedup annotation** — the add route already returns a WARNING/409 for person-set duplicates, so the data-integrity hole is closed at add-time; skipped the display-only annotation.

### Verification note
This Dropbox worktree has no `node_modules`, so the changes are **not** locally `tsc`'d — the dev CodeBuild remains the compile gate (per the handoff). Pure logic (`dedupeWorks`, `idLinkFor`) is covered by standalone node assertions.