### PR TITLE
P0: persist accept/reject from the Suggested tab (currently silently dropped — affects prod too)

### DIFF
--- a/src/components/elements/CurateIndividual/ReciterTabContent.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabContent.tsx
@@ -108,6 +108,16 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
         lastActioned.current = { pmid, prevState: 'NULL' };
       }
       props.onAssertionChange?.(pmid, userAssertion);
+      // ...and persist it. The card deliberately stays put here, but the accept/reject
+      // still has to reach the goldstandard. Without this the action lived only in local
+      // state and was silently discarded by the next Refresh/re-run — nothing was saved.
+      dispatch(reciterUpdatePublication(uid, {
+        publications: [pmid],
+        userAssertion: userAssertion,
+        manuallyAddedFlag: false,
+        userID: session?.data?.databaseUser?.userID,
+        personIdentifier: uid,
+      }));
       return;
     }
 
@@ -149,6 +159,17 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
     if (isSuggested) {
       publications.forEach((p: any) => props.onAssertionChange?.(p.pmid, userAssertion));
       setPublications(prev => prev.map((p: any) => ({ ...p, userAssertion })));
+      // ...and persist them, same reason as the single-article path above.
+      const suggestedPmids = publications.map((p: any) => p.pmid);
+      if (suggestedPmids.length) {
+        dispatch(reciterUpdatePublication(props.personIdentifier, {
+          publications: suggestedPmids,
+          userAssertion: userAssertion,
+          manuallyAddedFlag: false,
+          userID: session?.data?.databaseUser?.userID,
+          personIdentifier: props.personIdentifier,
+        }));
+      }
       return;
     }
 

--- a/src/components/elements/CurateIndividual/ReciterTabs.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabs.tsx
@@ -214,7 +214,7 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
                 <path d="M13.5 8a5.5 5.5 0 11-1.1-3.3M13.5 2v3h-3" />
               </svg>
               <span>Refresh Suggestions</span>
-              <span className={styles.unsavedBadge} title={`${netChangedCount} unsaved change(s) will be submitted`}>
+              <span className={styles.unsavedBadge} title={`${netChangedCount} change(s) saved — refresh to regenerate suggestions`}>
                 {netChangedCount}
               </span>
             </button>


### PR DESCRIPTION
## The bug
**Accepting an article in the Suggested tab never reaches the backend.** The action is applied to local React state and the "unsaved changes" counter, then silently discarded on the next Refresh/re-run. Nothing is written to the GoldStandard and no FeedbackLog entry is created.

`ReciterTabContent.tsx` — both `handleUpdatePublication` (single) and `handleUpdatePublicationAll` (bulk) start with:

```ts
if (isSuggested) {
  setPublications(...)        // local visual state
  props.onAssertionChange?.() // the "unsaved changes" badge
  return                      // <-- short-circuits the dispatch below
}
...
dispatch(reciterUpdatePublication(uid, request))  // never reached for Suggested
```

The Accepted/Rejected tabs fall through and persist correctly. The Suggested tab — the primary curation path — does not.

## Evidence (reciter-dev, live)
- Accepted a Suggested article for `rak2007`, then clicked Refresh.
- GoldStandard `knownpmids` unchanged (**243**), `rejectedpmids` unchanged (21), FeedbackLog unchanged (**43** rows, newest still 2026-01-10).
- **No goldstandard POST reached `reciter-pm-dev` at all** (pod logs, 2h window) — the request was never sent, which rules out an auth/endpoint/backend failure and pins it on the missing dispatch.
- `backendApiKey` is `NEXT_PUBLIC_…`, so the POST authenticates fine once it actually fires.

## This affects production
`master_Next14` (what `reciter-pm-prod` runs) has the **identical** early-return at lines 103/111 and 149/152. Curators accepting suggested articles in prod are almost certainly losing their work silently. This commit is deliberately small and self-contained so it can be cherry-picked to `master_Next14`.

## The fix
Dispatch the same proven `reciterUpdatePublication` thunk the Accepted/Rejected tabs already use, while keeping the Suggested card in place with its actioned visual state (the deliberate triage UX). Persisting per-click also avoids any submit-vs-re-run ordering race.

Also corrects the change-counter tooltip, which claimed the changes "will be submitted" on refresh when nothing ever submitted them.

## Verification note
Not locally `tsc`'d (Dropbox worktree has no `node_modules`) — dev CodeBuild is the compile gate. **Needs a live retest after deploy:** accept a Suggested article, then confirm `knownpmids` increments and a FeedbackLog row appears.