### PR TITLE
PROD P0: persist accept/reject from the Suggested tab (curators are silently losing accepts)

### DIFF
--- a/src/components/elements/CurateIndividual/ReciterTabContent.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabContent.tsx
@@ -108,6 +108,16 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
         lastActioned.current = { pmid, prevState: 'NULL' };
       }
       props.onAssertionChange?.(pmid, userAssertion);
+      // ...and persist it. The card deliberately stays put here, but the accept/reject
+      // still has to reach the goldstandard. Without this the action lived only in local
+      // state and was silently discarded by the next Refresh/re-run — nothing was saved.
+      dispatch(reciterUpdatePublication(uid, {
+        publications: [pmid],
+        userAssertion: userAssertion,
+        manuallyAddedFlag: false,
+        userID: session?.data?.databaseUser?.userID,
+        personIdentifier: uid,
+      }));
       return;
     }
 
@@ -149,6 +159,17 @@ const ReciterTabContent: React.FC<TabContentProps> = (props) => {
     if (isSuggested) {
       publications.forEach((p: any) => props.onAssertionChange?.(p.pmid, userAssertion));
       setPublications(prev => prev.map((p: any) => ({ ...p, userAssertion })));
+      // ...and persist them, same reason as the single-article path above.
+      const suggestedPmids = publications.map((p: any) => p.pmid);
+      if (suggestedPmids.length) {
+        dispatch(reciterUpdatePublication(props.personIdentifier, {
+          publications: suggestedPmids,
+          userAssertion: userAssertion,
+          manuallyAddedFlag: false,
+          userID: session?.data?.databaseUser?.userID,
+          personIdentifier: props.personIdentifier,
+        }));
+      }
       return;
     }
 

--- a/src/components/elements/CurateIndividual/ReciterTabs.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabs.tsx
@@ -193,7 +193,7 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
                 {refreshState === 'loading' ? 'Refreshing\u2026' : refreshState === 'done' ? 'Done' : 'Refresh Suggestions'}
               </span>
               {refreshState === 'idle' && netChangedCount > 0 && (
-                <span className={styles.unsavedBadge} title={`${netChangedCount} unsaved change(s) will be submitted`}>
+                <span className={styles.unsavedBadge} title={`${netChangedCount} change(s) saved — refresh to regenerate suggestions`}>
                   {netChangedCount}
                 </span>
               )}


### PR DESCRIPTION
Cherry-pick of #815 (verified on dev) to `master_Next14` for production.

## The bug (live in prod today)
Accepting an article in the **Suggested tab** — the primary curation path — **never reaches the backend**. `ReciterTabContent.tsx` returns early for `isSuggested`, short-circuiting the `dispatch(reciterUpdatePublication(...))` below it. The action lives only in React state and is silently discarded on the next Refresh/re-run: nothing is written to GoldStandard and no FeedbackLog entry is created. Accepted/Rejected tabs fall through and persist correctly; Suggested does not.

**Curators have been losing accepts in production without any error.**

## Verified on dev before promoting
Deployed to `reciter-pm-dev` (image `dev-1118…70352990`) and retested live against DynamoDB:

| | before | after |
|---|---|---|
| GoldStandard `knownpmids` | 243 | **244** ✅ |
| FeedbackLog `ACCEPTED` row | — | **PMID 42410044** ✅ |

Prior to the fix the same action produced **zero** goldstandard POSTs at the server (pod logs) — the request was never sent.

## The fix
Dispatch the same proven `reciterUpdatePublication` thunk the Accepted/Rejected tabs already use, while keeping the Suggested card in place with its actioned visual state. Persisting per-click also avoids any submit-vs-re-run ordering race.

`ReciterTabContent.tsx` applies verbatim from dev (prod's copy was byte-identical pre-fix). `ReciterTabs.tsx` is a one-line tooltip correction, hand-resolved to preserve prod's `refreshState` button — the badge claimed changes "will be submitted" on refresh when nothing ever submitted them.

## Known follow-ups (not blockers — tracked separately)
- **`curatedBy = 0`**: the goldstandard payload omits the userID, so the engine records curator `0` and History renders "Unknown". Pre-existing; affects any goldstandard write, not just this path.
- **`PENDING` row volume**: the engine's `newlyPending` diff logs a person's whole pending pool the first time it runs (one-time catch-up per person). Audit noise, not data loss.

Both predate this change and are unaffected by it; shipping the persistence fix first stops active data loss.