### PR TITLE
fix(curate): record the curating user on goldstandard writes (History shows 'Unknown' for everyone)

### DIFF
--- a/controllers/goldstandard.controller.ts
+++ b/controllers/goldstandard.controller.ts
@@ -3,14 +3,20 @@ import { NextApiRequest } from 'next'
 import url from 'url'
 import { saveUserFeedback } from './userfeedback.controller'
 
-export async function updateGoldStandard(req: NextApiRequest)  {
+// curatedBy is the curating user's admin_users.userID. ReCiter accepts it as a query
+// param on /reciter/goldstandard and defaults it to 0 ("unknown") when absent — which is
+// why every FeedbackLog row was being written with curatedBy=0 and rendering as "Unknown"
+// in the curation History. It is stamped server-side from the JWT by the route and is
+// never taken from the client.
+export async function updateGoldStandard(req: NextApiRequest, curatedBy: number = 0)  {
 
     const {
         query: { goldStandardUpdateFlag }
       } = req;
 
-    
-   return fetch(`${reciterConfig.reciter.reciterUpdateGoldStandardEndpoint}?goldStandardUpdateFlag=${goldStandardUpdateFlag}`, {
+    const curatedByParam = Number.isInteger(curatedBy) && curatedBy > 0 ? `&curatedBy=${curatedBy}` : ''
+
+   return fetch(`${reciterConfig.reciter.reciterUpdateGoldStandardEndpoint}?goldStandardUpdateFlag=${goldStandardUpdateFlag}${curatedByParam}`, {
         method: "POST",
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/api/reciter/update/goldstandard.ts
+++ b/src/pages/api/reciter/update/goldstandard.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { getToken } from 'next-auth/jwt'
 import { updateGoldStandard } from "../../../../../controllers/goldstandard.controller"
 import { reciterConfig } from '../../../../../config/local'
 
@@ -19,7 +20,20 @@ export default async function handler(
     if(req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
         try {
-        const apiResponse = await updateGoldStandard(req);
+        // Resolve the curating user (admin_users.userID) from the JWT and stamp it on the
+        // goldstandard write, so ReCiter records who curated instead of falling back to 0
+        // ("Unknown" in the History panel). Never trusted from the client. Best-effort:
+        // if the token is missing/unreadable we send nothing and ReCiter defaults to 0.
+        let curatedBy = 0
+        try {
+            const token: any = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+            const userID = Number(token?.databaseUser?.userID)
+            if (Number.isInteger(userID) && userID > 0) curatedBy = userID
+        } catch (e) {
+            console.warn('[goldstandard] could not resolve curatedBy from JWT; recording as unknown')
+        }
+
+        const apiResponse = await updateGoldStandard(req, curatedBy);
         if(apiResponse.statusCode === 200) {
             res.status(apiResponse.statusCode).send({
                 statusCode: apiResponse.statusCode,


### PR DESCRIPTION
Follow-up to #815. Now that accepts from the Suggested tab actually persist, every FeedbackLog row they produce is stamped `curatedBy = 0`, so the curation History panel attributes **every action to "Unknown"**.

## Cause
ReCiter's `POST /reciter/goldstandard` already takes a **`curatedBy` query param** (`admin_users.userID`, `defaultValue = "0"`), and its own javadoc describes it as "the curating user's id ... supplied by Publication Manager". **PM never sent it.** The single-object path (the one PM uses) passes the value straight through to the FeedbackLog write; only the bulk/list path hardcodes 0.

Verified live on dev: after an accept, the new FeedbackLog row came back as `curatedBy: 0`, alongside pre-existing rows that carry real ids (e.g. `4`).

## The fix
Resolve the curator from the **JWT server-side** in the API route (`token.databaseUser.userID`) and forward it to the engine as `&curatedBy=<id>`. This mirrors exactly how the external-article route stamps `addedBy` — whose controller notes *"Never trust a client-supplied addedBy; stamp it from the JWT server-side."* The id is never read from the request body or query.

Best-effort and fully backward-compatible: if the token is missing or unreadable, we send no param and ReCiter keeps its existing default of 0.

## Verification
Not locally `tsc`'d (Dropbox worktree has no `node_modules`) — dev CodeBuild is the compile gate. After deploy, confirm a fresh accept writes a FeedbackLog row whose `curatedBy` is the acting user's `admin_users.userID` (not 0) and that History names the curator.

Does **not** address the separate `PENDING` row-volume observation from #815; that is engine-side (`newlyPending` diff) and tracked separately.