### PR TITLE
PROD HOTFIX: goldstandard writes 500 (invalid Content-Length) - cherry-pick of #802

### DIFF
--- a/controllers/goldstandard.controller.ts
+++ b/controllers/goldstandard.controller.ts
@@ -15,7 +15,6 @@ export async function updateGoldStandard(req: NextApiRequest)  {
         headers: {
             'Content-Type': 'application/json',
             'api-key': reciterConfig.reciter.adminApiKey,
-            'Content-Length': req.body.length,
             'User-Agent': 'reciter-pub-manager-server'
         },
         body: JSON.stringify(req.body)
@@ -39,7 +38,7 @@ export async function updateGoldStandard(req: NextApiRequest)  {
         .catch((error) => {
             console.log('ReCiter Update Goldstandard api is not reachable: ' + error)
             return {
-                statusCode: error.status,
+                statusCode: error.status || 500,
                 statusText: error
             }
         });

--- a/src/pages/api/reciter/update/goldstandard.ts
+++ b/src/pages/api/reciter/update/goldstandard.ts
@@ -18,6 +18,7 @@ export default async function handler(
 ) {
     if(req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+        try {
         const apiResponse = await updateGoldStandard(req);
         if(apiResponse.statusCode === 200) {
             res.status(apiResponse.statusCode).send({
@@ -25,10 +26,14 @@ export default async function handler(
                 goldStandard: apiResponse.statusText
             })
         } else{
-            res.status(apiResponse.statusCode).send({
-                statusCode: apiResponse.statusCode,
+            res.status(apiResponse.statusCode || 500).send({
+                statusCode: apiResponse.statusCode || 500,
                 message: apiResponse.statusText
             })
+        }
+        } catch (err) {
+            console.error('[goldstandard] Unhandled error:', err)
+            res.status(500).send({ statusCode: 500, message: 'Internal server error' })
         }
         } else if(req.headers.authorization === undefined) {
             res.status(400).send({


### PR DESCRIPTION
**Prod hotfix. Accepts currently return 500.**

## What's happening
`POST /api/reciter/update/goldstandard` is 500ing in prod:

```
ReCiter Update Goldstandard api is not reachable: TypeError: fetch failed
RangeError [ERR_HTTP_INVALID_STATUS_CODE]: Invalid status code: undefined
```

`controllers/goldstandard.controller.ts` sets `'Content-Length': req.body.length` — `req.body` is a parsed object, so `.length` is `undefined`. undici rejects the invalid header and the fetch never reaches the engine. The `.catch` then returns `statusCode: error.status` (also `undefined`), and `res.status(undefined)` throws `ERR_HTTP_INVALID_STATUS_CODE`.

## Why it surfaced now
This bug has been in `master_Next14` all along — any goldstandard write from the Accepted/Rejected tabs already hit it. #816 (Suggested-tab persist fix) made the Suggested tab actually issue the POST, so the primary curation path now hits it too, turning previously-silent failure into a visible 500.

**#816 and #802 are coupled. #816 was shipped to prod without #802; this closes that gap.** Together they are what makes accepts actually persist (verified on dev, where both are present: `knownpmids` 243→244 with a real ACCEPTED FeedbackLog row).

## The fix
Straight cherry-pick of **#802** (`e340187`), which has been running on `dev` since the recovery wave:
- Drop the invalid `Content-Length` header.
- Guard `statusCode` with `|| 500` and wrap the handler in try/catch, so a transport failure returns a clean 500 instead of throwing.

## Alternative considered
Rolling back #816 would stop the 500s but return prod to **silently discarding accepts** — strictly worse. Forward-fix is correct.