### PR TITLE
PROD: Refresh Suggestions is a setTimeout stub, so accepted articles still show as Suggested (port of #810)

### DIFF
--- a/src/components/elements/CurateIndividual/ReciterTabs.tsx
+++ b/src/components/elements/CurateIndividual/ReciterTabs.tsx
@@ -129,14 +129,15 @@ const ReciterTabs = ({ reciterData, fullName, fetchOriginalData }: { reciterData
 
   const handleRefresh = () => {
     if (refreshState !== 'idle') return;
+    const uid = reciterData?.reciter?.personIdentifier;
+    if (!uid) return;
     setRefreshState('loading');
-    // In production: dispatch(reciterFetchData(reciterData.reciter?.personIdentifier, true));
-    // For now, simulate the network call with animation states
-    setTimeout(() => {
-      setRefreshState('done');
-      setChangedAssertions(new Map()); // Changes submitted — reset tracking
-      setTimeout(() => setRefreshState('idle'), 2000);
-    }, 2500);
+    // Actually re-run ReCiter. This previously only simulated the call with a setTimeout,
+    // so the Analysis was never regenerated: an article the curator had accepted kept
+    // showing up under Suggested even though the GoldStandard had been updated.
+    // CurateIndividual renders its loading skeleton while reciterFetching is true and the
+    // tabs remount with fresh data on completion, which resets the change counter.
+    dispatch(reciterFetchData(uid, true));
   };
 
   const countBadgeClass = (value: string) => {


### PR DESCRIPTION
Third and final piece of the prod curate fix. Accepts now **save** (#816 + #818), but prod still **shows** them as Suggested.

## Cause
`handleRefresh` in prod is placeholder code that shipped to production:

```js
const handleRefresh = () => {
  setRefreshState('loading');
  // In production: dispatch(reciterFetchData(..., true));
  // For now, simulate the network call with animation states
  setTimeout(() => { setRefreshState('done'); setChangedAssertions(new Map()); ... }, 2500);
};
```

It fakes a 2.5s "Refreshing… → Done" animation and clears the change counter, but **never re-runs ReCiter**. The curate page renders the ReCiter **Analysis**, not the GoldStandard, and the Analysis is only regenerated by a re-run. So an accepted article keeps showing under Suggested.

## Confirmed against prod data (nab4004, PMID 42384931)
- `GoldStandard.knownpmids`: 10 → **11, includes 42384931** (the accept saved correctly)
- `Analysis`: **10 ACCEPTED, 1 NULL** — 42384931 still `NULL`, i.e. still "Suggested"

The data is right; the view is stale.

## The fix
Dispatch `reciterFetchData(uid, true)` so the feature generator actually re-runs. Everything it needs is already in prod: `reciterFetchData(uid, refresh)` already appends `?analysisRefreshFlag=true&retrievalRefreshFlag=ONLY_NEWLY_ADDED_PUBLICATIONS`, `ReciterTabs` already imports it and has `dispatch`, and `CurateIndividual` already renders a loading skeleton on `reciterFetching` and remounts the tabs with fresh data (which resets the counter the stub was faking).

This is the prod port of **#810**, which fixed the same stub on dev.

## Note
Prod is 65 commits behind dev, and the curate flow depends on a chain of those commits (#802, #810, #815). This is the third of the three. Promoting the dev wave properly would be a better long-term answer than continuing to cherry-pick.