### PR TITLE
fix(authorships): block accepts for identities not in ReCiter; explain bulk-accept failures

### DIFF
--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -108,6 +108,23 @@ function buildWhere(body: any): any {
 const siblingKey = (r: any) =>
   r.source === "scopus" ? String(r.external_id || "") : String(r.pmid ?? "");
 
+// Which of these cwids have a ReCiter identity? `person` mirrors ReCiter's Identity table
+// (the AAR producer matches against the wider IDM `identity` universe, so top_cwid can name
+// someone — typically inactive faculty — ReCiter doesn't track; accepting those 404s at the
+// ExternalArticle endpoint and orphans gold-standard writes). Checked at read time, not
+// produce time, because people also leave WCM after a row is produced.
+// ponytail: app-side IN() lookup instead of a SQL JOIN — person/authorship_review collations
+// differ (general_ci vs unicode_ci), which breaks and de-indexes a direct join.
+async function reciterIdentitySet(cwids: Array<string | undefined | null>): Promise<Set<string>> {
+  const wanted = [...new Set(cwids.filter(Boolean).map(String))];
+  if (wanted.length === 0) return new Set();
+  const found: any[] = await models.Person.findAll({
+    where: { personIdentifier: { [Op.in]: wanted } },
+    attributes: ["personIdentifier"], raw: true,
+  });
+  return new Set(found.map((p) => String(p.personIdentifier)));
+}
+
 // POST /api/db/authorships — paginated, filtered list of unassigned WCM authorships.
 export const listAuthorships = async (req: NextApiRequest, res: NextApiResponse) => {
   try {
@@ -149,9 +166,15 @@ export const listAuthorships = async (req: NextApiRequest, res: NextApiResponse)
       });
       scopusSib = Object.fromEntries(sib.map((s) => [String(s.external_id), Number(s.n)]));
     }
+    const knownIdentities = await reciterIdentitySet(rows.map((r: any) => r.top_cwid));
     const out = rows.map((r: any) => {
       const map = r.source === "scopus" ? scopusSib : pmidSib;
-      return { ...r.toJSON(), pmid_sibling_count: map[siblingKey(r)] || 1 };
+      return {
+        ...r.toJSON(),
+        pmid_sibling_count: map[siblingKey(r)] || 1,
+        // false → the proposed identity can't be accepted into ReCiter (UI hides Accept)
+        identity_in_reciter: !r.top_cwid || knownIdentities.has(String(r.top_cwid)),
+      };
     });
 
     res.send({ rows: out, count, limit, offset });
@@ -287,6 +310,10 @@ export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse
       case "accept": {
         if (!cwid) return res.status(409).send("No proposed identity to accept");
         if (!row.single_candidate) return res.status(409).send("Multiple candidates — use \"Pick one\" to assign");
+        // 422 (not 409) so the client's scopus force-add prompt doesn't fire for this
+        if (!(await reciterIdentitySet([cwid])).size) {
+          return res.status(422).send(`${row.top_name || cwid} has no ReCiter identity (likely departed/inactive) — this authorship can't be accepted; dismiss it instead`);
+        }
         if (isScopus) {
           const resp = await addExternalArticle(cwid, scopusExternalPayload(row), reviewer, force);
           if (resp.statusCode === 409) return res.status(409).send(resp.statusText);
@@ -313,6 +340,9 @@ export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse
         } catch { candidateCwids = []; }
         const allowed = new Set([row.top_cwid, ...candidateCwids].filter(Boolean).map(String));
         if (!allowed.has(chosen)) return res.status(400).send("cwid is not a candidate for this authorship");
+        if (!(await reciterIdentitySet([chosen])).size) {
+          return res.status(422).send(`${chosen} has no ReCiter identity (likely departed/inactive) — this authorship can't be assigned; dismiss it instead`);
+        }
         if (isScopus) {
           const resp = await addExternalArticle(chosen, scopusExternalPayload(row), reviewer, force);
           if (resp.statusCode === 409) return res.status(409).send(resp.statusText);

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -43,6 +43,8 @@ interface AuthorshipRow {
   single_candidate?: boolean;
   candidate_cwids_json?: string;
   pmid_sibling_count?: number;
+  // false → proposed identity is not in ReCiter (departed/inactive); Accept is impossible
+  identity_in_reciter?: boolean;
   status?: string;
   snooze_until?: string;
   reviewer?: string;
@@ -243,6 +245,12 @@ const scopusBadgeStyle: CSSProperties = {
 const notInPubmedPillStyle: CSSProperties = {
   display: "inline-flex", alignItems: "center", gap: 4, fontSize: 11, fontWeight: 600, padding: "2px 8px",
   borderRadius: 20, background: "#fff7ed", color: "#c2410c", border: "1px solid #fed7aa", whiteSpace: "nowrap",
+};
+// replaces the Accept button when the proposed identity is not in ReCiter
+const noIdentityPillStyle: CSSProperties = {
+  display: "inline-flex", alignItems: "center", gap: 4, fontSize: 11, fontWeight: 600, padding: "5px 10px",
+  borderRadius: 20, background: "#f8fafc", color: "#64748b", border: "1px solid #e2e8f0", whiteSpace: "nowrap",
+  cursor: "help",
 };
 
 // Scopus evidence lead: no PMID — Scopus record + DOI links (mirrors PmidLink's slot).
@@ -491,12 +499,23 @@ const AuthorshipsTabs = () => {
     setMenu(null);
     Promise.allSettled(batch.map((row) => doActionAsync(row, "accept")))
       .then((results) => {
-        const failed = results.some((r) => r.status === "rejected");
+        const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
         const ok = batch.filter((_, i) => results[i].status === "fulfilled");
         if (ok.length > 0) setUndo({ rows: ok, label: `Accepted ${ok.length}` });
         // success: silently refill the queue to the next batch ("accept 20 → next 20").
-        // failure: full refresh (with loading) to restore the optimistically-removed rows.
-        if (failed) { setErrorMsg("Some accepts failed — refreshing"); fetchData(); }
+        // failure: full refresh (with loading) to restore the optimistically-removed rows,
+        // with the failures broken down by cause so the same rows don't fail opaquely forever.
+        if (failures.length) {
+          const dups = failures.filter((f) => (f.reason as any)?.status === 409).length;
+          const noId = failures.filter((f) => (f.reason as any)?.status === 422).length;
+          const other = failures.length - dups - noId;
+          const parts: string[] = [];
+          if (dups) parts.push(`${dups} possible duplicate${dups > 1 ? "s" : ""} (accept individually to review)`);
+          if (noId) parts.push(`${noId} with no ReCiter identity`);
+          if (other) parts.push(`${other} failed`);
+          setErrorMsg(`${failures.length} of ${batch.length} accepts skipped: ${parts.join("; ")} — refreshing`);
+          fetchData();
+        }
         else topUp();
         fetchSummary();
       });
@@ -533,7 +552,8 @@ const AuthorshipsTabs = () => {
   }, []);
 
   const toggleSelect = useCallback((row: AuthorshipRow) => {
-    if (!row.single_candidate || statusView !== "open") return; // multi rows aren't bulk-selectable
+    // multi rows and no-ReCiter-identity rows aren't bulk-selectable
+    if (!row.single_candidate || row.identity_in_reciter === false || statusView !== "open") return;
     setSelected((s) => {
       const next = new Set(s);
       next.has(row.id) ? next.delete(row.id) : next.add(row.id);
@@ -600,7 +620,13 @@ const AuthorshipsTabs = () => {
       if (!row) return;
       const doAction = doActionRef.current;
       const toggleSelect = toggleSelectRef.current;
-      if (k === "y") { if (row.single_candidate && statusView === "open") doAction?.(row, "accept"); else setErrorMsg("Use Pick one ▾ to assign a multi-candidate authorship"); e.preventDefault(); }
+      if (k === "y") {
+        if (row.single_candidate && statusView === "open") {
+          if (row.identity_in_reciter === false) setErrorMsg(`${row.top_name || row.top_cwid} is not in ReCiter — this authorship can't be accepted (dismiss it instead)`);
+          else doAction?.(row, "accept");
+        } else setErrorMsg("Use Pick one ▾ to assign a multi-candidate authorship");
+        e.preventDefault();
+      }
       else if (k === "n") { if (statusView === "open") { if (row.single_candidate) doAction?.(row, "reject"); else setErrorMsg("Use Pick one ▾ / None of these for a multi-candidate authorship"); } e.preventDefault(); }
       else if (k === "s") { if (statusView === "open") doAction?.(row, "snooze"); e.preventDefault(); }
       else if (k === "x") { toggleSelect?.(row); e.preventDefault(); }
@@ -619,11 +645,11 @@ const AuthorshipsTabs = () => {
   const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
   const classChips: Array<typeof classification> = ["all", "buried", "absent", "suggested"];
 
-  // F4: near-certain bulk = visible single-candidate rows with IO >= 95
-  const nearCertain = rows.filter((r) => r.single_candidate && (r.top_io_score ?? 0) >= 95);
+  // F4: near-certain bulk = visible single-candidate rows with IO >= 95 (and acceptable)
+  const nearCertain = rows.filter((r) => r.single_candidate && r.identity_in_reciter !== false && (r.top_io_score ?? 0) >= 95);
   const selectedRows = rows.filter((r) => selected.has(r.id));
   // Item 7: select-all targets the eligible (bulk-selectable) rows on this page
-  const eligibleRows = statusView === "open" ? rows.filter((r) => r.single_candidate) : [];
+  const eligibleRows = statusView === "open" ? rows.filter((r) => r.single_candidate && r.identity_in_reciter !== false) : [];
   const allEligibleSelected = eligibleRows.length > 0 && eligibleRows.every((r) => selected.has(r.id));
   const someEligibleSelected = eligibleRows.some((r) => selected.has(r.id));
   const toggleSelectAllEligible = useCallback(() => {
@@ -962,6 +988,7 @@ const AuthorshipCard = ({
   registerRef, onFocus, onToggleExpand, onToggleSelect, onPick, onAction, onMenu, onNarrowPmid,
 }: CardProps) => {
   const isMulti = !r.single_candidate && (r.n_candidates ?? 0) > 1;
+  const noIdentity = r.identity_in_reciter === false;
   const isAbsent = r.top_io_score == null;
   const wcm = hasWcm(r.author_affiliation);
   const candidates = isMulti ? parseCandidates(r.candidate_cwids_json) : [];
@@ -980,11 +1007,11 @@ const AuthorshipCard = ({
   return (
     <article ref={registerRef} tabIndex={0} onFocus={onFocus} onMouseEnter={onFocus} onClick={onToggleExpand} style={cardStyle}>
       <div style={{ display: "flex", alignItems: "flex-start", gap: 12, padding: "13px 15px" }}>
-        {/* selection checkbox — single-candidate open rows only */}
-        <input type="checkbox" disabled={!r.single_candidate || statusView !== "open"}
+        {/* selection checkbox — single-candidate open rows with a ReCiter identity only */}
+        <input type="checkbox" disabled={!r.single_candidate || noIdentity || statusView !== "open"}
           checked={isSelected} onChange={onToggleSelect} onClick={(e) => e.stopPropagation()}
           aria-label={`select ${r.wcm_author || ""}`}
-          style={{ width: 16, height: 16, marginTop: 3, accentColor: "#2563eb", cursor: r.single_candidate && statusView === "open" ? "pointer" : "default", flex: "none", opacity: r.single_candidate && statusView === "open" ? 1 : 0.3 }} />
+          style={{ width: 16, height: 16, marginTop: 3, accentColor: "#2563eb", cursor: r.single_candidate && !noIdentity && statusView === "open" ? "pointer" : "default", flex: "none", opacity: r.single_candidate && !noIdentity && statusView === "open" ? 1 : 0.3 }} />
 
         <div style={{ flex: 1, minWidth: 0 }}>
           {/* L1 — WCM author + position */}
@@ -1060,6 +1087,10 @@ const AuthorshipCard = ({
           {statusView === "open" ? (
             isMulti ? (
               <button style={btn("ghost")} onClick={(e) => { e.stopPropagation(); onToggleExpand(); }}>Pick one <IconChevR size={13} /></button>
+            ) : noIdentity ? (
+              <Tip title={`${r.top_name || r.top_cwid} is not in ReCiter (likely departed or inactive), so this authorship can't be accepted. Dismiss it via the ⋯ menu, or leave it open.`} placement="top" arrow>
+                <span style={noIdentityPillStyle} onClick={(e) => e.stopPropagation()}>No ReCiter identity</span>
+              </Tip>
             ) : (
               <button style={btn("accept", acting)} disabled={acting} onClick={(e) => { e.stopPropagation(); onAction("accept"); }}>
                 <IconCheck /> Accept


### PR DESCRIPTION
## Problem (prod, 2026-07-16)

Curators on the prod Authorships tab hit two opaque failures:

1. **`ExternalArticle add failed (404)`** — an Accept on a scopus row POSTs to ReCiter's `/reciter/external-article/by/uid`, whose only 404 path is *uid not in the Identity table*. The AAR producer matches authors against the wider IDM `identity` universe, so it proposes people ReCiter doesn't track. Verified: `paz2001`, `wib2004` absent from both DynamoDB `Identity` and reciterdb `person`. These rows can never be accepted, yet showed a green Accept button. Pubmed rows have the same disease in quieter form (gold-standard writes for a person ReCiter never processes).
2. **`Some accepts failed — refreshing`** — the bulk-accept toast collapses every failure (409 possible-duplicate, 404 no-identity, anything else) into one message with no reasons, so the same rows fail every retry (prod logs show identical failure sets across 3 consecutive bulk attempts).

## Scale (live reciterdb query, 2026-07-16)

Open rows whose `top_cwid` is not in `person` (≈ ReCiter Identity): **863 pubmed + 868 scopus = 1,731** (~6.4% of open rows with a proposed identity); 1,259 of them are in the single-candidate accept lane. 98% are **Inactive Faculty**.

## Fix

- `listAuthorships` returns `identity_in_reciter` per row — an app-side `IN()` lookup against `person` (a SQL JOIN breaks on the general_ci/unicode_ci collation mismatch between the tables). Read-time check, not produce-time, because people also leave WCM after rows are produced.
- `accept`/`assign` server-side guard returns **422** with a human message (422, not 409, so the client's scopus force-add prompt doesn't fire).
- UI: Accept button replaced by a **No ReCiter identity** pill with an explanatory tooltip; rows excluded from bulk selection, select-all, and the near-certain lane; keyboard `Y` explains instead of failing. Dismiss/Snooze remain available.
- Bulk toast now itemizes: `N of M accepts skipped: 2 possible duplicates (accept individually to review); 1 with no ReCiter identity`.

## Verification

- `npx tsc --noEmit` clean (one pre-existing baseline error in untouched `src/lib/articleProvenance.ts`).
- Root cause verified against prod: nginx access logs (404s/409s per uid) + DynamoDB Identity lookups + in-cluster reciterdb query.
- **Not yet verified at runtime** — needs a dev deploy + curator smoke test on `reciter-pm-dev` (SAML-walled): confirm the pill renders for an inactive-faculty row, bulk accept skips it, and the new toast wording appears.