### PR TITLE
Show every author on a Scopus result, not just the first

### DIFF
--- a/controllers/scopusSearch.controller.ts
+++ b/controllers/scopusSearch.controller.ts
@@ -17,6 +17,18 @@ export function scopusConfigured(): boolean {
 }
 
 // One Scopus Search entry -> external-article POST body (minus addedBy, set server-side).
+// Full author list, falling back to dc:creator (the FIRST author only) when the entry has no
+// author array — which is what every entry looked like before ScopusTool asked for `author` by
+// field, and is still what an older tool build returns. The fallback keeps a stale tool showing
+// one name rather than none; it is not the intended path.
+function scopusAuthors(entry: any, creator: any): string[] {
+    const authors = Array.isArray(entry.author)
+        ? entry.author.map((a: any) => a && (a.authname || a['ce:indexed-name'])).filter(Boolean)
+        : []
+    if (authors.length) return authors
+    return creator ? [creator] : []
+}
+
 function normalizeScopusDoc(entry: any) {
     if (!entry) return null
     const scopusId = String(entry['dc:identifier'] || '').replace(/^SCOPUS_ID:/, '')
@@ -29,7 +41,7 @@ function normalizeScopusDoc(entry: any) {
         doi: entry['prism:doi'] || undefined,
         pmid: pmidRaw ? Number(pmidRaw) : undefined,
         journalOrVenue: entry['prism:publicationName'] || undefined,
-        authors: creator ? [creator] : [],   // Scopus search view returns first author only
+        authors: scopusAuthors(entry, creator),
         pubDate: entry['prism:coverDate'] || undefined,
         publicationType: entry['subtypeDescription'] || undefined,
         sourceType: 'SCOPUS',


### PR DESCRIPTION
## The bug

```
PM card       Proal A.D.
ScienceDirect Amy D. Proal, Paul J. Albert, Trevor G. Marshall
```

`normalizeScopusDoc` read `dc:creator`, which Scopus populates with the **first author only**. The stale comment on that line said as much and treated it as a fact of life.

It is not display-only. The normalized object is the external-article POST body, so accepting a Scopus-only item **wrote** a one-author record into the publication.

## What changed

Read the full `author` array, keeping `dc:creator` as a fallback:

```ts
authors: scopusAuthors(entry, creator)
```

The fallback matters during rollout — until ScopusTool #38 is deployed, entries have no `author` array, and this degrades to the current one-name behaviour rather than to none.

## Requires ScopusTool #38

The tool has to ask Elsevier for the author array before there is one to read. Merging this alone changes nothing; merging the tool alone leaves PM still reading `dc:creator`. **Deploy the tool first**, then this.

Why the tool asks by `field=` rather than `view=COMPLETE`: COMPLETE caps a page at 25 and refuses `count=200` with an HTTP 400, so it would trade missing authors for missing documents. The field whitelist returns all 117 of a prolific author's records with full authors in one call. Probed live, details in #38.

## Verification

`npx tsc --noEmit` — clean for this file. The repo has one pre-existing unrelated error (`@aws-sdk/client-dynamodb` is in `package.json` but missing from the local `node_modules`), present before this change.

No unit test: this repo has no test runner or test suite, and standing one up for a six-line helper is a larger change than the fix. The real failure mode is the tool's field whitelist, which is pinned by tests in #38.

Still to verify in a browser on reciter-dev once both are deployed: the card for `10.1016/B978-0-444-63269-2.00007-6` should read all three authors.