### PR TITLE
Report a missing Scopus URL instead of "No Scopus documents matched"

### DIFF
--- a/config/local.js
+++ b/config/local.js
@@ -125,11 +125,13 @@ export const reciterConfig = {
      * This endpoint is used to search pubmed. You need to have ReCiter-Pubmed-Retrieval tool conifgured. See https://github.com/wcmc-its/ReCiter-PubMed-Retrieval-Tool.git
      * for details.
      *
-     * On prod these /pubmed/query-* routes live behind the same ingress as the
-     * ReCiter Spring Boot service, so RECITER_API_BASE_URL is sufficient. On
-     * dev the two services are separate (reciter-dev vs reciter-pubmed-dev),
-     * so RECITER_PUBMED_API_URL can override just these routes. Falls back to
-     * RECITER_API_BASE_URL when unset.
+     * The PubMed tool is a separate service in every environment
+     * (reciter-pubmed-dev / reciter-pubmed-prod), so RECITER_PUBMED_API_URL is
+     * REQUIRED — there is no fallback. It reads as one, so be explicit: unset,
+     * these become the literal string "undefined/pubmed/query-complex/" and the
+     * fetch fails at call time rather than at startup. An earlier version of
+     * this comment promised a fallback to RECITER_API_BASE_URL that the code
+     * below never implemented; the Scopus twin of that lie cost hours in prod.
      */
     reciterPubmed: {
         searchPubmedEndpoint: process.env.RECITER_PUBMED_API_URL + '/pubmed/query-complex/',
@@ -137,9 +139,14 @@ export const reciterConfig = {
     },
     /**
      * Scopus search via the ReCiter Scopus Retrieval Tool. The tool holds the Elsevier
-     * SCOPUS_API_KEY / SCOPUS_INST_TOKEN, so PM no longer needs them. Like PubMed, on dev
-     * the Scopus tool is a separate service (reciter-scopus-dev), so RECITER_SCOPUS_API_URL
-     * overrides just these routes; it falls back to RECITER_API_BASE_URL when unset.
+     * SCOPUS_API_KEY / SCOPUS_INST_TOKEN, so PM no longer needs them. Like PubMed, the tool
+     * is a separate service per environment (reciter-scopus-dev / reciter-scopus-prod), so
+     * RECITER_SCOPUS_API_URL is REQUIRED — there is no fallback to RECITER_API_BASE_URL,
+     * which serves no /scopus/* route. Unset, these become the literal string
+     * "undefined/scopus/search/documents"; scopusConfigured() gates on this exact variable
+     * so that shows up as an honest 503 rather than an empty result set.
+     * NOTE the scheme: these are in-cluster NodePort services listening on port 80 only —
+     * an https:// value connects to :443 and hangs until timeout.
      * See https://github.com/wcmc-its/ReCiter-Scopus-Retrieval-Tool.git.
      */
     reciterScopus: {

--- a/controllers/scopusSearch.controller.ts
+++ b/controllers/scopusSearch.controller.ts
@@ -13,7 +13,15 @@ import { reciterConfig } from '../config/local'
 export function scopusConfigured(): boolean {
     // The Elsevier credentials now live in the Scopus Retrieval Tool; here we only need the
     // tool endpoint to be configured. A missing key in the tool surfaces as a 5xx below.
-    return !!(process.env.RECITER_SCOPUS_API_URL || process.env.RECITER_API_BASE_URL)
+    //
+    // ONLY RECITER_SCOPUS_API_URL counts. This used to also accept RECITER_API_BASE_URL, but that
+    // was a fallback in name only: config/local.js builds the endpoint from RECITER_SCOPUS_API_URL
+    // alone, so with just the base URL set this returned true while the endpoint was the literal
+    // string "undefined/scopus/search/documents". The fetch threw, the route answered 502, and the
+    // tab rendered it as "No Scopus documents matched" — a misconfigured server claiming the person
+    // has no Scopus record. Prod ran that way and it cost hours to find. Gate on the one variable
+    // that is actually used, so a missing value says so.
+    return !!process.env.RECITER_SCOPUS_API_URL
 }
 
 // One Scopus Search entry -> external-article POST body (minus addedBy, set server-side).


### PR DESCRIPTION
## Why

```ts
return !!(process.env.RECITER_SCOPUS_API_URL || process.env.RECITER_API_BASE_URL)
```

`config/local.js` builds the Scopus endpoints from `RECITER_SCOPUS_API_URL` **alone**. `RECITER_API_BASE_URL` is not a fallback — it serves no `/scopus/*` route — but it is always set, so this gate always passed. With the Scopus variable missing, the endpoint was the literal string:

```
"undefined/scopus/search/documents"
```

The fetch throws, the route answers 502, and `TabScopusAuthorships` renders that as **"No Scopus documents matched"** — a misconfigured server stating confidently that the person has no Scopus record. The 503 written for exactly this case could never fire, because the gate it sits behind had already passed.

That is how prod ran until today, and the false negative is what made it expensive to diagnose: the failure was indistinguishable from a correct empty result.

## What

Gate on the one variable the URL is actually built from, so an unset value produces the honest 503.

The config comments carried the same false promise for **both** Scopus and PubMed — "Falls back to `RECITER_API_BASE_URL` when unset" — which neither implements. Both corrected.

Also recorded there: these are in-cluster **NodePort services listening on port 80 only**, so an `https://` value connects to `:443` and hangs until timeout rather than failing fast. That mistake was made while fixing the original bug and presents identically to it.

## Scope

Behaviour changes only when `RECITER_SCOPUS_API_URL` is unset — today an empty results list, after this a 503 saying the server is not configured. Every environment that has the variable set is unaffected.

`npx tsc --noEmit` — 0 errors in both touched files. The repo has one pre-existing unrelated error (`@aws-sdk/client-dynamodb` declared but not installed locally).

## Also worth doing, not here

`master_Next14` carries the identical gate and should get this cherry-picked with the other Scopus fixes.