### PR TITLE
Scopus: full author list, and an honest error on missing config (prod)

### DIFF
--- a/config/local.js
+++ b/config/local.js
@@ -125,33 +125,26 @@ export const reciterConfig = {
      * This endpoint is used to search pubmed. You need to have ReCiter-Pubmed-Retrieval tool conifgured. See https://github.com/wcmc-its/ReCiter-PubMed-Retrieval-Tool.git
      * for details.
      *
-     * The PubMed tool is a separate service in every environment
-     * (reciter-pubmed-dev / reciter-pubmed-prod), so RECITER_PUBMED_API_URL is
-     * REQUIRED — there is no fallback. It reads as one, so be explicit: unset,
-     * these become the literal string "undefined/pubmed/query-complex/" and the
-     * fetch fails at call time rather than at startup. An earlier version of
-     * this comment promised a fallback to RECITER_API_BASE_URL that the code
-     * below never implemented; the Scopus twin of that lie cost hours in prod.
+     *On prod these /pubmed/query-* routes live behind the same ingress as the
+     * ReCiter Spring Boot service, so RECITER_API_BASE_URL is sufficient. On
+     * dev the two services are separate (reciter-dev vs reciter-pubmed-dev),
+     * so RECITER_PUBMED_API_URL can override just these routes. Falls back to
+     * RECITER_API_BASE_URL when unset.
      */
     reciterPubmed: {
-        searchPubmedEndpoint: process.env.RECITER_PUBMED_API_URL + '/pubmed/query-complex/',
-        searchPubmedCountEndpoint: process.env.RECITER_PUBMED_API_URL + '/pubmed/query-number-pubmed-articles/',
+        searchPubmedEndpoint: process.env.RECITER_API_BASE_URL + '/pubmed/query-complex/',
+        searchPubmedCountEndpoint: process.env.RECITER_API_BASE_URL + '/pubmed/query-number-pubmed-articles/',
     },
     /**
      * Scopus search via the ReCiter Scopus Retrieval Tool. The tool holds the Elsevier
-     * SCOPUS_API_KEY / SCOPUS_INST_TOKEN, so PM no longer needs them. Like PubMed, the tool
-     * is a separate service per environment (reciter-scopus-dev / reciter-scopus-prod), so
-     * RECITER_SCOPUS_API_URL is REQUIRED — there is no fallback to RECITER_API_BASE_URL,
-     * which serves no /scopus/* route. Unset, these become the literal string
-     * "undefined/scopus/search/documents"; scopusConfigured() gates on this exact variable
-     * so that shows up as an honest 503 rather than an empty result set.
-     * NOTE the scheme: these are in-cluster NodePort services listening on port 80 only —
-     * an https:// value connects to :443 and hangs until timeout.
+     * SCOPUS_API_KEY / SCOPUS_INST_TOKEN, so PM no longer needs them. Like PubMed, on dev
+     * the Scopus tool is a separate service (reciter-scopus-dev), so RECITER_SCOPUS_API_URL
+     * overrides just these routes; it falls back to RECITER_API_BASE_URL when unset.
      * See https://github.com/wcmc-its/ReCiter-Scopus-Retrieval-Tool.git.
      */
     reciterScopus: {
-        searchDocumentsEndpoint: process.env.RECITER_SCOPUS_API_URL + '/scopus/search/documents',
-        searchAuthorsEndpoint: process.env.RECITER_SCOPUS_API_URL  + '/scopus/search/authors',
+        searchDocumentsEndpoint: process.env.RECITER_API_BASE_URL + '/scopus/search/documents',
+        searchAuthorsEndpoint: process.env.RECITER_API_BASE_URL  + '/scopus/search/authors',
     },
     /**
      * PM#771 — OpenAlex is a free, keyless public API. It is queried ONLY server-side

--- a/config/local.js
+++ b/config/local.js
@@ -125,11 +125,13 @@ export const reciterConfig = {
      * This endpoint is used to search pubmed. You need to have ReCiter-Pubmed-Retrieval tool conifgured. See https://github.com/wcmc-its/ReCiter-PubMed-Retrieval-Tool.git
      * for details.
      *
-     * On prod these /pubmed/query-* routes live behind the same ingress as the
-     * ReCiter Spring Boot service, so RECITER_API_BASE_URL is sufficient. On
-     * dev the two services are separate (reciter-dev vs reciter-pubmed-dev),
-     * so RECITER_PUBMED_API_URL can override just these routes. Falls back to
-     * RECITER_API_BASE_URL when unset.
+     * The PubMed tool is a separate service in every environment
+     * (reciter-pubmed-dev / reciter-pubmed-prod), so RECITER_PUBMED_API_URL is
+     * REQUIRED — there is no fallback. It reads as one, so be explicit: unset,
+     * these become the literal string "undefined/pubmed/query-complex/" and the
+     * fetch fails at call time rather than at startup. An earlier version of
+     * this comment promised a fallback to RECITER_API_BASE_URL that the code
+     * below never implemented; the Scopus twin of that lie cost hours in prod.
      */
     reciterPubmed: {
         searchPubmedEndpoint: process.env.RECITER_PUBMED_API_URL + '/pubmed/query-complex/',
@@ -137,9 +139,14 @@ export const reciterConfig = {
     },
     /**
      * Scopus search via the ReCiter Scopus Retrieval Tool. The tool holds the Elsevier
-     * SCOPUS_API_KEY / SCOPUS_INST_TOKEN, so PM no longer needs them. Like PubMed, on dev
-     * the Scopus tool is a separate service (reciter-scopus-dev), so RECITER_SCOPUS_API_URL
-     * overrides just these routes; it falls back to RECITER_API_BASE_URL when unset.
+     * SCOPUS_API_KEY / SCOPUS_INST_TOKEN, so PM no longer needs them. Like PubMed, the tool
+     * is a separate service per environment (reciter-scopus-dev / reciter-scopus-prod), so
+     * RECITER_SCOPUS_API_URL is REQUIRED — there is no fallback to RECITER_API_BASE_URL,
+     * which serves no /scopus/* route. Unset, these become the literal string
+     * "undefined/scopus/search/documents"; scopusConfigured() gates on this exact variable
+     * so that shows up as an honest 503 rather than an empty result set.
+     * NOTE the scheme: these are in-cluster NodePort services listening on port 80 only —
+     * an https:// value connects to :443 and hangs until timeout.
      * See https://github.com/wcmc-its/ReCiter-Scopus-Retrieval-Tool.git.
      */
     reciterScopus: {

--- a/controllers/scopusSearch.controller.ts
+++ b/controllers/scopusSearch.controller.ts
@@ -13,7 +13,15 @@ import { reciterConfig } from '../config/local'
 export function scopusConfigured(): boolean {
     // The Elsevier credentials now live in the Scopus Retrieval Tool; here we only need the
     // tool endpoint to be configured. A missing key in the tool surfaces as a 5xx below.
-    return !!(process.env.RECITER_SCOPUS_API_URL || process.env.RECITER_API_BASE_URL)
+    //
+    // ONLY RECITER_SCOPUS_API_URL counts. This used to also accept RECITER_API_BASE_URL, but that
+    // was a fallback in name only: config/local.js builds the endpoint from RECITER_SCOPUS_API_URL
+    // alone, so with just the base URL set this returned true while the endpoint was the literal
+    // string "undefined/scopus/search/documents". The fetch threw, the route answered 502, and the
+    // tab rendered it as "No Scopus documents matched" — a misconfigured server claiming the person
+    // has no Scopus record. Prod ran that way and it cost hours to find. Gate on the one variable
+    // that is actually used, so a missing value says so.
+    return !!process.env.RECITER_SCOPUS_API_URL
 }
 
 // One Scopus Search entry -> external-article POST body (minus addedBy, set server-side).

--- a/controllers/scopusSearch.controller.ts
+++ b/controllers/scopusSearch.controller.ts
@@ -17,6 +17,18 @@ export function scopusConfigured(): boolean {
 }
 
 // One Scopus Search entry -> external-article POST body (minus addedBy, set server-side).
+// Full author list, falling back to dc:creator (the FIRST author only) when the entry has no
+// author array — which is what every entry looked like before ScopusTool asked for `author` by
+// field, and is still what an older tool build returns. The fallback keeps a stale tool showing
+// one name rather than none; it is not the intended path.
+function scopusAuthors(entry: any, creator: any): string[] {
+    const authors = Array.isArray(entry.author)
+        ? entry.author.map((a: any) => a && (a.authname || a['ce:indexed-name'])).filter(Boolean)
+        : []
+    if (authors.length) return authors
+    return creator ? [creator] : []
+}
+
 function normalizeScopusDoc(entry: any) {
     if (!entry) return null
     const scopusId = String(entry['dc:identifier'] || '').replace(/^SCOPUS_ID:/, '')
@@ -29,7 +41,7 @@ function normalizeScopusDoc(entry: any) {
         doi: entry['prism:doi'] || undefined,
         pmid: pmidRaw ? Number(pmidRaw) : undefined,
         journalOrVenue: entry['prism:publicationName'] || undefined,
-        authors: creator ? [creator] : [],   // Scopus search view returns first author only
+        authors: scopusAuthors(entry, creator),
         pubDate: entry['prism:coverDate'] || undefined,
         publicationType: entry['subtypeDescription'] || undefined,
         sourceType: 'SCOPUS',

--- a/controllers/scopusSearch.controller.ts
+++ b/controllers/scopusSearch.controller.ts
@@ -21,7 +21,7 @@ export function scopusConfigured(): boolean {
     // tab rendered it as "No Scopus documents matched" — a misconfigured server claiming the person
     // has no Scopus record. Prod ran that way and it cost hours to find. Gate on the one variable
     // that is actually used, so a missing value says so.
-    return !!process.env.RECITER_SCOPUS_API_URL
+    return !!process.env.RECITER_API_BASE_URL
 }
 
 // One Scopus Search entry -> external-article POST body (minus addedBy, set server-side).


### PR DESCRIPTION
## What

Cherry-picks of `cd664a2` (#842) and `876b857` (#843), both merged to `dev`. #842 is deployed and verified on `reciter-pm-dev`. Applied with no conflicts.

```
2 files changed, 37 insertions(+), 10 deletions(-)
  controllers/scopusSearch.controller.ts   read author[], gate on the real env var
  config/local.js                          correct two false comments
```

### 1. Every author, not just the first

`normalizeScopusDoc` read `dc:creator`, which Scopus populates with the **first author only**, so a three-author chapter rendered as one name — and, because that object is the external-article POST body, was **stored** as one name.

Measured on the `ExternalArticle` table, which prod and dev ReCiter share:

```
Scopus-accepted rows   120   across 91 people
truly multi-author     115
author names lost      721   max 28 on one record
```

**Requires ScopusTool #39** to be deployed first — this reads an `author` array the tool only returns once that ships. The `dc:creator` fallback means an un-upgraded tool degrades to today's one-name behaviour rather than to none.

Does **not** repair the 120 existing rows; that is a separate backfill.

### 2. An honest error when the Scopus URL is missing

`scopusConfigured()` also accepted `RECITER_API_BASE_URL`, which is not a fallback — `config/local.js` builds the endpoints from `RECITER_SCOPUS_API_URL` alone. Since the base URL is always set, the gate always passed, and with the Scopus variable missing the endpoint was the literal string `"undefined/scopus/search/documents"`. The fetch threw, the route answered 502, and the tab rendered **"No Scopus documents matched"** — a misconfigured server reporting the person has no Scopus record.

**Prod ran exactly that way until today.** The 503 written for this case could never fire.

**Inert on prod as it stands:** `RECITER_SCOPUS_API_URL` is now set on `reciter-pm-prod`, so this changes nothing there today. It only alters behaviour when the variable is missing — which is precisely when the old code lied.

The config comments promised the same non-existent fallback for **both** Scopus and PubMed; both corrected, along with a note that these are NodePort services on port 80, since an `https://` value hangs to timeout rather than failing fast.

## Verification

`npx tsc --noEmit` — 0 errors in both touched files. One pre-existing unrelated error in the repo (`@aws-sdk/client-dynamodb` declared but not installed locally), present before these commits.

No unit test: this repo has no test runner or suite, and standing one up for a six-line helper is a larger change than the fix. The contract is tested on the tool side in #38/#39.

## Deploy order

ScopusTool #39 → then this.