### PR TITLE
fix(search): parse newline/comma-separated CWID pastes, stop clobbering pubSearchFilter

### DIFF
--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -412,7 +412,11 @@ const Search = () => {
       setTotalCount(countAllData);
     }
     if (searchText) {
-      let searchWords = searchText.trim().split(' ');
+      // Split on any run of whitespace or commas, not just a single space, so a CWID
+      // list pasted from a spreadsheet column (newline-separated) or a comma-separated
+      // list parses into one token per person instead of collapsing into one mangled
+      // string that then misses the bulk-CWID threshold below.
+      let searchWords = searchText.trim().split(/[\s,]+/).filter(Boolean);
       dispatch(updateAuthorFilter(searchWords.join(),10));
 
       updatedFilters = { ...updatedFilters, nameOrUids: searchWords };

--- a/src/redux/actions/actions.js
+++ b/src/redux/actions/actions.js
@@ -1862,11 +1862,20 @@ export const clearReportSearchResults = () => dispatch => {
     })
 }
 
+// initialStatePubSearchFilter is also the pubSearchFilter reducer's default state (reducers.js).
+// Mutating it in place (as the three functions below used to) permanently pollutes that default,
+// so PUB_FILTER_CLEAR stops actually clearing anything for the rest of the session. Clone it instead.
+const cloneInitialPubSearchFilter = () => ({
+    ...initialStatePubSearchFilter,
+    filters: { ...initialStatePubSearchFilter.filters },
+    sort: { ...initialStatePubSearchFilter.sort },
+})
+
 export const clearPubSearchFilters = ()  => {
     return(dispatch, getState) => {
         const filters = getState().filters;
-        
-        let reportsSearchFilters = initialStatePubSearchFilter;
+
+        let reportsSearchFilters = cloneInitialPubSearchFilter();
             //clearing all report filters upon clicking reset button
             reportsSearchFilters.filters.personIdentifers = [];
             reportsSearchFilters.filters.orgUnits = [];
@@ -1897,14 +1906,14 @@ export const clearPubSearchFilters = ()  => {
 export const updateIndividualPersonReportCriteria =(personIdentifier) =>{
     return(dispatch, getState) => {
         const filters = getState().filters;
-        let reportsSearchFilters = initialStatePubSearchFilter;
+        let reportsSearchFilters = cloneInitialPubSearchFilter();
           if (personIdentifier) {
             reportsSearchFilters.filters.personIdentifers = [personIdentifier.personIdentifier];
           }
           updateAuthorFilter(personIdentifier.personIdentifier,10)
           dispatch({
             type: methods.PUB_FILTER_CLEAR,
-            payoload: reportsSearchFilters
+            payload: reportsSearchFilters
           });
     }
     
@@ -1916,7 +1925,7 @@ export const updatePubFiltersFromSearch = () => {
       
       // get filters from Search Page
       const filters = getState().filters;
-    let reportsSearchFilters = initialStatePubSearchFilter;
+    let reportsSearchFilters = cloneInitialPubSearchFilter();
     if (filters.orgUnits) {
       reportsSearchFilters.filters.orgUnits = [...filters.orgUnits]; 
     }
@@ -1936,7 +1945,7 @@ export const updatePubFiltersFromSearch = () => {
 
     dispatch({
       type: methods.PUB_FILTER_CLEAR,
-      payoload: reportsSearchFilters
+      payload: reportsSearchFilters
     });
   }
 }

--- a/src/redux/reducers/reducers.js
+++ b/src/redux/reducers/reducers.js
@@ -747,7 +747,10 @@ export const pubSearchFilter = ( state = initialStatePubSearchFilter, action) =>
       return action.payload 
     
     case methods.PUB_FILTER_CLEAR:
-      return initialStatePubSearchFilter
+      // All three dispatchers (clearPubSearchFilters, updateIndividualPersonReportCriteria,
+      // updatePubFiltersFromSearch) send a payload built from a clone of initialStatePubSearchFilter;
+      // this used to ignore it and rely on those dispatchers mutating the shared default in place instead.
+      return action.payload || initialStatePubSearchFilter
 
     case methods.PUB_POPULATE_SEARCH_FILTERS:
       return action.payload


### PR DESCRIPTION
Fixes #850.

Traced from source (`origin/dev`) — not confirmed live yet, this environment is SAML-walled with no login available. Please smoke-test on dev before merging: paste a newline-separated CWID list into Find People, Search, click Create Reports.

## What was broken

1. **`Search.js`** — `searchText.trim().split(' ')` only splits on a literal space. A CWID list pasted from a spreadsheet column (one per line) collapses into a single mangled token. That token has `length === 1`, which misses the `> 3` bulk-CWID-mode threshold in `person.controller.ts` (`nameCWIDSpaceCountThreshold`), so it falls through to name-search instead of exact-ID matching and returns nothing. `Create Reports` then carries that same empty/broken filter to the report page. Fixed by splitting on any whitespace/comma run.

2. **`actions.js` / `reducers.js`** — `clearPubSearchFilters`, `updateIndividualPersonReportCriteria`, and `updatePubFiltersFromSearch` all did `let reportsSearchFilters = initialStatePubSearchFilter` (same object reference) and then mutated it in place. `initialStatePubSearchFilter` is also the `pubSearchFilter` reducer's default state, so the first mutation permanently pollutes it — `PUB_FILTER_CLEAR` stops actually clearing anything for the rest of the session. The reducer's `PUB_FILTER_CLEAR` case also just returned `initialStatePubSearchFilter` unconditionally, ignoring `action.payload` entirely (which is why the mutation-through-shared-reference was load-bearing instead of just an anti-pattern, and why two of the three dispatch sites had a `payoload` typo that nobody noticed — it was never read either way).

   Fixed by cloning before mutating (`cloneInitialPubSearchFilter()`) and having the reducer read `action.payload`.

## Verification

- `next lint` clean on the three touched files (pre-existing warnings elsewhere unrelated)
- `tsc --noEmit` — one pre-existing unrelated error (`articleProvenance.ts`, missing `@aws-sdk/client-dynamodb` types in this worktree's `node_modules`), nothing in the touched files
- No test framework in this repo to add a unit test to; recommend the live smoke test above before merge