### PR TITLE
fix(security): require an authenticated Superuser session on the admin user-management API

### DIFF
--- a/controllers/db/adminAuth.controller.ts
+++ b/controllers/db/adminAuth.controller.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest } from 'next'
+import { getToken } from 'next-auth/jwt'
+import { getCapabilities } from '../../src/utils/constants'
+
+const safeJsonParse = (value: any, fallback: any) => {
+    if (value == null) return fallback
+    if (typeof value !== 'string') return value
+    try { return JSON.parse(value) } catch { return fallback }
+}
+
+/**
+ * True if the request carries a valid, signed session belonging to a user whose role grants
+ * canManageUsers (Superuser only).
+ *
+ * The `backendApiKey` header these admin routes also check is `NEXT_PUBLIC_RECITER_BACKEND_API_KEY`
+ * -- a NEXT_PUBLIC_ env var, which Next.js inlines into the client JS bundle at build time. It is
+ * not a secret; it identifies "a request from this app's frontend," not "a request from an
+ * authorized admin." Nothing else gated these routes, so anyone who reads it out of the served JS
+ * could call them directly with no session at all -- including the route that assigns roles, which
+ * made it a full authentication bypass to Superuser. This is the actual authorization check.
+ */
+export const isAuthorizedAdmin = async (req: NextApiRequest): Promise<boolean> => {
+    const token: any = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+    if (!token) return false
+    const roles = safeJsonParse(token.userRoles, [])
+    return getCapabilities(roles).canManageUsers === true
+}

--- a/src/pages/api/db/admin/adminRoles/index.ts
+++ b/src/pages/api/db/admin/adminRoles/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../config/local'
 import { listAllAdminRoles } from '../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 import { AdminRole } from '../../../../../db/models/AdminRole'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminRole | string>) {
     if (req.method === "GET") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await listAllAdminRoles (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/departments/index.ts
+++ b/src/pages/api/db/admin/departments/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../config/local'
 import { listAllAdminDepartments } from '../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 import { AdminDepartment } from '../../../../../db/models/AdminDepartment'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminDepartment | string>) {
     if (req.method === "GET") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await listAllAdminDepartments(req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/userInfo/index.ts
+++ b/src/pages/api/db/admin/userInfo/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../config/local'
 import { fetchUserDetailsByUserId } from '../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 import { AdminUser } from '../../../../../db/models/AdminUser'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await fetchUserDetailsByUserId (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/users/addEditUser/index.ts
+++ b/src/pages/api/db/admin/users/addEditUser/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../../config/local'
 import { createOrUpdateAdminUser } from '../../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../../controllers/db/adminAuth.controller'
 import { AdminUser } from '../../../../../../db/models/AdminUser'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await createOrUpdateAdminUser (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/users/index.ts
+++ b/src/pages/api/db/admin/users/index.ts
@@ -2,11 +2,16 @@ import { listAllUsers } from "../../../../../../controllers/db/manage-users/user
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { AdminUser } from '../../../../../db/models/AdminUser'
 import { reciterConfig } from '../../../../../../config/local'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await listAllUsers(req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/users/userInfo/index.ts
+++ b/src/pages/api/db/admin/users/userInfo/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../../config/local'
 import { fetchUserDetailsByUserId } from '../../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../../controllers/db/adminAuth.controller'
 import { AdminUser } from '../../../../../../db/models/AdminUser'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await fetchUserDetailsByUserId (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")


### PR DESCRIPTION
Fixes #852.

## What was wrong

Every route under `src/pages/api/db/admin/*` was gated only by a static header check against `reciterConfig.backendApiKey`, which resolves to `process.env.NEXT_PUBLIC_RECITER_BACKEND_API_KEY`. The `NEXT_PUBLIC_` prefix inlines it into the client JS bundle -- it's public, not a server secret. `middleware.ts` doesn't cover `/api/*`, so nothing else gated these routes. Net effect: anyone who reads the key out of the served JS could call the role-assignment endpoint directly, no login required, and grant themselves Superuser. Full writeup in #852.

## Fix

New `controllers/db/adminAuth.controller.ts` (`isAuthorizedAdmin`): verifies the request's NextAuth JWT via `getToken()` and requires `getCapabilities(roles).canManageUsers === true` (Superuser only, existing capability model, nothing new invented). Applied to the six admin user-management routes, layered on top of the existing key check (kept, harmless, just not a security control by itself):

- `users/addEditUser` (write -- the critical one)
- `adminRoles`
- `users` (list)
- `userInfo` + `users/userInfo` (duplicate routes, same handler)
- `departments`

## Verification

- `next lint` clean
- `tsc --noEmit` clean (one pre-existing unrelated error in `articleProvenance.ts`, present on unmodified `origin/dev`)
- **Not yet tested against a running instance.** Please smoke-test on dev before merging: confirm a non-Superuser session gets 403 from these routes, and confirm Manage Users still works end-to-end for a real Superuser session.

## Scope note

Same static-key-only pattern likely exists on other route families (e.g. the Find People search endpoint) -- not touched here, flagged in #852 as a follow-up audit.

## How this was found

Side effect of an adversarial security review of #849 (Curator_Scoped role) -- a reviewer traced the trust boundary behind the new curate-authorization guard back to the admin API that assigns roles in the first place, and found it unauthenticated.