### PR TITLE
feat(auth): finish Curator_Scoped role + server-side curate authorization

### DIFF
--- a/controllers/db/authorization.controller.ts
+++ b/controllers/db/authorization.controller.ts
@@ -1,0 +1,76 @@
+import models from '../../src/db/sequelize'
+import { getCapabilities } from '../../src/utils/constants'
+import { isPersonInScope, isProxyFor } from '../../src/utils/scopeResolver'
+
+// Minimal per-person lookup for scope checks -- org unit + person types only, nothing else
+// the curate-write path needs.
+const findPersonScopeAttributes = async (personIdentifier: string) => {
+    const person: any = await models.Person.findOne({
+        where: { personIdentifier },
+        attributes: ['primaryOrganizationalUnit'],
+        raw: true,
+    })
+    const typeRows: any[] = await models.PersonPersonType.findAll({
+        where: { personIdentifier },
+        attributes: ['personType'],
+        raw: true,
+    })
+    return {
+        orgUnit: person?.primaryOrganizationalUnit ?? null,
+        personTypes: typeRows.map((r) => r.personType).filter(Boolean),
+    }
+}
+
+const safeJsonParse = (value: any, fallback: any) => {
+    if (value == null) return fallback
+    if (typeof value !== 'string') return value
+    try { return JSON.parse(value) } catch { return fallback }
+}
+
+/**
+ * True if the token's roles allow curating targetUid. Never trust the client for this --
+ * call from every curate-write API route before performing the write.
+ *
+ * Before this, curate-write endpoints (e.g. goldstandard.ts) checked only a shared static
+ * API key, never the caller's role/scope -- Curator_Self and Curator_All were just as
+ * unenforced server-side as Curator_Scoped is without this. See PM#849.
+ */
+export const canCurate = async (token: any, targetUid: any): Promise<boolean> => {
+    // Reject anything that isn't a plain non-empty string outright. targetUid flows into a
+    // Sequelize `where: { personIdentifier }` below -- an array value there means IN(...), not
+    // equality, which would let a scope check pass against a different (decoy) person than the
+    // one actually acted on downstream. Never let that ambiguity past this point.
+    if (typeof targetUid !== 'string' || targetUid.trim().length === 0) return false
+
+    const roles = safeJsonParse(token?.userRoles, [])
+    const caps = getCapabilities(roles)
+
+    if (caps.canCurate.all) return true
+    if (caps.canCurate.self && caps.canCurate.personIdentifier === targetUid) return true
+
+    // Proxy delegation only extends a role that already has some curate capability (matches
+    // the existing client-side intent in Search.js, which only ever surfaces proxy access
+    // nested under a curator role) -- it is not an independent grant. Without this gate, a
+    // Reporter_All user (canCurate: false) with a stray proxy_person_ids entry could curate.
+    if (caps.canCurate.self || caps.canCurate.scoped) {
+        const proxyPersonIds = safeJsonParse(token?.proxyPersonIds, [])
+        if (isProxyFor(proxyPersonIds, targetUid)) return true
+    }
+
+    if (caps.canCurate.scoped) {
+        const scopeData = safeJsonParse(token?.scopeData, null)
+        // isPersonInScope treats a scope with neither dimension set as "no restriction," which
+        // is the right default for other callers but wrong here: a Curator_Scoped user who was
+        // saved with no scope configured (both fields left empty in the UI) must be denied
+        // everyone, not treated as Curator_All. Fail closed instead of delegating to that default.
+        const hasScope = scopeData && (
+            (Array.isArray(scopeData.personTypes) && scopeData.personTypes.length > 0) ||
+            (Array.isArray(scopeData.orgUnits) && scopeData.orgUnits.length > 0)
+        )
+        if (!hasScope) return false
+        const target = await findPersonScopeAttributes(targetUid)
+        return isPersonInScope(scopeData, target.orgUnit, target.personTypes)
+    }
+
+    return false
+}

--- a/controllers/db/manage-users/user.controller.ts
+++ b/controllers/db/manage-users/user.controller.ts
@@ -227,7 +227,17 @@ export const createOrUpdateAdminUser = async (
   req: NextApiRequest,
   res: NextApiResponse
 ) => {
-  const { cwid, email, firstName, lastName, middleName, division, title, selectedRoleIds, departmentIds, isEditUserId } = req.body;
+  const { cwid, email, firstName, lastName, middleName, division, title, selectedRoleIds, departmentIds, isEditUserId, scopePersonTypes, scopeOrgUnits } = req.body;
+  // Curator_Scoped's personType/orgUnit scope (admin_users.scope_person_types/scope_org_units,
+  // see PM#849). Empty/absent clears scope -- matches the JSON DEFAULT NULL columns and the
+  // full-replace pattern already used for roles/departments below.
+  // Array.isArray, not just truthiness -- a client-sent string also has .length, and would
+  // otherwise get persisted verbatim into the JSON column, then read back as a string instead
+  // of an array everywhere downstream that assumes one (canCurate/isPersonInScope).
+  const scopeFields = {
+    scope_person_types: Array.isArray(scopePersonTypes) && scopePersonTypes.length > 0 ? scopePersonTypes : null,
+    scope_org_units: Array.isArray(scopeOrgUnits) && scopeOrgUnits.length > 0 ? scopeOrgUnits : null,
+  };
 
   try {
     if (isEditUserId) {
@@ -236,7 +246,8 @@ export const createOrUpdateAdminUser = async (
         'nameFirst': firstName,
         'nameMiddle': middleName,
         'nameLast': lastName,
-        'modifyTimestamp': new Date()
+        'modifyTimestamp': new Date(),
+        ...scopeFields
       }
       
 
@@ -310,7 +321,8 @@ export const createOrUpdateAdminUser = async (
         'nameLast': lastName,
         'email': email,
         'status': 1,  // Hardcoded 1 to make user active bydefault
-        'createTimestamp': new Date()
+        'createTimestamp': new Date(),
+        ...scopeFields
       }
 
       
@@ -357,7 +369,7 @@ export const fetchUserDetailsByUserId = async (
   try {
     const UserDetails = await models.AdminUser.findAll({
       where: { userID: req.body },
-      attributes: ["userID", "personIdentifier", "nameFirst", "nameMiddle", "nameLast", "email", "status"],
+      attributes: ["userID", "personIdentifier", "nameFirst", "nameMiddle", "nameLast", "email", "status", "scope_person_types", "scope_org_units"],
       include: [{
         model: models.AdminUsersDepartment,
         attributes: ["id", "userID", "departmentID"],

--- a/repositories/db/userroles.repository.ts
+++ b/repositories/db/userroles.repository.ts
@@ -21,7 +21,12 @@ export function queryUserPermissions(replacements: Record<string, any>) {
     `;
 
     return sequelize.query(
-        `SELECT DISTINCT au.personIdentifier, roleLabel,aur.roleID FROM admin_users as au INNER JOIN admin_users_roles as aur ` +
+        // scope_person_types/scope_org_units/proxy_person_ids are per-admin_users-row, so they
+        // repeat identically across a user's role rows here -- callers (nextauth jwt callback)
+        // read them off the first row. See PM#849.
+        `SELECT DISTINCT au.personIdentifier, roleLabel, aur.roleID, ` +
+        `au.scope_person_types, au.scope_org_units, au.proxy_person_ids ` +
+        `FROM admin_users as au INNER JOIN admin_users_roles as aur ` +
         `ON au.userID = aur.userID INNER JOIN admin_roles ar ON aur.roleID = ar.roleID  WHERE  ${whereClause} `,
         {
             replacements,

--- a/scripts/migrations/add-curator-scoped-role.sql
+++ b/scripts/migrations/add-curator-scoped-role.sql
@@ -1,0 +1,27 @@
+-- ============================================================================
+-- Migration: Add Curator_Scoped role
+-- Phase: 8 (Auth Pipeline) of v1.1 Feature Port
+-- Completes what add-scope-proxy-columns.sql (Phase 7) started -- that
+-- migration added scope_person_types/scope_org_units/proxy_person_ids to
+-- admin_users but nothing ever added a role that uses them or wired the
+-- columns into the session (see PM#849).
+--
+-- admin_roles has no unique constraint on roleLabel (only roleID is a PK),
+-- so this uses a NOT EXISTS guard rather than ON DUPLICATE KEY / INSERT
+-- IGNORE for idempotency.
+--
+-- Apply schedule:
+--   dev reciterDB: now
+--   prod reciterDB: after the Curator_Scoped UI + server-side enforcement
+--     (PM#849) are verified on dev
+-- ============================================================================
+
+INSERT INTO admin_roles (roleLabel, createTimestamp, modifyTimestamp)
+SELECT 'Curator_Scoped', NOW(), NOW()
+WHERE NOT EXISTS (
+  SELECT 1 FROM admin_roles WHERE roleLabel = 'Curator_Scoped'
+);
+
+-- Verification (run manually after applying):
+-- SELECT * FROM admin_roles WHERE roleLabel = 'Curator_Scoped';
+-- Expected: exactly one row

--- a/src/components/elements/AddUser/AddUser.tsx
+++ b/src/components/elements/AddUser/AddUser.tsx
@@ -7,7 +7,7 @@ import { RootStateOrAny } from "../../../types/redux";
 import styles from './AddUser.module.css';
 import Loader from '../Common/Loader';
 import TextField from '@mui/material/TextField';
-import { createAdminUser, createORupdateUserIDAction, fetchUserInfoByID, getAdminDepartments, getAdminRoles} from "../../../redux/actions/actions";
+import { createAdminUser, createORupdateUserIDAction, fetchUserInfoByID, getAdminDepartments, getAdminRoles, getPersonTypes} from "../../../redux/actions/actions";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import ToastContainerWrapper from '../ToastContainerWrapper/ToastContainerWrapper';
@@ -19,6 +19,7 @@ const ROLE_LABELS: Record<string, string> = {
     'Curator_Self': 'Curator \u2014 Self',
     'Curator_Department': 'Curator \u2014 Department',
     'Curator_Department_Delegate': 'Curator \u2014 Department Delegate',
+    'Curator_Scoped': 'Curator \u2014 Scoped',
     'Reporter_All': 'Reporter \u2014 All',
 };
 const ROLE_DESCS: Record<string, string> = {
@@ -27,6 +28,7 @@ const ROLE_DESCS: Record<string, string> = {
     'Curator_Self': 'Can only curate their own publications.',
     'Curator_Department': 'Can curate publications for their managed org units.',
     'Curator_Department_Delegate': 'Delegated curation access for specific departments.',
+    'Curator_Scoped': 'Can curate publications only for people matching the person type(s) and/or org unit(s) selected below.',
     'Reporter_All': 'Can generate and export reports for all users.',
 };
 const formatRoleLabel = (slug: string) => ROLE_LABELS[slug] || slug.replace(/_/g, ' ');
@@ -42,6 +44,7 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
 
     const adminDepartments = useSelector((state: RootStateOrAny) => state.AllAdminDepatments);
     const allAdminRoles = useSelector((state: RootStateOrAny) => state.AllAdminRoles);
+    const personTypesData = useSelector((state: RootStateOrAny) => state.personTypesData);
 
     const [state, setState] = useState({
         cwid: "",
@@ -58,7 +61,14 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
     const [selectedRoles, setSelectedRoles] = useState([]);
     const [formErrorsInst, setformErrInst] = useState<{[key: string]: any}>({});
     const [selectedDepartments, setSelectedDepartments] = useState([]);
+    // Curator_Scoped's own personType/orgUnit scope -- deliberately separate from
+    // selectedDepartments above, which writes to the older AdminUsersDepartment join
+    // table used by Curator_Department. These write to admin_users.scope_person_types /
+    // scope_org_units (see PM#849).
+    const [selectedPersonTypes, setSelectedPersonTypes] = useState([]);
+    const [selectedScopeOrgUnits, setSelectedScopeOrgUnits] = useState([]);
     const [loading, setLoading] = useState(false);
+    const isCuratorScoped = selectedRoles.includes('Curator_Scoped');
 
     const router = useRouter()
     const isEdit = router.query.userId ? true : false;
@@ -80,6 +90,12 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
         if ( !firstName || firstName === '' || firstName.trim().length === 0 ) formErrInst.firstName = 'Please enter valid first Name!'
         if ( !lastName || lastName === '' || lastName.trim().length === 0 ) formErrInst.lastName = 'Please enter valid last Name!'
         if ( !selectedRoles || selectedRoles.length === 0  ) formErrInst.selectedRole = 'Please select atleast one role!'
+        // A Curator_Scoped user saved with no scope on either axis is denied everyone server-side
+        // (canCurate fails closed on an empty scope, not "unrestricted") -- catch it here instead
+        // of letting an admin save a silently-nonfunctional user.
+        if ( isCuratorScoped && selectedPersonTypes.length === 0 && selectedScopeOrgUnits.length === 0 ) {
+            formErrInst.selectedScope = 'Curator — Scoped needs at least one person type or org unit selected below.'
+        }
         setformErrInst(formErrInst)
         return formErrInst
     }
@@ -104,7 +120,11 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
             let selectedRoleIds = roleIds || [];
             let departmentIds = departMentIds || [];
             let isEditUserId = router.query.userId;
-            let createOrUpdatePayload = { cwid, email, firstName, lastName, middleName, division, title, selectedRoleIds, departmentIds, isEditUserId }
+            let createOrUpdatePayload = {
+                cwid, email, firstName, lastName, middleName, division, title, selectedRoleIds, departmentIds, isEditUserId,
+                scopePersonTypes: isCuratorScoped ? selectedPersonTypes : [],
+                scopeOrgUnits: isCuratorScoped ? selectedScopeOrgUnits : [],
+            }
 
             if (isEditUserId) {
                 let resp = await createAdminUser(createOrUpdatePayload)
@@ -126,6 +146,7 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
     useEffect(() => {
         dispatch(getAdminRoles());
         dispatch(getAdminDepartments());
+        dispatch(getPersonTypes());
     },[])
 
     useEffect(() => {
@@ -134,7 +155,7 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
         if (isEditUserId) {
             setLoading(true)
             let userDetails = fetchUserInfoByID(isEditUserId).then(result => {
-                const { adminUsersDepartments, adminUsersRoles, email, nameFirst, nameLast, nameMiddle, personIdentifier } = result && result[0];
+                const { adminUsersDepartments, adminUsersRoles, email, nameFirst, nameLast, nameMiddle, personIdentifier, scope_person_types, scope_org_units } = result && result[0];
                 if (adminUsersRoles) {
                     let roleNames = [];
                     allAdminRoles.map(role => {
@@ -154,6 +175,9 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
                     })
                     setSelectedDepartments(departmentNames ? departmentNames : [])
                 }
+
+                setSelectedPersonTypes(scope_person_types || [])
+                setSelectedScopeOrgUnits(scope_org_units || [])
 
                 setState(state => ({ ...state, cwid: personIdentifier, lastName: nameLast, firstName: nameFirst, email, middleName: nameMiddle }))
                 setLoading(false)
@@ -496,6 +520,63 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
                                     {formErrorsInst.selectedRole && <span className={styles.errorText}>{formErrorsInst.selectedRole}</span>}
                                 </div>
                             </div>
+                            {isCuratorScoped && (
+                                <div className={styles.fieldGrid} style={{ marginTop: 16 }}>
+                                    <div className={styles.field}>
+                                        <label className={styles.fieldLabel}>Person type(s) user can manage</label>
+                                        <Autocomplete
+                                            freeSolo
+                                            multiple
+                                            id="scopePersonTypes"
+                                            disableClearable
+                                            value={selectedPersonTypes}
+                                            options={personTypesData.map((option) => option.personType)}
+                                            onChange={(event, value) => setSelectedPersonTypes(value as string[])}
+                                            sx={orgUnitSx}
+                                            renderTags={renderOrgTags}
+                                            renderInput={(params) => (
+                                                <TextField
+                                                    variant="outlined"
+                                                    {...params}
+                                                    placeholder={selectedPersonTypes.length === 0 ? "Search and select person types..." : ""}
+                                                    InputProps={{
+                                                        ...params.InputProps,
+                                                        type: 'search',
+                                                    }}
+                                                />
+                                            )}
+                                        />
+                                        <span className={styles.fieldHint}>A person matches if they have any of the selected types. Leave empty for no person-type restriction.</span>
+                                    </div>
+                                    <div className={styles.field}>
+                                        <label className={styles.fieldLabel}>Org unit(s) for scoped access</label>
+                                        <Autocomplete
+                                            freeSolo
+                                            multiple
+                                            id="scopeOrgUnits"
+                                            disableClearable
+                                            value={selectedScopeOrgUnits}
+                                            options={adminDepartments.map((option) => option.departmentLabel)}
+                                            onChange={(event, value) => setSelectedScopeOrgUnits(value as string[])}
+                                            sx={orgUnitSx}
+                                            renderTags={renderOrgTags}
+                                            renderInput={(params) => (
+                                                <TextField
+                                                    variant="outlined"
+                                                    {...params}
+                                                    placeholder={selectedScopeOrgUnits.length === 0 ? "Search and select departments..." : ""}
+                                                    InputProps={{
+                                                        ...params.InputProps,
+                                                        type: 'search',
+                                                    }}
+                                                />
+                                            )}
+                                        />
+                                        <span className={styles.fieldHint}>Separate from &ldquo;Organizational unit(s) user can manage&rdquo; above (that field is for Curator — Department). Leave empty for no org-unit restriction.</span>
+                                    </div>
+                                </div>
+                            )}
+                            {formErrorsInst.selectedScope && <span className={styles.errorText}>{formErrorsInst.selectedScope}</span>}
                         </div>
 
                         {/* ── Footer ── */}

--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -165,6 +165,30 @@ export const authOptions = {
         token.databaseUser = user.databaseUser || null;
         token.userRoles = user.userRoles || [];
 
+        // scope_person_types/scope_org_units/proxy_person_ids (admin_users, see PM#849) come back
+        // on every role row from findUserPermissions, identical per row since they're per-user, not
+        // per-role -- so the first row is enough. Stored as MariaDB JSON-alias-for-LONGTEXT columns,
+        // so a raw (non-Model) query returns them as JSON text, not pre-parsed values; parse before
+        // re-stringifying onto the token, or Search.js's single JSON.parse(session.data.scopeData)
+        // would hand back strings-of-arrays instead of arrays.
+        const parseJsonColumn = (value) => {
+          if (value == null) return null;
+          if (typeof value !== 'string') return value;
+          try { return JSON.parse(value); } catch { return null; }
+        };
+        let firstRole = {};
+        try {
+          const rolesArr = JSON.parse(token.userRoles || '[]');
+          firstRole = rolesArr[0] || {};
+        } catch (e) {
+          console.warn('JWT callback: could not parse userRoles for scope data', e);
+        }
+        token.scopeData = JSON.stringify({
+          personTypes: parseJsonColumn(firstRole.scope_person_types),
+          orgUnits: parseJsonColumn(firstRole.scope_org_units),
+        });
+        token.proxyPersonIds = JSON.stringify(parseJsonColumn(firstRole.proxy_person_ids) || []);
+
         token.name = `${user.firstName || ''} ${user.lastName || ''}`.trim() || token.username;;
         token.picture = user.image || user.databaseUser?.profilePicture;
         console.log('JWT callback - final token created with username:', token.username);

--- a/src/pages/api/reciter/update/goldstandard.ts
+++ b/src/pages/api/reciter/update/goldstandard.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { getToken } from 'next-auth/jwt'
 import { updateGoldStandard } from "../../../../../controllers/goldstandard.controller"
+import { canCurate } from "../../../../../controllers/db/authorization.controller"
 import { reciterConfig } from '../../../../../config/local'
 
 type Error = {
@@ -25,12 +26,27 @@ export default async function handler(
         // ("Unknown" in the History panel). Never trusted from the client. Best-effort:
         // if the token is missing/unreadable we send nothing and ReCiter defaults to 0.
         let curatedBy = 0
+        let token: any = null
         try {
-            const token: any = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+            token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
             const userID = Number(token?.databaseUser?.userID)
             if (Number.isInteger(userID) && userID > 0) curatedBy = userID
         } catch (e) {
             console.warn('[goldstandard] could not resolve curatedBy from JWT; recording as unknown')
+        }
+
+        // The static backendApiKey check above only proves the request came from this app's
+        // own server code -- it says nothing about which curator is behind it or who they're
+        // allowed to curate. Enforce that here. Was previously enforced nowhere: Curator_Self
+        // and Curator_All were exactly as unchecked as Curator_Scoped is without this. See PM#849.
+        const targetUid = req.body?.uid
+        const allowed = await canCurate(token, targetUid)
+        if (!allowed) {
+            res.status(403).send({
+                statusCode: 403,
+                message: "You do not have permission to curate this person's publications"
+            })
+            return
         }
 
         const apiResponse = await updateGoldStandard(req, curatedBy);


### PR DESCRIPTION
Fixes #849. Should merge after #853 (PM#852 fix) — this role's own scope data flows through the admin API #853 locks down; landing this first without that would mean anyone could self-grant Curator_Scoped (or Superuser) via the still-open admin endpoints.

## What this does

Wires up `Curator_Scoped`, which existed only as disconnected pieces before this: DB columns nothing populated, scope-check logic nothing called, a capability-table entry no UI ever offered.

- `add-curator-scoped-role.sql` — the missing `admin_roles` row (apply manually dev then prod)
- `userroles.repository.ts` — selects the scope/proxy columns
- `[...nextauth].jsx` — populates `token.scopeData`/`proxyPersonIds` (the "Phase 8 Auth Pipeline" the original migration flagged as a prerequisite and that never happened — `Search.js` already reads `session.data.scopeData`, it was always null)
- `manage-users/user.controller.ts` — persists scope fields
- `AddUser.tsx` — `Curator_Scoped` in the role picker + a personType Autocomplete, shown only when that role's selected; validates at least one scope dimension is set before save
- `authorization.controller.ts` (new) — `canCurate(token, targetUid)`, wired into `goldstandard.ts` (the app's one curate-write endpoint), which previously enforced no role/scope at all server-side. Folds in the `Curator_Self`/`Curator_All` enforcement fix in the same pass since it's the same guard function either way.

## Security review

Three independent adversarial reviews (auth-logic correctness, bypass/edge-cases, injection/trust-boundary), all findings fixed:

- A `Curator_Scoped` user saved with no scope configured, or holding a stale pre-deploy session token missing the new fields, now fails closed instead of resolving to unrestricted access
- Proxy delegation no longer bypasses roles with zero curate capability (e.g. `Reporter_All`)
- Non-string `targetUid` (e.g. an array — Sequelize coerces that into an `IN(...)` list, which could pool a decoy person's attributes into the scope check) is rejected before it reaches a query
- `Array.isArray` check added on the scope-write path so a non-array value can't get persisted into the JSON columns and cause type confusion downstream

One review also surfaced #852 (unrelated, pre-existing, fixed in #853) — flagging the merge-order note above.

## Verification

Repo has no test framework (no jest, no `*.test.*`). `next lint` and `tsc --noEmit` clean (one pre-existing unrelated error in `articleProvenance.ts`, present on unmodified `origin/dev`). **Not yet tested against a running instance** — recommend on dev: confirm the `Curator_Scoped` role appears in Edit User after the migration runs, grant a test user a personType scope, confirm Search filters to matching people and a `goldstandard` POST for an out-of-scope uid 403s.
