### PR TITLE
feat(authorships): hold immature no-DOI scopus rows out of the queue

### DIFF
--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -20,6 +20,17 @@ const LIST_ATTRIBUTES = [
 
 const todayStr = () => new Date().toISOString().slice(0, 10);
 
+// A no-DOI scopus row can't yet be verified against PubMed (aar_universe_scopus.py's
+// re-check needs either a DOI or, past this floor, a title/author fallback search).
+// Scopus routinely indexes a doc before PubMed does and before Scopus itself backfills
+// its DOI, so a *fresh* no-DOI row is more likely still settling than genuinely
+// PubMed-absent. Hold it out of every view until it clears the floor — the producer's
+// monthly re-check keeps running underneath regardless, so a row that resolves to PubMed
+// in the meantime is auto-dismissed before a curator ever sees it.
+const SCOPUS_NO_DOI_MATURITY_DAYS = 60;
+const maturityCutoffStr = () =>
+  new Date(Date.now() - SCOPUS_NO_DOI_MATURITY_DAYS * 86400000).toISOString().slice(0, 10);
+
 const SORTS: Record<string, any[]> = {
   // default: single-candidate (high-precision) first, then identity-only score desc.
   // ["pmid","DESC"] is a secondary key so same-paper pubmed authorships land adjacent.
@@ -100,6 +111,14 @@ function buildWhere(body: any): any {
   } else if (dateTo) {
     and.push({ entrez_date: { [Op.lte]: dateTo } });
   }
+  // hold immature no-DOI scopus rows out of every view until they clear the floor above
+  and.push({
+    [Op.not]: {
+      source: "scopus",
+      doi: null,
+      entrez_date: { [Op.gt]: maturityCutoffStr() },
+    },
+  });
 
   return and.length ? { [Op.and]: and } : {};
 }

--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -111,12 +111,17 @@ function buildWhere(body: any): any {
   } else if (dateTo) {
     and.push({ entrez_date: { [Op.lte]: dateTo } });
   }
-  // hold immature no-DOI scopus rows out of every view until they clear the floor above
+  // hold immature no-DOI scopus rows out of every view until they clear the floor above.
+  // entrez_date is nullable (aar_universe_scopus.py has no coverDate fallback) — a bare
+  // Op.gt against NULL evaluates to NULL, and NOT(NULL) is NULL too, so an unguarded
+  // clause here would make a missing-date row vanish permanently instead of just holding
+  // it. Require entrez_date to be non-null before comparing, so a NULL date falls through
+  // to "show the row" rather than "hide it forever."
   and.push({
     [Op.not]: {
       source: "scopus",
       doi: null,
-      entrez_date: { [Op.gt]: maturityCutoffStr() },
+      entrez_date: { [Op.and]: [{ [Op.ne]: null }, { [Op.gt]: maturityCutoffStr() }] },
     },
   });
 


### PR DESCRIPTION
Companion to the ReCiter Research producer fix (scripts/aar_universe_scopus.py, `d174a51a8`).

Root cause found live in the Authorships tab: a Scopus row can carry `doi=null` (~1% of scopus-only docs). The producer's monthly re-check against PubMed was gated on `doi IS NOT NULL`, so a null-DOI row's "Not in PubMed" badge could never self-correct even after PubMed later indexed the real article — Accept then hit a live PubMed match and confusingly told the curator the opposite of the badge (concrete case: Kushner, PMID 41884643).

Producer-side (separate repo) now has a title+author PubMed fallback for null-DOI rows, both at ingest and in the recurring re-check. This PR adds the other half raised during review: a title match isn't always unique, and a *freshly*-swept null-DOI row is more likely still settling (Scopus indexes ahead of PubMed, and ahead of its own DOI backfill) than genuinely absent. So:

- `buildWhere` now excludes `source='scopus' AND doi IS NULL AND entrez_date` newer than a 60-day floor from every view (open/snoozed/dismissed/all) — status stays `open` in the DB, this is display-only.
- The producer's re-check keeps running underneath regardless, so a row that resolves to PubMed while held is auto-dismissed before a curator ever sees it; only genuinely-still-open rows surface once they clear the floor.

**Update 2026-08-14, post-merge data pull:** live-measured the actual no-DOI backlog before landing this — 1,393 open no-DOI rows, ages 111 days to 31,271 days, median 11.8 years. 99.5% (1,386/1,393) landed on a single day (2026-07-05, the one-time `--mode initial` 5-year backfill), not a monthly trickle. **Every open row is already well past the 60-day floor**, so against today's backlog this filter is a no-op — it hides nothing right now. What it *does* do: protect genuinely-fresh rows the monthly recurring cron adds going forward from showing up before the producer's re-check has had a chance to resolve them. Worth merging on that basis, but going in with the expectation set correctly — this does not clear any of the current queue. Clearing the current backlog is a separate, content-based problem (see the Book-skip / title-and-ISSN-fallback work in the companion producer commit, and thread #4 of `docs/HANDOFF_2026-08-14_authorships_live_session.md` in ReCiter Research for the still-open ISSN-backlog gap).

tsc clean on the changed file.
