### PR TITLE
feat(authorships): promote Reject to a primary card button

### DIFF
--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -339,6 +339,17 @@ function scopusExternalPayload(row: any) {
   };
 }
 
+// Every candidate identity a row was proposed against (top_cwid + candidate_cwids_json,
+// deduped) — the full set "None of these" rejects and reopen() un-rejects.
+function candidateCwidsFromRow(row: any): string[] {
+  let parsed: any[] = [];
+  try { parsed = JSON.parse(row.candidate_cwids_json || "[]"); } catch { parsed = []; }
+  const list = Array.isArray(parsed)
+    ? parsed.map((c: any) => (typeof c === "string" ? c : c?.cwid)).filter(Boolean).map(String)
+    : [];
+  return Array.from(new Set([row.top_cwid, ...list].filter(Boolean).map(String)));
+}
+
 // POST /api/db/authorships/action — single-row curator action.
 // body: { id, action: "accept"|"reject"|"snooze"|"dismiss"|"assign"|"reopen", cwid?, force? }
 // cwid is required only for "assign"; force retries a scopus Accept past a 409 WARNING.
@@ -393,12 +404,7 @@ export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse
         if (!chosen) return res.status(400).send("cwid is required for assign");
         // Integrity boundary: the server verifies the chosen cwid is a real candidate for
         // this authorship before any authoritative write (client can't spoof an identity).
-        let candidateCwids: string[] = [];
-        try {
-          const parsed = JSON.parse(row.candidate_cwids_json || "[]");
-          if (Array.isArray(parsed)) candidateCwids = parsed.map((c: any) => (typeof c === "string" ? c : c?.cwid)).filter(Boolean).map(String);
-        } catch { candidateCwids = []; }
-        const allowed = new Set([row.top_cwid, ...candidateCwids].filter(Boolean).map(String));
+        const allowed = new Set(candidateCwidsFromRow(row));
         if (!allowed.has(chosen)) return res.status(400).send("cwid is not a candidate for this authorship");
         if (!(await reciterIdentitySet([chosen])).size) {
           return res.status(422).send(`${chosen} has no ReCiter identity (likely departed/inactive) — this authorship can't be assigned; dismiss it instead`);
@@ -423,17 +429,25 @@ export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse
       }
       case "reject": {
         if (!cwid) return res.status(409).send("No proposed identity to reject");
-        if (!row.single_candidate) return res.status(409).send("Multiple candidates — use \"Pick one\" to assign");
         if (isScopus) {
           // scopus reject = local dismissal, never gold standard (no PMID to reject).
           await models.AuthorshipReview.update({ status: "rejected", reviewer, resolved_at: new Date() }, { where: { id } });
           break;
         }
-        const gs = await writeGoldStandard(cwid, pmid as number, "rejected", "UPDATE", curator.userID);
-        if (gs !== 200) return res.status(502).send(`Gold-standard write failed (${gs})`);
+        // "None of these" on a multi-candidate row asserts none of them wrote it — reject
+        // every candidate, not just top_cwid. reopen() reverses the same set, recomputed
+        // from candidate_cwids_json (stable once a row leaves "open" — see aar_db.py: the
+        // producer never revisits an already-resolved row's upsert).
+        const targets = row.single_candidate ? [cwid] : candidateCwidsFromRow(row);
+        for (const target of targets) {
+          const gs = await writeGoldStandard(target, pmid as number, "rejected", "UPDATE", curator.userID);
+          if (gs !== 200) return res.status(502).send(`Gold-standard write failed for ${target} (${gs})`);
+        }
         await models.AuthorshipReview.update({ status: "rejected", reviewer, resolved_at: new Date() }, { where: { id } });
-        try { await appendFeedbackLog(curator.userID, cwid, pmid as number, "REJECTED"); }
-        catch (e) { console.log("[authorships] feedbacklog (reject) non-fatal:", e); }
+        for (const target of targets) {
+          try { await appendFeedbackLog(curator.userID, target, pmid as number, "REJECTED"); }
+          catch (e) { console.log("[authorships] feedbacklog (reject) non-fatal:", e); }
+        }
         break;
       }
       case "snooze": {
@@ -456,9 +470,12 @@ export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse
         } else if ((row.status === "accepted" || row.status === "assigned") && reverseCwid) {
           const gs = await writeGoldStandard(reverseCwid, pmid as number, "known", "DELETE", curator.userID);
           if (gs !== 200) return res.status(502).send(`Gold-standard undo failed (${gs})`);
-        } else if (row.status === "rejected" && reverseCwid) {
-          const gs = await writeGoldStandard(reverseCwid, pmid as number, "rejected", "DELETE", curator.userID);
-          if (gs !== 200) return res.status(502).send(`Gold-standard undo failed (${gs})`);
+        } else if (row.status === "rejected") {
+          const targets = row.single_candidate ? (reverseCwid ? [reverseCwid] : []) : candidateCwidsFromRow(row);
+          for (const target of targets) {
+            const gs = await writeGoldStandard(target, pmid as number, "rejected", "DELETE", curator.userID);
+            if (gs !== 200) return res.status(502).send(`Gold-standard undo failed for ${target} (${gs})`);
+          }
         }
         await models.AuthorshipReview.update({ status: "open", snooze_until: null, resolved_at: null, resolution_cwid: null, reviewer }, { where: { id } });
         break;

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -216,13 +216,14 @@ const scopusNote = (r: AuthorshipRow): string => {
   return `Not in PubMed — found via the Scopus AF-ID sweep, so production never scored it (no IO/Authorship Score exists). ${who}; ranked by identity-match confidence (${confBand(r.top_confidence)}). Accepting adds it as an ExternalArticle (no PMID → not gold standard).`;
 };
 
-const btn = (variant: "accept" | "soft" | "ghost", disabled?: boolean): CSSProperties => {
+const btn = (variant: "accept" | "reject" | "soft" | "ghost", disabled?: boolean): CSSProperties => {
   const base: CSSProperties = {
     display: "inline-flex", alignItems: "center", gap: 6, borderRadius: 7, padding: "6px 12px",
     font: "inherit", fontSize: 13, fontWeight: 600, cursor: disabled ? "default" : "pointer",
     border: "1px solid transparent", whiteSpace: "nowrap", opacity: disabled ? 0.5 : 1,
   };
   if (variant === "accept") return { ...base, background: "#16a34a", color: "#fff" };
+  if (variant === "reject") return { ...base, background: "#fff", color: "#b91c1c", borderColor: "#fecaca" };
   if (variant === "soft") return { ...base, background: "#f0fdf4", color: "#15803d", borderColor: "#bbf7d0" };
   return { ...base, background: "#fff", color: "#475569", borderColor: "#dde3ea" };
 };
@@ -963,16 +964,12 @@ const AuthorshipsTabs = () => {
         </span>
       </div>
 
-      {/* overflow menu: Reject / Snooze / Dismiss.
-          Reject writes a "rejected" gold-standard entry against top_cwid — valid only for
-          single-candidate rows (the backend 409s on multi). For multi-candidate rows the
-          equivalent "this isn't any of them" action is None of these → dismiss. */}
+      {/* overflow menu: Snooze / Dismiss, plus None of these for multi-candidate rows.
+          Reject (single-candidate only — the backend 409s on multi) is now a primary
+          button on the card itself, not buried here. Multi-candidate's equivalent
+          "this isn't any of them" action stays None of these → dismiss. */}
       <Menu anchorEl={menu?.anchor} open={!!menu} onClose={() => setMenu(null)}>
-        {menu?.row.single_candidate ? (
-          <MenuItem onClick={() => menu && doAction(menu.row, "reject")} style={{ color: "#b91c1c" }}>
-            <IconX size={14} style={{ marginRight: 8 }} /> Reject
-          </MenuItem>
-        ) : (
+        {menu && !menu.row.single_candidate && (
           <MenuItem onClick={() => menu && doAction(menu.row, "dismiss")} style={{ color: "#b91c1c" }}>
             <IconX size={14} style={{ marginRight: 8 }} /> None of these
           </MenuItem>
@@ -1190,9 +1187,14 @@ const AuthorshipCard = ({
                 <span style={noIdentityPillStyle} onClick={(e) => e.stopPropagation()}>No ReCiter identity</span>
               </Tip>
             ) : (
-              <button style={btn("accept", acting)} disabled={acting} onClick={(e) => { e.stopPropagation(); onAction("accept"); }}>
-                <IconCheck /> Accept
-              </button>
+              <>
+                <button style={btn("reject", acting)} disabled={acting} onClick={(e) => { e.stopPropagation(); onAction("reject"); }}>
+                  <IconX size={14} /> Reject
+                </button>
+                <button style={btn("accept", acting)} disabled={acting} onClick={(e) => { e.stopPropagation(); onAction("accept"); }}>
+                  <IconCheck /> Accept
+                </button>
+              </>
             )
           ) : (
             <button style={btn("ghost", acting)} disabled={acting} onClick={(e) => { e.stopPropagation(); onAction("reopen"); }}>Reopen</button>

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -1183,9 +1183,14 @@ const AuthorshipCard = ({
             isMulti ? (
               <button style={btn("ghost")} onClick={(e) => { e.stopPropagation(); onToggleExpand(); }}>Pick one <IconChevR size={13} /></button>
             ) : noIdentity ? (
-              <Tip title={`${r.top_name || r.top_cwid} is not in ReCiter (likely departed or inactive), so this authorship can't be accepted. Dismiss it via the ⋯ menu, or leave it open.`} placement="top" arrow>
-                <span style={noIdentityPillStyle} onClick={(e) => e.stopPropagation()}>No ReCiter identity</span>
-              </Tip>
+              <>
+                <button style={btn("reject", acting)} disabled={acting} onClick={(e) => { e.stopPropagation(); onAction("reject"); }}>
+                  <IconX size={14} /> Reject
+                </button>
+                <Tip title={`${r.top_name || r.top_cwid} is not in ReCiter (likely departed or inactive), so this authorship can't be accepted.`} placement="top" arrow>
+                  <span style={noIdentityPillStyle} onClick={(e) => e.stopPropagation()}>No ReCiter identity</span>
+                </Tip>
+              </>
             ) : (
               <>
                 <button style={btn("reject", acting)} disabled={acting} onClick={(e) => { e.stopPropagation(); onAction("reject"); }}>

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -694,7 +694,7 @@ const AuthorshipsTabs = () => {
         } else setErrorMsg("Use Pick one ▾ to assign a multi-candidate authorship");
         e.preventDefault();
       }
-      else if (k === "n") { if (statusView === "open") { if (row.single_candidate) doAction?.(row, "reject"); else setErrorMsg("Use Pick one ▾ / None of these for a multi-candidate authorship"); } e.preventDefault(); }
+      else if (k === "n") { if (statusView === "open") doAction?.(row, "reject"); e.preventDefault(); }
       else if (k === "s") { if (statusView === "open") doAction?.(row, "snooze"); e.preventDefault(); }
       else if (k === "x") { toggleSelect?.(row); e.preventDefault(); }
       else if (e.key === "Enter") {
@@ -964,14 +964,14 @@ const AuthorshipsTabs = () => {
         </span>
       </div>
 
-      {/* overflow menu: Snooze / Dismiss, plus None of these for multi-candidate rows.
-          Reject (single-candidate only — the backend 409s on multi) is now a primary
-          button on the card itself, not buried here. Multi-candidate's equivalent
-          "this isn't any of them" action stays None of these → dismiss. */}
+      {/* overflow menu: Snooze / Dismiss, plus Reject all for multi-candidate rows.
+          Single-candidate Reject is a primary button on the card itself, not buried here.
+          Multi-candidate's "none of them wrote it" is a real reject too — against every
+          candidate, not just top_cwid — so it belongs here, not the no-op Dismiss below. */}
       <Menu anchorEl={menu?.anchor} open={!!menu} onClose={() => setMenu(null)}>
         {menu && !menu.row.single_candidate && (
-          <MenuItem onClick={() => menu && doAction(menu.row, "dismiss")} style={{ color: "#b91c1c" }}>
-            <IconX size={14} style={{ marginRight: 8 }} /> None of these
+          <MenuItem onClick={() => menu && doAction(menu.row, "reject")} style={{ color: "#b91c1c" }}>
+            <IconX size={14} style={{ marginRight: 8 }} /> Reject all
           </MenuItem>
         )}
         <MenuItem onClick={() => menu && doAction(menu.row, "snooze")}>Snooze 90 days</MenuItem>
@@ -1416,8 +1416,8 @@ const MultiEvidence = ({ row: r, candidates, pickedCwid, acting, onPick, onActio
           onClick={(e) => { e.stopPropagation(); pickedCwid && onAction("assign", { cwid: pickedCwid }); }}>
           <IconCheck /> Assign selected
         </button>
-        <button style={btn("ghost", acting)} disabled={acting} onClick={(e) => { e.stopPropagation(); onAction("dismiss"); }}>
-          <IconX /> None of these
+        <button style={btn("reject", acting)} disabled={acting} onClick={(e) => { e.stopPropagation(); onAction("reject"); }}>
+          <IconX /> Reject all
         </button>
       </div>
     </>


### PR DESCRIPTION
Reject was buried in the ⋯ overflow menu (an extra click per reject), even though the
J/K/Y/N/S keyboard shortcuts already treat it as primary (N = reject, same prominence as
Y = accept). Flagged live: rejects happen often enough that the extra click is real
friction.

Single-candidate cards now show Reject next to Accept directly (outlined red, Accept
stays solid green). Same `doAction(row, "reject")` path the keyboard shortcut already
used.

**Also fixed, flagged live in the same session:** "None of these" (multi-candidate) was
a no-op — `dismiss` only flips local status, never touches the gold standard, regardless
of how many candidates a row lists. The backend's `reject` case also flatly 409'd on any
multi-candidate row ("use Pick one"), which is *why* it was wired to dismiss in the first
place. Fixed properly instead of just relabeling:
- New `candidateCwidsFromRow()` helper (also de-dupes the identical inline parsing that
  `assign` already had).
- `reject` on a multi-candidate PubMed row now writes a real gold-standard reject against
  *every* candidate, not just top_cwid — "none of these" logically means each one is
  wrong. Scopus rows unchanged (still local-only, no PMID to reject against).
- `reopen` reverses the same full candidate set for a rejected row (recomputed from
  `candidate_cwids_json`, which the producer only ever writes once per row).
- Renamed both "None of these" entry points (Pick-one panel + overflow menu) to
  "Reject all" so the label matches what it now actually does, and the `N` keyboard
  shortcut now works on multi-candidate rows too instead of erroring.

tsc clean, 0 errors.