### PR TITLE
fix(authorships): default sort to IO, clarify the Confidence option

### DIFF
--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -285,7 +285,13 @@ const AuthorshipsTabs = () => {
   const [classification, setClassification] = useState<"all" | "buried" | "absent" | "suggested">("all");
   const [search, setSearch] = useState("");
   const [searchInput, setSearchInput] = useState("");
-  const [sort, setSort] = useState("confidence"); // default sort = Confidence (desc)
+  // default sort = IO desc, matching the page's own lede ("IO ... leads"). top_confidence
+  // (the matcher's identity-match heuristic, not an authorship-likelihood score) was the
+  // prior default, but it's near-constant across the queue — most rows land on the same
+  // base value for a given given-name-match/affiliation-match combo — so it silently fell
+  // through to the pmid tiebreaker for the vast majority of rows (live-verified: 19/20 on
+  // one real page tied at 0.65, ordered only by pmid, unrelated to what's shown on the card).
+  const [sort, setSort] = useState("io");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [datePreset, setDatePreset] = useState("24m"); // default = Last 2 years; "any"|"30d"|"90d"|"6m"|"12m"|"24m"|"custom"
@@ -722,7 +728,7 @@ const AuthorshipsTabs = () => {
             style={{ height: 32, border: "1px solid #dde3ea", borderRadius: 7, background: "#fff", font: "inherit", fontSize: 13, color: "#0f172a", padding: "0 10px", cursor: "pointer" }}>
             <option value="io">Identity-only (IO) — strongest first</option>
             <option value="date">Newest</option>
-            <option value="confidence">Confidence</option>
+            <option value="confidence">Match confidence (name/affiliation, not IO)</option>
             <option value="precision">Best match</option>
             <option value="fg">Authorship Score</option>
           </select>


### PR DESCRIPTION
Flagged live: "Sort by confidence isn't working as I would expect" — the visible IO/
Authorship-Score numbers bounced around with no apparent order. Not a query bug: pulled
the actual live response for the exact filter state in question and `top_confidence`
*is* correctly sorted descending, tie-broken by pmid descending, exactly per the SORTS
map (`confidence: [["top_confidence","DESC"],["pmid","DESC"]]`).

The real problem: `top_confidence` is the matcher's name/affiliation identity-match
heuristic, not an authorship-likelihood score, and it has almost no variance across the
queue. On the live page that prompted this: 19 of 20 rows tied at exactly 0.65 — the
common case (initial given-name match, no affiliation-dept match, cohort size 1) always
lands on the same base heuristic value. So sorting by it silently degenerates into
sorting by pmid for the vast majority of rows, with zero relation to the score shown on
the card. It was also the tab's *default* sort, contradicting the page's own lede ("IO
... leads").

- Default sort changed `confidence` → `io`.
- "Confidence" dropdown option relabeled "Match confidence (name/affiliation, not IO)" so
  a curator who picks it deliberately isn't misled about what it orders by.

No backend change — this is a client default + a label. tsc clean (1 pre-existing
unrelated error in articleProvenance.ts, not touched by this change).