### PR TITLE
fix(security): require an authenticated Superuser session on the admin user-management API

### DIFF
--- a/controllers/db/adminAuth.controller.ts
+++ b/controllers/db/adminAuth.controller.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest } from 'next'
+import { getToken } from 'next-auth/jwt'
+import { getCapabilities } from '../../src/utils/constants'
+
+const safeJsonParse = (value: any, fallback: any) => {
+    if (value == null) return fallback
+    if (typeof value !== 'string') return value
+    try { return JSON.parse(value) } catch { return fallback }
+}
+
+/**
+ * True if the request carries a valid, signed session belonging to a user whose role grants
+ * canManageUsers (Superuser only).
+ *
+ * The `backendApiKey` header these admin routes also check is `NEXT_PUBLIC_RECITER_BACKEND_API_KEY`
+ * -- a NEXT_PUBLIC_ env var, which Next.js inlines into the client JS bundle at build time. It is
+ * not a secret; it identifies "a request from this app's frontend," not "a request from an
+ * authorized admin." Nothing else gated these routes, so anyone who reads it out of the served JS
+ * could call them directly with no session at all -- including the route that assigns roles, which
+ * made it a full authentication bypass to Superuser. This is the actual authorization check.
+ */
+export const isAuthorizedAdmin = async (req: NextApiRequest): Promise<boolean> => {
+    const token: any = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+    if (!token) return false
+    const roles = safeJsonParse(token.userRoles, [])
+    return getCapabilities(roles).canManageUsers === true
+}

--- a/src/pages/api/db/admin/adminRoles/index.ts
+++ b/src/pages/api/db/admin/adminRoles/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../config/local'
 import { listAllAdminRoles } from '../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 import { AdminRole } from '../../../../../db/models/AdminRole'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminRole | string>) {
     if (req.method === "GET") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await listAllAdminRoles (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/departments/index.ts
+++ b/src/pages/api/db/admin/departments/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../config/local'
 import { listAllAdminDepartments } from '../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 import { AdminDepartment } from '../../../../../db/models/AdminDepartment'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminDepartment | string>) {
     if (req.method === "GET") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await listAllAdminDepartments(req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/userInfo/index.ts
+++ b/src/pages/api/db/admin/userInfo/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../config/local'
 import { fetchUserDetailsByUserId } from '../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 import { AdminUser } from '../../../../../db/models/AdminUser'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await fetchUserDetailsByUserId (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/users/addEditUser/index.ts
+++ b/src/pages/api/db/admin/users/addEditUser/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../../config/local'
 import { createOrUpdateAdminUser } from '../../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../../controllers/db/adminAuth.controller'
 import { AdminUser } from '../../../../../../db/models/AdminUser'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await createOrUpdateAdminUser (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/users/index.ts
+++ b/src/pages/api/db/admin/users/index.ts
@@ -2,11 +2,16 @@ import { listAllUsers } from "../../../../../../controllers/db/manage-users/user
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { AdminUser } from '../../../../../db/models/AdminUser'
 import { reciterConfig } from '../../../../../../config/local'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await listAllUsers(req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/users/userInfo/index.ts
+++ b/src/pages/api/db/admin/users/userInfo/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../../config/local'
 import { fetchUserDetailsByUserId } from '../../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../../controllers/db/adminAuth.controller'
 import { AdminUser } from '../../../../../../db/models/AdminUser'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await fetchUserDetailsByUserId (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")


### PR DESCRIPTION
## The vulnerability

Every route under `src/pages/api/db/admin/*` (including role assignment) was gated only by `NEXT_PUBLIC_RECITER_BACKEND_API_KEY` — a `NEXT_PUBLIC_` env var, i.e. baked into the public JS bundle at build time, not a secret. Unauthenticated privilege escalation to Superuser: anyone who read the key out of the served JS could call these routes directly with no session at all, including the one that assigns roles.

## Why this branch, not `master`

`reciter-pm-prod` is running an image built from **`master_Next14`**, not plain `master`:
- Live image on `reciter-pm-prod` right now: `master_Next14-1135.2026-08-14.17.33.39.bf670bc4`
- `ReCiter-Publication-Manager-Dev-V2` (source branch `master_Next14`) last **succeeded** today at 13:30, commit `bf670bc4` — exact match to what's deployed
- `ReCiter-Publication-Manager` (source branch `master`) has **failed its last 3 executions**, most recent April 23, 2026 — it is not currently deploying anything

So this is the branch that actually needs the fix to close the live hole. (A parallel PR also went to plain `master` for hygiene, in case that pipeline is ever revived — see #TBD.)

## The fix

This is a clean cherry-pick of #853 (already merged to `dev`, live-verified there, survived a 3-lens adversarial security review — bypass/regression/completeness) — `master_Next14` already carries the same capability model (`getCapabilities`/`ROLE_CAPABILITIES` in `src/utils/constants.js`, byte-for-byte identical to `dev`'s), the same `next-auth@4.24.13`, and already has `secret: process.env.NEXTAUTH_SECRET` correctly wired into the NextAuth options — so no additional plumbing was needed here (unlike the `master` PR, which required also backporting that secret-wiring fix).

New `controllers/db/adminAuth.controller.ts`: `isAuthorizedAdmin()` decodes the session via `getToken()` and checks `getCapabilities(roles).canManageUsers === true`. Applied as a 403 gate on top of the existing key check across the same 6 routes #853 fixed: `adminRoles`, `departments`, `userInfo`, `users/addEditUser`, `users/index`, `users/userInfo`.

## Verification

- `tsc --noEmit`: clean, 0 errors
- `eslint` on the changed files: clean, 0 issues
- 3-lens adversarial review (bypass / regression / completeness): completeness and regression both `SAFE_TO_PR` outright; bypass's two blockers (wrong target branch, missing secret wiring) don't apply here — this branch already has both right
- Not yet live-tested against a real Superuser session (no staging environment runs this branch's actual code outside of prod itself) — worth a manual smoke test right after deploy: confirm a real Superuser can still use Manage Users, and that an unauthenticated `curl` with just the backend API key now gets 403 on all 6 routes

## Known pre-existing, out of scope for this fix

- JWT sessions are valid for up to 2 hours after mint with no server-side re-check — a just-demoted Superuser keeps admin access for up to that window. Pre-existing architectural property, identical to `dev`'s already-shipped version of this same check, not introduced or worsened by this diff.