### PR TITLE
fix(security): require an authenticated Superuser session on the admin user-management API

### DIFF
--- a/controllers/db/adminAuth.controller.ts
+++ b/controllers/db/adminAuth.controller.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest } from 'next'
+import { getToken } from 'next-auth/jwt'
+import { allowedPermissions } from '../../src/utils/constants'
+
+const safeJsonParse = (value: any, fallback: any) => {
+    if (value == null) return fallback
+    if (typeof value !== 'string') return value
+    try { return JSON.parse(value) } catch { return fallback }
+}
+
+/**
+ * True if the request carries a valid, signed session belonging to a user whose role is Superuser.
+ *
+ * The `backendApiKey` header these admin routes also check is `NEXT_PUBLIC_RECITER_BACKEND_API_KEY`
+ * -- a NEXT_PUBLIC_ env var, which Next.js inlines into the client JS bundle at build time. It is
+ * not a secret; it identifies "a request from this app's frontend," not "a request from an
+ * authorized admin." Nothing else gated these routes, so anyone who reads it out of the served JS
+ * could call them directly with no session at all -- including the route that assigns roles, which
+ * made it a full authentication bypass to Superuser. This is the actual authorization check.
+ */
+export const isAuthorizedAdmin = async (req: NextApiRequest): Promise<boolean> => {
+    const token: any = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+    if (!token) return false
+    const roles = safeJsonParse(token.userRoles, [])
+    return Array.isArray(roles) && roles.some((r: any) => r.roleLabel === allowedPermissions.Superuser)
+}

--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -295,6 +295,10 @@ const options = {
         jwt: true,
         maxAge: 7200,
     },
+    secret: process.env.NEXTAUTH_SECRET,
+    jwt: {
+        secret: process.env.NEXTAUTH_SECRET,
+    },
 };
 
 const persistUserLogin =async (cwid)=>{

--- a/src/pages/api/db/admin/adminRoles/index.ts
+++ b/src/pages/api/db/admin/adminRoles/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../config/local'
 import { listAllAdminRoles } from '../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 import { AdminRole } from '../../../../../db/models/AdminRole'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminRole | string>) {
     if (req.method === "GET") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await listAllAdminRoles (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/departments/index.ts
+++ b/src/pages/api/db/admin/departments/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../config/local'
 import { listAllAdminDepartments } from '../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 import { AdminDepartment } from '../../../../../db/models/AdminDepartment'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminDepartment | string>) {
     if (req.method === "GET") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await listAllAdminDepartments(req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/userInfo/index.ts
+++ b/src/pages/api/db/admin/userInfo/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../config/local'
 import { fetchUserDetailsByUserId } from '../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 import { AdminUser } from '../../../../../db/models/AdminUser'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await fetchUserDetailsByUserId (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/users/addEditUser/index.ts
+++ b/src/pages/api/db/admin/users/addEditUser/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../../config/local'
 import { createOrUpdateAdminUser } from '../../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../../controllers/db/adminAuth.controller'
 import { AdminUser } from '../../../../../../db/models/AdminUser'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await createOrUpdateAdminUser (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/users/index.ts
+++ b/src/pages/api/db/admin/users/index.ts
@@ -2,11 +2,16 @@ import { listAllUsers } from "../../../../../../controllers/db/manage-users/user
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { AdminUser } from '../../../../../db/models/AdminUser'
 import { reciterConfig } from '../../../../../../config/local'
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await listAllUsers(req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")

--- a/src/pages/api/db/admin/users/userInfo/index.ts
+++ b/src/pages/api/db/admin/users/userInfo/index.ts
@@ -1,12 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { reciterConfig } from '../../../../../../../config/local'
 import { fetchUserDetailsByUserId } from '../../../../../../../controllers/db/manage-users/user.controller'
+import { isAuthorizedAdmin } from '../../../../../../../controllers/db/adminAuth.controller'
 import { AdminUser } from '../../../../../../db/models/AdminUser'
 
 export default async function handler(req: NextApiRequest,
     res: NextApiResponse<AdminUser | string>) {
     if (req.method === "POST") {
         if(req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+            if (!(await isAuthorizedAdmin(req))) {
+                res.status(403).send("Forbidden")
+                return
+            }
             await fetchUserDetailsByUserId (req, res)
         } else if(req.headers.authorization === undefined) {
             res.status(400).send("Authorization header is needed")


### PR DESCRIPTION
## The vulnerability

Same bug as #859: every route under `src/pages/api/db/admin/*` (including role assignment) was gated only by `NEXT_PUBLIC_RECITER_BACKEND_API_KEY` — a `NEXT_PUBLIC_` env var baked into the public JS bundle, not a secret. Unauthenticated privilege escalation to Superuser.

## Important: this is not the live prod branch

Verified against a live `kubectl` check and CodePipeline execution history: `reciter-pm-prod` is currently deployed from **`master_Next14`** (pipeline `ReCiter-Publication-Manager-Dev-V2`, succeeded today), not this branch. The pipeline that watches plain `master` (`ReCiter-Publication-Manager`) has **failed its last 3 executions**, most recent April 23, 2026 — nothing has shipped from `master` in months.

**#859 is the fix that actually closes the live hole.** This PR exists for hygiene / in case the `master`-watching pipeline is ever revived — `master` is nominally "prod" by name and shouldn't sit vulnerable regardless of whether its pipeline is currently live.

## The fix

`master` is a much older fork than `dev`/`master_Next14` (`next-auth@3.29.10`, no capability model — `getCapabilities`/`ROLE_CAPABILITIES` don't exist here). So this can't be a cherry-pick of #853; it's a from-scratch `controllers/db/adminAuth.controller.ts` adapted to what `master` actually has: `getToken()` from next-auth v3's own `next-auth/jwt`, checking `role.roleLabel === allowedPermissions.Superuser` — the same comparison pattern master's own `src/middleware.ts` already uses (though that file only decodes the JWT for UI-redirect purposes and doesn't verify its signature; this is the real, signature-verified check). Applied to the same 6 routes as #859/#853.

Also includes a second commit, cherry-picked from the previously-unmerged `fix/nextauth-secret-backport` (same author, written back in April): master's NextAuth options object has no `secret:` field, so v3 falls back to auto-generating a signing key per pod restart rather than using `NEXTAUTH_SECRET`. Without that fix, `getToken({secret: process.env.NEXTAUTH_SECRET})` would never match the real signing key and this new check would fail closed for every session — including legitimate Superusers, not just attackers. Folding it in here since my new code depends on it to function at all.

## Verification

- `tsc --noEmit`: clean, 0 errors (master's build tooling itself is in rough shape — dead `npm-force-resolutions` preinstall script, lockfile out of sync with package.json, several transitively-drifted `@types/*` packages — none of it related to this diff; worked around locally without touching any committed file)
- `eslint` on the changed files: clean, 0 issues
- Adversarially reviewed alongside #859 (3-lens: bypass / regression / completeness) — completeness and regression both `SAFE_TO_PR`; the review's two blockers (wrong deploy target, missing secret wiring) are exactly what's addressed above
- No staging environment runs `master`'s actual code (confirmed: `ReCiter-Publication-Manager-Dev-V2` runs `master_Next14`, a different codebase generation) — so this hasn't been live-tested against a real session. Recommend a real end-to-end test (login as Superuser, hit one of the 6 routes) before/right after this ever gets deployed anywhere.