### PR TITLE
fix(authorships): exclude null-name ghost identities from the accept-guard

### DIFF
--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -118,8 +118,20 @@ const siblingKey = (r: any) =>
 async function reciterIdentitySet(cwids: Array<string | undefined | null>): Promise<Set<string>> {
   const wanted = [...new Set(cwids.filter(Boolean).map(String))];
   if (wanted.length === 0) return new Set();
+  // Require a name: ReCiter's own POST /reciter/identity/ makes alternateNames
+  // (firstName/lastName) mandatory, so a null-name `person` row can't be a currently-valid
+  // identity — it's stale sync debris (live case: lbm2001, dateAdded=dateUpdated=2019-08-16,
+  // every descriptive field NULL). Without this guard those ghost rows pass the identity
+  // check, the curator sees a working Accept button, and the real ReCiter add 404s — the
+  // exact dead-end this guard exists to prevent, just via a different mechanism than the
+  // "never was in ReCiter" case it already covers. 157/33,091 person rows (0.47%) are
+  // affected as of 2026-08-14, several dated 2026-05-04 (the documented Analysis-corruption
+  // incident date — plausibly related, not confirmed).
   const found: any[] = await models.Person.findAll({
-    where: { personIdentifier: { [Op.in]: wanted } },
+    where: {
+      personIdentifier: { [Op.in]: wanted },
+      [Op.or]: [{ firstName: { [Op.ne]: null } }, { lastName: { [Op.ne]: null } }],
+    },
     attributes: ["personIdentifier"], raw: true,
   });
   return new Set(found.map((p) => String(p.personIdentifier)));

--- a/src/components/elements/Authorships/AuthorshipsTabs.tsx
+++ b/src/components/elements/Authorships/AuthorshipsTabs.tsx
@@ -803,8 +803,8 @@ const AuthorshipsTabs = () => {
 
       {/* scopus pub-type facet (chips from summary.pubTypes) */}
       {source === "scopus" && (summary?.pubTypes?.length ?? 0) > 0 && (
-        <div style={{ display: "flex", alignItems: "center", gap: 8, margin: "2px 0 14px", flexWrap: "wrap" }}>
-          <span style={{ fontSize: 12, color: "#94a3b8" }}>Type</span>
+        <div style={{ display: "flex", alignItems: "center", gap: 5, margin: "2px 0 14px", flexWrap: "wrap" }}>
+          <span style={{ fontSize: 11, color: "#94a3b8" }}>Type</span>
           <button onClick={() => setSelectedPubTypes([])} style={pubChipStyle(selectedPubTypes.length === 0)}>All</button>
           {(summary?.pubTypes || []).map((pt) => {
             const on = selectedPubTypes.includes(pt.type);
@@ -960,7 +960,7 @@ const kbdStyle: CSSProperties = {
 
 const pubChipStyle = (active: boolean): CSSProperties => ({
   border: `1px solid ${active ? "#c7d2fe" : "#dde3ea"}`, background: active ? "#eef2ff" : "#fff",
-  color: active ? "#4338ca" : "#475569", borderRadius: 16, padding: "3px 11px", fontSize: 12,
+  color: active ? "#4338ca" : "#475569", borderRadius: 14, padding: "2px 8px", fontSize: 11,
   fontWeight: 600, cursor: "pointer", font: "inherit",
 });
 


### PR DESCRIPTION
Flagged live: accepting Laurence B. McCullough (lbm2001) 404'd — "ExternalArticle add
failed (404)" — even though he had a normal, working Accept button, not the "No ReCiter
identity" pill #855 added for exactly this dead-end. Same underlying disease, different
mechanism than #855 covered.

Root cause: the identity-guard (`reciterIdentitySet`) checks the reciterdb `person`
mirror table for existence only. lbm2001's row: `dateAdded = dateUpdated = 2019-08-16`,
every descriptive field (firstName/lastName/email/org/orcid) NULL — a 7-year-old ghost
row, not a live mirror of anyone currently in ReCiter's Identity table. Live-checked scale:
157 of 33,091 person rows (0.47%) are null-name; several cluster on 2026-05-04, the same
date as the documented Analysis-corruption incident (plausible connection, not confirmed).

Fix: `reciterIdentitySet` now requires firstName or lastName to be non-null. ReCiter's own
`POST /reciter/identity/` makes `alternateNames` (firstName/lastName) mandatory at
creation — a null-name row categorically can't be a currently-valid identity, so this
isn't a heuristic guess, it's enforcing the same contract ReCiter itself enforces.

**Also**, unrelated, flagged in the same screenshot: the Scopus pub-type filter chips
("Type: Article (390), Book Chapter (300), ...") were wrapping to 2-3 rows. Compacted
(`pubChipStyle`: fontSize 12→11, padding 3px 11px→2px 8px, borderRadius 16→14; container
gap 8→5) so more fit per row.

tsc clean on both changed files.