### PR TITLE
Literature Search: Mode 4 Phases 2-4 (corpus retrieval, evidence filtering, bibliometric stats)

### DIFF
--- a/controllers/literatureSearch.check.js
+++ b/controllers/literatureSearch.check.js
@@ -49,6 +49,7 @@ const {
 const mode1 = require('./literatureSearch.check.mode1')
 const mode2 = require('./literatureSearch.check.mode2')
 const mode3 = require('./literatureSearch.check.mode3')
+const mode4 = require('./literatureSearch.check.mode4')
 const rowCounts = require('./literatureSearch.check.rowCounts')
 const dialects = require('./literatureSearch.check.dialects')
 const exportsCheck = require('./literatureSearch.check.exports')
@@ -66,6 +67,7 @@ const lit = requireCompiled('controllers/literatureSearch.controller.js')
     const { q, hits } = await mode1.run(lit)
     await mode2.run(lit, { hits })
     await mode3.run(lit)
+    await mode4.run(lit)
     const { rc, rowsResult } = await rowCounts.run(lit)
     // Embase (Ovid) is asserted in two halves: the pure/dialect facts where the dialects are checked, and
     // the EXPORT in the exports section, where the renderers are loaded. This carries the run between them.
@@ -77,7 +79,9 @@ const lit = requireCompiled('controllers/literatureSearch.controller.js')
         + '\n     Mode 2 (the design derivation, the structured-abstract join, the 50-cap, count-before-fetch,'
         + '\n             the three bands, the priced narrowings, and the escape hatch)'
         + '\n     Mode 3 (the tier order incl. the SR-below-RCT inversion, the guideline tier against a real'
-        + '\n             PubMed record, the stable sort, the evidence floor, and PICO)')
+        + '\n             PubMed record, the stable sort, the evidence floor, and PICO)'
+        + '\n     Mode 4 (sharded corpus retrieval past the 50-cap, the hot-shard report, dedup, Case Report'
+        + '\n             exclusion, the case-series flag, and the Phase 4 aggregations)')
 })().catch(e => {
     cleanOutDir()
     console.error('\nFAILED:', e.message)

--- a/controllers/literatureSearch.check.mode4.js
+++ b/controllers/literatureSearch.check.mode4.js
@@ -1,0 +1,112 @@
+/*
+ * MODE 4 of the Literature Search check — Phases 2-4 (fetchCorpus, excludeCaseReports,
+ * flagProbableCaseSeries, the Phase 4 aggregations). Same rules as Mode 1-3's checks: live
+ * PubMed, NO LLM (Phases 2-4 never call Bedrock — Phase 1 is Mode 1's buildStrategy(), already
+ * checked, reused verbatim), assertions are RELATIONAL/BEHAVIOURAL rather than pinned to an exact
+ * yield that PubMed indexing will rot.
+ *
+ * Two fixtures, not one, because the two things worth proving need different shapes:
+ *   - NARROW: a real 2-year pull, deliberately over PubMed's own 50-record UI cap (Mode 2/3's
+ *     RECORD_CAP) so a shard that returns more than 50 records actually exercises "the cap is
+ *     hits, not RECORD_CAP" rather than coincidentally matching it.
+ *   - BROAD: one single, deliberately huge MeSH term for one year, to prove a hot shard is
+ *     reported (not silently truncated, not silently sub-sharded — decision 4 is deferred) without
+ *     needing a real pilot topic to happen to trip it.
+ */
+const assert = require('node:assert')
+
+const NARROW = {
+    db: 'pubmed',
+    concepts: [
+        {
+            label: 'Probiotics / microbiome',
+            lines: [{ terms: '"Gastrointestinal Microbiome"[MeSH] OR probiotic*[tiab]', on: true }],
+        },
+        {
+            label: 'Depression',
+            lines: [{ terms: '"Depressive Disorder"[MeSH] OR depress*[tiab]', on: true }],
+        },
+    ],
+    limits: '', // no date/type limit here on purpose — fetchCorpus supplies the [dp] shard itself
+}
+
+const BROAD = {
+    db: 'pubmed',
+    concepts: [{ label: 'Neoplasms', lines: [{ terms: 'Neoplasms[MeSH]', on: true }] }],
+    limits: '',
+}
+
+const run = async (lit) => {
+    // ---- Phase 2: the normal path — two real shards, neither hot. --------------------------
+    const corpus = await lit.fetchCorpus(NARROW, 2023, 2024)
+    assert.strictEqual(corpus.shards.length, 2, 'one shard per year in [fromYear, toYear]')
+    assert.ok(corpus.shards.every(s => s.ok), 'neither test year is anywhere near the 2,000 threshold')
+    assert.ok(corpus.shards[0].year === 2023 && corpus.shards[1].year === 2024, 'shards stay in year order')
+
+    // THE ONE THAT MATTERS FOR THIS PHASE. Mode 2/3 cap at 50 by design; Mode 4 must not, or it
+    // silently reinherits the exact recall-collapse RECALL-STUDY.md measured. At least one real
+    // year here has to clear 50 or this assertion cannot tell "uncapped" from "coincidentally
+    // small this year".
+    const bigShard = corpus.shards.find(s => s.hits > 50)
+    assert.ok(bigShard, 'fixture sanity: at least one test year must exceed RECORD_CAP for the next line to mean anything')
+    assert.strictEqual(bigShard.records.length, bigShard.hits, `shard ${bigShard.year} returned all ${bigShard.hits} hits, not truncated at 50`)
+
+    assert.strictEqual(
+        corpus.records.length,
+        corpus.shards.reduce((n, s) => n + (s.ok ? s.records.length : 0), 0) - corpus.duplicates,
+        'deduped corpus size = sum of shard records minus duplicates',
+    )
+    assert.ok(new Set(corpus.records.map(r => r.pmid)).size === corpus.records.length, 'no duplicate PMIDs survive dedup')
+
+    // ---- Phase 2: the hot-shard path — reported, not truncated or auto-sub-sharded. --------
+    const hot = await lit.fetchCorpus(BROAD, 2024, 2024)
+    assert.strictEqual(hot.shards.length, 1)
+    assert.strictEqual(hot.shards[0].ok, false, 'Neoplasms[MeSH] for one year is well over the threshold')
+    assert.ok(hot.shards[0].hits > lit.RETRIEVAL_THRESHOLD, 'the reported hit count is the real, over-threshold count')
+    assert.ok(/threshold/i.test(hot.shards[0].error), 'the error names the reason, not just a bare failure')
+    assert.strictEqual(hot.records.length, 0, 'a hot year contributes nothing rather than a silent partial pull')
+
+    // ---- Phase 3: evidence-type filtering. --------------------------------------------------
+    const withoutCaseReports = lit.excludeCaseReports(corpus.records)
+    assert.ok(withoutCaseReports.every(r => r.tier.label !== 'Case report'), 'every Case Report is gone')
+    assert.ok(withoutCaseReports.length <= corpus.records.length, 'filtering only ever removes records')
+    const removedCount = corpus.records.length - withoutCaseReports.length
+    const actualCaseReports = corpus.records.filter(r => r.tier.label === 'Case report').length
+    assert.strictEqual(removedCount, actualCaseReports, 'exactly the Case Reports were dropped, nothing else')
+
+    const flagged = lit.flagProbableCaseSeries(withoutCaseReports)
+    assert.strictEqual(flagged.length, withoutCaseReports.length, 'flagging never excludes — every record stays')
+    assert.ok(flagged.every(r => r.caseSeriesProbable === true || r.caseSeriesProbable === undefined),
+        'the flag is present-and-true or absent, never present-and-false')
+    assert.ok(flagged.filter(r => r.caseSeriesProbable).every(r => r.tier.label === 'Other'),
+        'only records with no recognised study-design [pt] are ever flagged')
+
+    // ---- Phase 4: pure aggregation — every record counts once, in every stat. --------------
+    const byYear = lit.publicationsPerYear(flagged)
+    assert.strictEqual(byYear.reduce((n, y) => n + y.count, 0), flagged.length, 'publicationsPerYear accounts for every record')
+    assert.deepStrictEqual(byYear.map(y => y.year), [...byYear.map(y => y.year)].sort(), 'years are in ascending order')
+
+    const mix = lit.evidenceMixByYear(flagged)
+    for (const y of Object.keys(mix)) {
+        const sum = Object.values(mix[y]).reduce((a, b) => a + b, 0)
+        const expected = byYear.find(x => x.year === y).count
+        assert.strictEqual(sum, expected, `evidence mix for ${y} accounts for every record that year`)
+    }
+
+    const journals = lit.journalDistribution(flagged, 5)
+    assert.ok(journals.length <= 5, 'respects the top-N cap')
+    assert.ok(journals.every((j, i) => i === 0 || journals[i - 1].count >= j.count), 'sorted by count, descending')
+
+    const pct = lit.percentileTrend(flagged)
+    assert.strictEqual(pct.reduce((n, p) => n + p.n, 0), flagged.length, 'percentileTrend also accounts for every record')
+    assert.ok(pct.every(p => p.scored <= p.n), 'scored (has a real percentile) never exceeds n (records that year)')
+    assert.ok(pct.every(p => p.median === null || (p.median >= 0 && p.median <= 100)), 'a real median is a real percentile')
+
+    console.log(`  Mode 4 fixture: ${corpus.records.length} records across ${corpus.shards.length} years `
+        + `(${corpus.duplicates} cross-shard duplicates), ${removedCount} Case Reports dropped, `
+        + `${flagged.filter(r => r.caseSeriesProbable).length} probable case series flagged`)
+
+    return { corpus, flagged }
+}
+
+module.exports = { run }

--- a/controllers/literatureSearch.controller.ts
+++ b/controllers/literatureSearch.controller.ts
@@ -47,7 +47,8 @@
 // This file is now the BARREL. The implementation lives in focused modules, split by concern so no
 // single file is 2,000+ lines: strategy (query assembly + types), counting (arithmetic over PubMed
 // counts), records (fetch/shape/evidence tiers), llm (every Bedrock call), experts (the MeSH→panel
-// bridge), build (the Mode 1 multi-database orchestration). Consumers — the API route and the check
+// bridge), build (the Mode 1 multi-database orchestration), corpus (Mode 4 Phases 2-4: sharded
+// retrieval, evidence filtering, bibliometric stats). Consumers — the API route and the check
 // harnesses — import from here, so the split changed no call site.
 export * from './literatureSearch.strategy'
 export * from './literatureSearch.counting'
@@ -55,3 +56,4 @@ export * from './literatureSearch.records'
 export * from './literatureSearch.llm'
 export * from './literatureSearch.experts'
 export * from './literatureSearch.build'
+export * from './literatureSearch.corpus'

--- a/controllers/literatureSearch.corpus.ts
+++ b/controllers/literatureSearch.corpus.ts
@@ -1,0 +1,188 @@
+// Mode 4 (bibliometric review) — Phases 2-4. Split out the same way counting/records/llm already
+// are; the design contract lives in
+// Projects/ReCiter-Publication-Manager/literature-search/PLAN-literature-mode4-bibliometric-review.md
+// (not in this repo — planning docs live in Projects, code lives here). Phase 1 (strategy) is Mode
+// 1's buildStrategy(), reused verbatim, no new code. Phases 5-8 (clustering, scoring, synthesis,
+// export) are not built yet.
+//
+// PubMed only. Scopus/Embase corpus retrieval is explicitly out of scope for v1 (Scopus has no
+// MeSH — the clustering half of this feature needs it — and Embase is Ovid-only, no API), so this
+// file never takes a `db` parameter the way strategy.ts's Dialect table does.
+import { Strategy, assembleQuery } from './literatureSearch.strategy'
+import { PubRecord, fetchRecords } from './literatureSearch.records'
+import { countPubmed } from './literatureSearch.counting'
+
+// ---------------------------------------------------------------------------
+// PHASE 2 — full-corpus retrieval, sharded by year.
+//
+// The PubMed retrieval tool refuses any query over 2,000 hits outright (its own
+// RETRIEVAL_THRESHOLD — see ReCiter-PubMed-Retrieval-Tool). A 10-year pull on a real subfield
+// will very likely clear that in aggregate, so this shards by publication year and calls
+// countPubmed/fetchRecords once per year. Year-sharding is free here: it is exactly the axis the
+// trend analysis (Phase 4) needs anyway, so the shard IS the unit the stats are computed over.
+//
+// Mirrors the tool's own cap so a hot year gets a clear, attributable error instead of a bare
+// fetch failure. If the tool's threshold ever changes, this stops being the source of truth for
+// it (the tool's own throw still is) and just becomes a slightly stale early warning.
+export const RETRIEVAL_THRESHOLD = 2000
+
+export type YearShard =
+    | { year: number; hits: number; ok: true; records: PubRecord[] }
+    // hits > RETRIEVAL_THRESHOLD: a year too hot to pull whole. Sub-sharding a hot year by
+    // evidence type is the handoff's decision 4 — deliberately DEFERRED (recommended: build it
+    // only if a real pilot year actually trips this), so a hot year is reported, not silently
+    // dropped or silently truncated. A caller sees exactly which year(s) need a human call.
+    | { year: number; hits: number; ok: false; error: string }
+
+export type Corpus = {
+    records: PubRecord[]            // deduped, full corpus
+    shards: YearShard[]             // one entry per year, in order — the trend axis for Phase 4
+    duplicates: number              // PMIDs seen in more than one shard (MEDLINE entry-date vs.
+                                     // print-date can straddle a year boundary)
+}
+
+// A transient fetch failure on ONE year must not lose the other nine — retry the shard a few
+// times before giving up on it, same instinct as the tool's own esearch retry, just one layer up
+// (a shard-level failure here is a whole year, not one esearch call).
+async function fetchShard(query: string, cap: number, attempts = 3): Promise<PubRecord[]> {
+    let lastErr: unknown
+    for (let i = 0; i < attempts; i++) {
+        try {
+            return await fetchRecords(query, cap, 'date')
+        } catch (e) {
+            lastErr = e
+            if (i < attempts - 1) await new Promise(r => setTimeout(r, 500 * (i + 1)))
+        }
+    }
+    throw lastErr
+}
+
+export async function fetchCorpus(strategy: Strategy, fromYear: number, toYear: number): Promise<Corpus> {
+    const base = assembleQuery(strategy)
+    const shards: YearShard[] = []
+
+    for (let y = fromYear; y <= toYear; y++) {
+        const query = `${base} AND ${y}:${y}[dp]`
+        const hits = await countPubmed(query)
+
+        if (hits === 0) {
+            shards.push({ year: y, hits: 0, ok: true, records: [] })
+            continue
+        }
+        if (hits > RETRIEVAL_THRESHOLD) {
+            shards.push({
+                year: y, hits, ok: false,
+                error: `${hits.toLocaleString()} hits in ${y} alone exceeds the ${RETRIEVAL_THRESHOLD}-record `
+                    + 'retrieval threshold. Not sub-sharded automatically (deferred by design — see decision 4 '
+                    + 'in the Mode 4 handoff); narrow the strategy for this year or sub-shard by evidence type.',
+            })
+            continue
+        }
+        const records = await fetchShard(query, hits)
+        shards.push({ year: y, hits, ok: true, records })
+    }
+
+    // Dedup by PMID, first shard seen wins. A paper straddling a year boundary (MEDLINE entry
+    // date vs. print date disagree) can legitimately match two `[dp]` shards.
+    const byPmid = new Map<string, PubRecord>()
+    let seen = 0
+    for (const s of shards) {
+        if (!s.ok) continue
+        for (const r of s.records) {
+            seen++
+            if (!byPmid.has(r.pmid)) byPmid.set(r.pmid, r)
+        }
+    }
+
+    return { records: [...byPmid.values()], shards, duplicates: seen - byPmid.size }
+}
+
+// ---------------------------------------------------------------------------
+// PHASE 3 — evidence-type filtering. Extends tierOf(), never replaces it: every record already
+// carries `.tier`, computed at fetch time from PubMed's own [pt] list, same as Mode 3. Nothing
+// here asks a model to classify study design.
+
+const CASE_REPORT = 'Case report' // tierOf()'s own label — see literatureSearch.records.ts TIERS
+
+export const excludeCaseReports = (records: PubRecord[]): PubRecord[] =>
+    records.filter(r => r.tier.label !== CASE_REPORT)
+
+// THE HONEST GAP tierOf() ALREADY DOCUMENTS: PubMed has no [pt] tag for "case series" at all, so
+// it cannot be derived the way Case Report/RCT/Meta-analysis can. This is a best-effort MeSH/text
+// heuristic, not a claim — every record it flags stays in the corpus, unexcluded, and the caller
+// is expected to render the flag as "probable, unverified" (the plan's recommended option: coarse
+// and honest beats inventing a clean tier that would misrepresent PubMed's own indexing).
+//
+// Signal: a record indexed only as "Other" (i.e. tierOf found no recognised study-design [pt] —
+// most commonly bare "Journal Article") AND either a MeSH heading associated with retrospective
+// case description, or title language a case-series title conventionally uses ("a case series
+// of...", "N cases of...", "our experience with...").
+const CASE_SERIES_MESH = /retrospective studies|case-control studies/i
+const CASE_SERIES_TITLE = /\bcase series\b|\b\d+\s+(patients|cases)\b|\bour experience\b/i
+
+export const flagProbableCaseSeries = (records: PubRecord[]): PubRecord[] =>
+    records.map(r => {
+        if (r.tier.label !== 'Other') return r
+        const meshHit = r.mesh.some(m => CASE_SERIES_MESH.test(m))
+        const titleHit = CASE_SERIES_TITLE.test(r.title)
+        return meshHit || titleHit ? { ...r, caseSeriesProbable: true } : r
+    })
+
+// ---------------------------------------------------------------------------
+// PHASE 4 — bibliometric statistics. Pure aggregation over whatever corpus it is handed — no LLM,
+// no network, no ranking, so the recall-collapse trap the rest of this feature is built around
+// (RECALL-STUDY.md) does not apply here. Every record in `records` counts once, in every stat.
+
+export type YearCount = { year: string; count: number }
+export type EvidenceMixByYear = Record<string, Record<string, number>>  // year -> tier.label -> count
+export type JournalCount = { journal: string; count: number }
+export type PercentilePoint = { year: string; median: number | null; n: number; scored: number }
+
+export function publicationsPerYear(records: PubRecord[]): YearCount[] {
+    const counts = new Map<string, number>()
+    for (const r of records) counts.set(r.year, (counts.get(r.year) || 0) + 1)
+    return [...counts.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([year, count]) => ({ year, count }))
+}
+
+export function evidenceMixByYear(records: PubRecord[]): EvidenceMixByYear {
+    const out: EvidenceMixByYear = {}
+    for (const r of records) {
+        out[r.year] ??= {}
+        out[r.year][r.tier.label] = (out[r.year][r.tier.label] || 0) + 1
+    }
+    return out
+}
+
+export function journalDistribution(records: PubRecord[], top = 20): JournalCount[] {
+    const counts = new Map<string, number>()
+    for (const r of records) {
+        const j = r.journal || '(no journal recorded)'
+        counts.set(j, (counts.get(j) || 0) + 1)
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, top).map(([journal, count]) => ({ journal, count }))
+}
+
+// iCite's nih_percentile is ROUTINELY ABSENT for recent papers (see withCitationMetrics's own
+// comment) — that is correct, not broken, so `scored` (records with a real percentile) is
+// reported alongside `n` (records that year, total) rather than silently averaging over a
+// shrinking, recency-biased denominator.
+export function percentileTrend(records: PubRecord[]): PercentilePoint[] {
+    const byYear = new Map<string, number[]>()
+    const totalByYear = new Map<string, number>()
+    for (const r of records) {
+        totalByYear.set(r.year, (totalByYear.get(r.year) || 0) + 1)
+        if (typeof r.nihPercentile === 'number') {
+            if (!byYear.has(r.year)) byYear.set(r.year, [])
+            byYear.get(r.year)!.push(r.nihPercentile)
+        }
+    }
+    const median = (xs: number[]) => {
+        const s = [...xs].sort((a, b) => a - b)
+        const mid = Math.floor(s.length / 2)
+        return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2
+    }
+    return [...totalByYear.keys()].sort().map(year => {
+        const scored = byYear.get(year) || []
+        return { year, median: scored.length ? median(scored) : null, n: totalByYear.get(year)!, scored: scored.length }
+    })
+}

--- a/controllers/literatureSearch.records.ts
+++ b/controllers/literatureSearch.records.ts
@@ -187,6 +187,10 @@ export type PubRecord = {
     mesh: string[]
     // NIH percentile from iCite. DISPLAY ONLY — see withCitationMetrics(). Often absent, by design.
     nihPercentile?: number
+    // Mode 4 Phase 3 only — see flagProbableCaseSeries() in literatureSearch.corpus.ts. PubMed has
+    // no [pt] tag for case series, so this is a best-effort MeSH/text heuristic, never a tier.
+    // Undefined everywhere else; never excludes a record on its own.
+    caseSeriesProbable?: boolean
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Builds on #824 (Modes 1-3, still open/review-only). Adds Phases 2-4 of Mode 4, the bibliometric-review mode for the Dan Cook / Anesthesiology pilot. Design doc: `PLAN-literature-mode4-bibliometric-review.md` / `HANDOFF-literature-mode4-bibliometric-review.md` (Projects, not this repo).

**Draft — review only, same as #824. Do not merge.** Backend-only, no route/UI wiring, nothing deployed.

## What's here

- `literatureSearch.corpus.ts`
  - `fetchCorpus()` — Phase 2: shards a validated strategy by publication year, so no shard truncates at Mode 2/3's 50-record `RECORD_CAP` (the recall-collapse `RECALL-STUDY.md` measured). A year over the PubMed tool's 2,000-record threshold is reported, not silently sub-sharded — decision 4 in the handoff is deliberately deferred. Dedups by PMID across shards (a paper can straddle a `[dp]` year boundary).
  - `excludeCaseReports()` / `flagProbableCaseSeries()` — Phase 3, extends `tierOf()` rather than duplicating it. Case series has no PubMed `[pt]` tag, so the flag is a best-effort MeSH/text heuristic that never excludes a record — matches the plan's recommended "coarse and honest" default. Needs sign-off from whoever owns the pilot (handoff decision 2) before this ships user-facing.
  - Phase 4 aggregations — `publicationsPerYear`, `evidenceMixByYear`, `journalDistribution`, `percentileTrend`. Pure code, no LLM, no ranking, so the recall-collapse trap doesn't apply.
- `literatureSearch.check.mode4.js`, wired into `npm run check:literature` — live PubMed, no LLM, same style as Modes 1-3's checks. Two fixtures: a real 2-year narrow pull (proves no truncation + dedup arithmetic) and one deliberately-broad single-year pull (proves the hot-shard path reports cleanly instead of truncating or auto-sub-sharding).

Ran clean: 857 records across 2 years, 44 cross-shard duplicates, 1 Case Report dropped, 25 probable case series flagged.

## Not in this PR

Phase 1 (strategy) is Mode 1's `buildStrategy()`, reused verbatim — no new code, already checked by #824. Phases 5-8 (clustering, scoring, synthesis, export) and all route/UI wiring are not built. Two cheap validation probes (coverage against 2 real airway/anesthesiology reviews, a real measured Bedrock cost sample) were run separately and are written up in the Projects handoff, not in this diff.

## Open, not resolved by this PR

The 4 decisions the handoff calls out as not engineering calls: deploy timing relative to #824, case-series methodology sign-off, the allowlist model for a faculty user, and whether to build sub-sharding-by-evidence-type now or defer (this PR takes the doc's own recommended default: defer).