### PR TITLE
Literature Search: Mode 4 Phases 5-8 (clustering, scoring, narrative synthesis, export)

### DIFF
--- a/controllers/literatureExport.bibliometricDoc.ts
+++ b/controllers/literatureExport.bibliometricDoc.ts
@@ -1,0 +1,142 @@
+// Mode 4 (bibliometric review) — the review document. Split out of literatureExport.ts (barrel), a
+// SIBLING of literatureExport.synthesisDoc.ts: same AI-ASSISTED disclosure convention, same
+// reproHeader() usage, same disclaimer-at-the-end style. What differs is the shape underneath it —
+// this document has no single evidence table, it has SIX (five stat tables plus the cluster
+// roster), because a bibliometric review's job is to characterize a whole corpus, not answer one
+// question over a hand-picked subset the way Modes 2/3 do.
+import { Block, RunFacts, reproHeader, modelDisclosure } from './literatureExport.blocks'
+
+export type BibliometricStats = {
+    publicationsPerYear: Array<{ year: string; count: number }>
+    evidenceMixByYear: Record<string, Record<string, number>>
+    journalDistribution: Array<{ journal: string; count: number }>
+    percentileTrend: Array<{ year: string; median: number | null; n: number; scored: number }>
+}
+
+export function bibliometricDoc(
+    topic: string,
+    facts: RunFacts & { fromYear: number; toYear: number },
+    stats: BibliometricStats,
+    clusters: Array<{ id: string; label: string; pmids: string[]; isUncategorized?: boolean }>,
+    narrative: { intro: string; sections: Array<{ label: string; paragraph: string; invented?: string[] }>; caseSeriesNote?: string },
+): Block[] {
+    return [
+        { kind: 'h1', text: `Bibliometric review: ${topic}` },
+
+        // AI-ASSISTED — same convention synthesisDoc.ts opens with, adapted for what actually
+        // happened here. THE CAVEAT THAT MATTERS MOST: unlike Mode 2/3's synthesize(), which reads
+        // every record a human selected, the narrative sections below were each written over a
+        // representative SHORTLIST of a cluster's papers (preFilterForScoring()'s deterministic
+        // pre-filter, then whatever synthesizeCluster() was actually given) — never a full-corpus
+        // read. A reader who treats a cluster paragraph as "this model read all N papers in this
+        // cluster" is trusting a claim this document never makes.
+        { kind: 'p', text:
+            `AI-ASSISTED. This document's narrative sections (below) were drafted by ${facts.model ? modelDisclosure(facts.model) : 'a language model'}, `
+            + 'one topic cluster at a time, over a representative shortlist of that cluster\'s papers selected by a deterministic pre-filter — '
+            + 'this is NOT a full-corpus AI read. Every claim carries its own PMID — verify each one against the source before relying on it. '
+            + 'A claim with no PMID is unsupported.' },
+
+        // Placed here, not buried after every cluster section — the plan's own instruction, and the
+        // obvious one: a reader who has already scrolled past six tables and every cluster's prose
+        // is not the reader who needs to be told "case series can't be cleanly tagged in PubMed"
+        // before reading the case-flagged rows in those tables and sections.
+        ...(narrative.caseSeriesNote ? [{ kind: 'small' as const, text: narrative.caseSeriesNote }] : []),
+
+        { kind: 'h2', text: 'Overview' },
+        { kind: 'p', text: narrative.intro },
+
+        { kind: 'h2', text: 'Publications per year' },
+        { kind: 'table', head: ['Year', 'Count'], rows:
+            stats.publicationsPerYear.map(y => [y.year, String(y.count)]) },
+
+        { kind: 'h2', text: 'Evidence-type mix by year' },
+        ...evidenceMixTable(stats.evidenceMixByYear),
+
+        { kind: 'h2', text: 'Journal distribution (top 20)' },
+        { kind: 'table', head: ['Journal', 'Count'], rows:
+            stats.journalDistribution.map(j => [j.journal, String(j.count)]) },
+
+        { kind: 'h2', text: 'Citation percentile trend (iCite)' },
+        { kind: 'table', head: ['Year', 'Median percentile', 'N', 'Scored'], rows:
+            // A null median is NOT "N/A" and NOT 0 — same rule impactScoreOf()/percentileTrend()
+            // itself already applies to a missing nihPercentile: a year with zero scored records has
+            // no median to report, and printing one would be arithmetic over an empty set.
+            stats.percentileTrend.map(p => [p.year, p.median === null ? '' : String(p.median), String(p.n), String(p.scored)]) },
+
+        { kind: 'h2', text: 'Keyword clusters' },
+        ...clusterTable(clusters),
+
+        // One section per cluster the model actually wrote a paragraph for, in the order
+        // assembleNarrativeReview() already decided (size descending, cluster id as the tie-break —
+        // see that function's own comment). Nothing here re-sorts narrative.sections.
+        ...narrative.sections.flatMap(section => ([
+            { kind: 'h2' as const, text: section.label },
+            { kind: 'p' as const, text: section.paragraph },
+            // A FABRICATED CITATION TRAVELS — same reasoning as synthesisDoc.ts's own warning, reused
+            // per-cluster here because a fabricated citation is exactly as serious whichever section
+            // of the document it turns up in. The one wording change: this paragraph is printed
+            // ABOVE its warning (task order is paragraph-then-warning, not warning-then-paragraph the
+            // way synthesisDoc.ts opens with it), so the pointer reads "above", not "below".
+            ...(section.invented?.length ? [
+                { kind: 'h2' as const, text: 'WARNING — this synthesis cites papers that were not in the evidence set' },
+                { kind: 'p' as const, text:
+                    `The model cited PMID ${section.invented.join(', ')}, which ${section.invented.length === 1 ? 'was' : 'were'} not among the records selected for this cluster's synthesis. `
+                    + 'The citation came from outside the evidence set, so the claim it supports is unverified and the sentence around it must not be relied on. '
+                    + 'The paragraph above is reproduced UNEDITED — it has deliberately not been rewritten to hide this — and it must be read against the sources before any of it is used.' },
+            ] : []),
+        ])),
+
+        ...reproHeader(facts),
+
+        { kind: 'p', text:
+            'Verify every claim against its cited source before relying on this draft; this is a scoping/bibliometric review, not a systematic review, '
+            + 'and does not include risk-of-bias or GRADE assessment.' },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Evidence-type mix by year, flattened into a table. The COLUMN SET IS DERIVED, not hardcoded — it
+// is the union of every tier.label that actually appears anywhere in evidenceMixByYear. A fixed
+// list here (e.g. copied from TIERS in literatureSearch.records.ts) would silently disagree with
+// tierOf() the moment that table's labels change, and the disagreement would be invisible: it would
+// not throw, it would just quietly drop a column and undercount every year that used the new label.
+function evidenceMixTable(mix: Record<string, Record<string, number>>): Block[] {
+    const years = Object.keys(mix).sort()
+
+    const labels = new Set<string>()
+    for (const yearCounts of Object.values(mix)) {
+        for (const label of Object.keys(yearCounts)) labels.add(label)
+    }
+    // Alphabetical, for a deterministic column order — this file has no access to TIERS' rank
+    // ordering (and importing it would be exactly the hardcoded-list coupling this function exists
+    // to avoid), so there is no more meaningful order available than the labels' own names.
+    const tierLabels = [...labels].sort()
+
+    // Every record carries exactly one tier.label (tierOf() always returns one — see
+    // literatureSearch.records.ts), so a label absent from a given year is a genuine count of zero
+    // for that year, not a missing value. Unlike a missing nihPercentile or an unscored record, '0'
+    // here is not a fabrication — it is the correct arithmetic answer to "how many of these ran that
+    // year."
+    return [{
+        kind: 'table',
+        head: ['Year', ...tierLabels],
+        rows: years.map(year => [year, ...tierLabels.map(label => String(mix[year][label] || 0))]),
+    }]
+}
+
+// Keyword-cluster roster: real clusters first, biggest first (same size-desc, id-tiebreak order
+// assembleNarrativeReview() uses for its own sections, so the table above a cluster's prose and the
+// order the prose appears in agree), then — if the corpus had any — ONE row for the uncategorized
+// bucket at the bottom, with its real count. Never omitted: a reader adding this column up must land
+// on the corpus total, not a total that quietly excludes whatever no seed MeSH term claimed.
+function clusterTable(clusters: Array<{ id: string; label: string; pmids: string[]; isUncategorized?: boolean }>): Block[] {
+    const real = clusters
+        .filter(c => !c.isUncategorized)
+        .sort((a, b) => b.pmids.length - a.pmids.length || a.id.localeCompare(b.id))
+    const uncategorized = clusters.find(c => c.isUncategorized)
+
+    const rows = real.map(c => [c.label, String(c.pmids.length)])
+    if (uncategorized) rows.push([uncategorized.label, String(uncategorized.pmids.length)])
+
+    return [{ kind: 'table', head: ['Cluster', 'Papers'], rows }]
+}

--- a/controllers/literatureExport.corpusSheet.ts
+++ b/controllers/literatureExport.corpusSheet.ts
@@ -1,0 +1,133 @@
+// Mode 4 (bibliometric review) — the .xlsx corpus sheet. Split out of literatureExport.ts
+// (barrel), a SIBLING of literatureExport.sheets.ts's recordSheets(), not a modification of it.
+import { DIALECTS } from './literatureSearch.strategy'
+import { RunFacts, modelDisclosure } from './literatureExport.blocks'
+import { Sheet, RecordLike } from './literatureExport.sheets'
+
+// ---------------------------------------------------------------------------
+// WHY THIS FILE HAS NO truncated() AND NO "AI screening" REFUSAL ROW — read recordSheets' own
+// comment above `truncated()` in literatureExport.sheets.ts first; this is the short version of why
+// none of that applies here.
+//
+// That logic exists because Modes 2/3 rank a query's yield by relevance and RETRIEVE ONLY THE TOP
+// 50 — so the sheet in front of a screener can be a near-disjoint sliver of what the strategy
+// actually matched (measured: 1% recall on a relevance-ranked top 50, see RECALL-STUDY.md), and an
+// "AI suggested Include/Exclude" column on that sliver would misrepresent it as a screen.
+//
+// Mode 4 never does that. fetchCorpus() (literatureSearch.corpus.ts) shards by year and pulls EVERY
+// record each year's query matches, up to RETRIEVAL_THRESHOLD per year — and a year that clears the
+// threshold comes back as a reported, attributable shard error (`ok: false`), never a silent
+// truncation. So `records` here is always the full corpus (or the full corpus minus a year the
+// caller was told, loudly, could not be pulled whole) — never a ranked slice standing in for a much
+// bigger yield. There is no cap to disclose and nothing to refuse.
+//
+// There is also no AI include/exclude verdict ANYWHERE in Mode 4 — this feature is a report, not a
+// filter (see scoreRelevance()'s own header comment in literatureSearch.score.ts: "YOUR SCORE IS A
+// SUGGESTION, not a filter"). So this sheet carries impact/relevance SCORES, not verdicts, and the
+// one disclosure it does owe the reader is different: those scores were computed for a
+// representative shortlist of the corpus (preFilterForScoring()'s ~200-record budget), not for
+// every row. That disclosure lives on the Search sheet below, in place of recordSheets' "AI
+// screening" row.
+
+// A record's impact/relevance fields arrive only for the shortlist preFilterForScoring() (and, for
+// relevance, scoreRelevance() actually answering for) picked — every other record in the corpus is
+// still a full row here, just with these five columns blank. Cluster membership, by contrast, is
+// assigned to every record (clusterByMesh() never drops one — see its own "never silently dropped"
+// comment), so clusterLabel is expected to be populated corpus-wide, including 'Uncategorized / no
+// dominant MeSH topic' for the fallthrough bucket.
+export type ScoredRecordLike = RecordLike & {
+    caseSeriesProbable?: boolean
+    clusterLabel?: string
+    impactScore?: number; impactJustification?: string
+    relevanceScore?: number; relevanceJustification?: string
+}
+
+export function corpusSheet(
+    records: ScoredRecordLike[],
+    facts: RunFacts & { fromYear: number; toYear: number },
+): Sheet[] {
+    return [
+        {
+            name: 'Records',
+            head: [
+                'PMID', 'Title', 'Authors', 'Year', 'Journal', 'Evidence type', 'Case series',
+                'Cluster', 'Impact score', 'Impact justification', 'Relevance score',
+                'Relevance justification', 'Link',
+            ],
+            // Every row has exactly 13 cells, matching the 13-column head above — no conditional
+            // spread here (unlike recordSheets' `cut` branch), because unlike that sheet nothing
+            // about THIS sheet's shape ever changes row to row or run to run. A short row would
+            // silently shift every later cell one column left for that record alone (see sheets.ts's
+            // own comment on this), so every optional value below is padded to '' rather than
+            // omitted.
+            rows: records.map(r => [
+                r.pmid, r.title, r.authors, r.year, r.journal,
+                // "Evidence type" is r.design, not a new field — RecordLike.design is ALREADY
+                // tierOf()'s own label (see the comment on `design` in literatureSearch.records.ts:
+                // "derived — see designOf(). Same string as tier.label"). A second column deriving
+                // the same string a different way would be two names for one fact, free to drift.
+                r.design,
+                // THREE STATES, NOT TWO — same principle recordSheets applies to include/exclude/
+                // not-screened. PubMed has no case-series [pt] tag (flagProbableCaseSeries()'s own
+                // comment), so the flag is a heuristic, never a verdict: 'Probable' when it fired,
+                // blank — never 'No' — when it did not, because the absence of the flag is not the
+                // same claim as a checked "confirmed not a case series."
+                r.caseSeriesProbable === true ? 'Probable' : '',
+                r.clusterLabel ?? '',
+                // MISSING IS NOT ZERO, for all four of these — the same rule withCitationMetrics()
+                // and recordSheets() already apply to a missing nihPercentile, for the same reason:
+                // Number(undefined) coerced to 0 would read as "scored, and scored at rock bottom,"
+                // when the truth is "never sent to a scorer at all." A blank cell is the only honest
+                // rendering of "not in the shortlist."
+                typeof r.impactScore === 'number' ? r.impactScore : '',
+                r.impactJustification ?? '',
+                typeof r.relevanceScore === 'number' ? r.relevanceScore : '',
+                r.relevanceJustification ?? '',
+                `https://pubmed.ncbi.nlm.nih.gov/${r.pmid}/`,
+            ]),
+        },
+        {
+            // Same reason recordSheets' Search sheet exists: the reproducibility facts travel WITH
+            // the data, in the same file, so a PMID list someone downloads is never later unaccounted
+            // for.
+            name: 'Search',
+            head: ['Field', 'Value'],
+            rows: [
+                ['Database', DIALECTS[facts.db || 'pubmed'].provenance],
+                ['Date searched', facts.runDate],
+                ['Year range', `${facts.fromYear}-${facts.toYear}`],
+                // RECORDS IN CORPUS IS records.length, NOT facts.hits — deliberately, and unlike
+                // recordSheets' Search sheet, which uses facts.hits because Mode 2/3 run ONE query
+                // and `hits` is that query's exact count. Mode 4 has no single query: fetchCorpus()
+                // runs one query PER YEAR and dedupes the union (a paper straddling a year boundary
+                // can match two shards — see fetchCorpus's own comment). Summing each shard's `hits`
+                // would DOUBLE-COUNT those duplicates, and a year that tripped RETRIEVAL_THRESHOLD
+                // contributes a reported count with zero records behind it. `records.length` is the
+                // one number guaranteed to equal the row count of the Records sheet sitting right
+                // next to this one — which is the whole point of a sheet that carries its own facts.
+                ['Records in corpus', records.length],
+                ...(facts.model
+                    ? [['Model (query drafting, cluster labeling, relevance scoring, narrative)', modelDisclosure(facts.model)]]
+                    : []),
+                // THE DISCLOSURE THIS SHEET OWES IN PLACE OF recordSheets' "AI screening" ROW — see
+                // this file's header comment for why the two are different claims. This one says
+                // plainly that most rows above were never sent to a scorer, so a blank Impact/
+                // Relevance cell is not a hidden zero and a populated one is not "every record was
+                // judged."
+                ['Impact / relevance scoring', 'Computed for a representative shortlist of this '
+                    + 'corpus only, not every record — see preFilterForScoring() in '
+                    + 'literatureSearch.score.ts. A blank Impact score or Relevance score cell means '
+                    + 'that record was not in the shortlist (or, for Relevance, that the model did '
+                    + 'not return a score for it); it is not a zero.'],
+                // Boolean query goes LAST, same convention as recordSheets and reproHeader — it is
+                // the thing a reader scrolls to and copy-pastes, so it sits at the bottom of the
+                // list, not buried in the middle of it.
+                ['Boolean query', `${facts.query} — this is the base query for ONE year; Mode 4 `
+                    + `AND's it with a [dp] date-range term and runs it once for each year from `
+                    + `${facts.fromYear} to ${facts.toYear} (see fetchCorpus() in `
+                    + `literatureSearch.corpus.ts), then dedupes the union into the corpus above. `
+                    + 'There is no single query that reproduces the whole corpus in one PubMed search box.'],
+            ] as Array<Array<string | number>>,
+        },
+    ]
+}

--- a/controllers/literatureExport.ts
+++ b/controllers/literatureExport.ts
@@ -21,11 +21,15 @@
 // lets `npm run check:literature` assert what a document SAYS with no dependency and no model call.
 
 //
-// This file is now the BARREL. The builders live in four focused modules, split by concern so no
-// single file is 400+ lines: blocks (Block type, repro header, model label), strategyDoc (the
-// PRISMA-S appendix), synthesisDoc (issue-review / clinical-question), sheets (the .xlsx). The
-// renderers and consumers import from here, so the split changed no call site.
+// This file is now the BARREL. The builders live in focused modules, split by concern so no single
+// file is 400+ lines: blocks (Block type, repro header, model label), strategyDoc (the PRISMA-S
+// appendix), synthesisDoc (issue-review / clinical-question), sheets (Mode 2/3's .xlsx),
+// corpusSheet (Mode 4's .xlsx — a sibling of sheets, not a modification of it), bibliometricDoc
+// (Mode 4's review document — a sibling of synthesisDoc). The renderers and consumers import from
+// here, so the split changed no call site.
 export * from './literatureExport.blocks'
 export * from './literatureExport.strategyDoc'
 export * from './literatureExport.synthesisDoc'
 export * from './literatureExport.sheets'
+export * from './literatureExport.corpusSheet'
+export * from './literatureExport.bibliometricDoc'

--- a/controllers/literatureSearch.cluster.ts
+++ b/controllers/literatureSearch.cluster.ts
@@ -1,0 +1,245 @@
+// Mode 4 (bibliometric review) — Phase 5: keyword/topic clustering. Split out the same way
+// counting/records/llm/corpus already are; the design contract lives in
+// Projects/ReCiter-Publication-Manager/literature-search/PLAN-literature-mode4-bibliometric-review.md
+// (not in this repo — planning docs live in Projects, code lives here).
+//
+// TWO PASSES, DELIBERATELY SEPARATE, the same split as strategy-build vs. suggestFixes elsewhere in
+// this feature: clusterByMesh() is PURE — deterministic, no network, no LLM — and labelClusters() is
+// the one Bedrock call that turns a cluster's MeSH terms into a phrase a human would actually say.
+// A caller can show the clusters (by MeSH terms, by size) the instant fetchCorpus() and this
+// function return, and let the label arrive a beat later without blocking the page on it.
+import { PubRecord } from './literatureSearch.records'
+import { UsageLog, invoke } from './literatureSearch.llm'
+
+// ---------------------------------------------------------------------------
+// PHASE 5a — MeSH-term clustering. PURE: no network, no LLM. See PHASE 5b below for the one
+// Bedrock call this file makes.
+//
+// ponytail: a greedy top-MeSH-term partition, not graph-community-detection (Louvain/Leiden on a
+// MeSH co-occurrence graph). There is no such library installed, and this codebase already prefers
+// coarse-and-honest over granular-and-wrong — see flagProbableCaseSeries()'s own comment in
+// literatureSearch.corpus.ts for the precedent of that exact judgment call. A record carrying
+// several hot MeSH terms lands in whichever cluster's seed term is the more frequent one overall
+// (a deterministic tie-break on the frequency sort, not a similarity score), so two genuinely
+// distinct sub-topics that happen to share their single most-frequent MeSH term will read as one
+// cluster here. Upgrade path, if a pilot corpus reads too coarse: Jaccard-similarity merging (or
+// splitting) on top of these seed clusters, using the members' full MeSH sets rather than just the
+// seed term.
+
+// Generic/administrative MeSH checktags — every one a real PubMed indexing term, none of them a
+// "topic" a librarian would recognise as this paper's subject. Case-insensitive match against the
+// record's raw mesh[] strings.
+const MESH_STOPLIST = new Set([
+    'humans', 'animals', 'male', 'female', 'adult', 'aged', 'aged, 80 and over', 'middle aged',
+    'child', 'child, preschool', 'infant', 'infant, newborn', 'young adult', 'adolescent',
+    'rats', 'mice', 'pregnancy', 'retrospective studies', 'prospective studies',
+    'follow-up studies', 'treatment outcome', 'cross-sectional studies', 'double-blind method',
+    'randomized controlled trials as topic', 'reproducibility of results', 'time factors',
+])
+
+export type Cluster = { id: string; label: string; meshTerms: string[]; pmids: string[]; isUncategorized?: boolean }
+export type ClusterResult = { clusters: Cluster[] }
+
+// The record's own MeSH terms, stoplist-excluded and de-duped. A Set, not the raw array: a term
+// PubMed happened to list twice on one record must not inflate that term's corpus-wide frequency,
+// and this same de-duped set is reused below for both the corpus-wide count and each cluster's own
+// top-terms tally, so there is exactly one place a record's "real" MeSH terms are decided.
+function meshTermsOf(r: PubRecord): Set<string> {
+    const out = new Set<string>()
+    for (const raw of r.mesh) {
+        const term = raw.trim()
+        if (term && !MESH_STOPLIST.has(term.toLowerCase())) out.add(term)
+    }
+    return out
+}
+
+// id for a real cluster: lowercase, non-alphanumeric -> '-', collapse repeats, trim '-'.
+function slugify(term: string): string {
+    return term.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+}
+
+// Not guaranteed unique on its own — two seed MeSH terms could in principle collapse to the same
+// slug ("COVID-19" / "Covid, 19") — so collisions get a numeric suffix rather than silently
+// clobbering an earlier cluster's id.
+function uniqueSlug(term: string, used: Set<string>): string {
+    const base = slugify(term) || 'topic'
+    let id = base
+    for (let n = 2; used.has(id); n++) id = `${base}-${n}`
+    used.add(id)
+    return id
+}
+
+// The cluster's own top few MeSH terms, by WITHIN-CLUSTER frequency (not the corpus-wide count),
+// seed term first, capped at 6 — the same 6 that goes to the model in labelClusters() and to
+// whatever legend or tooltip renders a cluster; it is a "what's in here" sample, not a claim that
+// only 6 MeSH terms are present.
+function topMeshTerms(members: PubRecord[], seedTerm: string, termsByPmid: Map<string, Set<string>>): string[] {
+    const freq = new Map<string, number>()
+    for (const r of members) {
+        for (const term of termsByPmid.get(r.pmid)!) {
+            if (term === seedTerm) continue
+            freq.set(term, (freq.get(term) || 0) + 1)
+        }
+    }
+    const rest = [...freq.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).map(([t]) => t)
+    return [seedTerm, ...rest].slice(0, 6)
+}
+
+export function clusterByMesh(
+    records: PubRecord[],
+    opts?: { minClusterSize?: number; maxClusters?: number },
+): ClusterResult {
+    const minClusterSize = opts?.minClusterSize ?? 5
+    const maxClusters = opts?.maxClusters ?? 25
+
+    const termsByPmid = new Map(records.map(r => [r.pmid, meshTermsOf(r)]))
+
+    // a. Frequency across the whole corpus. Stoplist already excluded, inside meshTermsOf().
+    const freq = new Map<string, number>()
+    for (const terms of termsByPmid.values()) {
+        for (const term of terms) freq.set(term, (freq.get(term) || 0) + 1)
+    }
+
+    // b. Seeds: frequent enough to be a real topic rather than a one-off, sorted frequency desc
+    // then alphabetically for a deterministic walk order, capped at maxClusters candidates.
+    const threshold = Math.max(3, Math.ceil(records.length * 0.01))
+    const seeds = [...freq.entries()]
+        .filter(([, n]) => n >= threshold)
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([term]) => term)
+        .slice(0, maxClusters)
+
+    // c-d. Walk the seeds in that fixed order; each seed claims every still-UNASSIGNED record
+    // carrying its term. A candidate cluster that comes up short of minClusterSize is never
+    // published as its own cluster — its would-be members are simply never marked assigned, so a
+    // later (necessarily less-frequent, by the sort above) seed can still claim them, and anything
+    // no seed ever claims falls through to step e below.
+    const assigned = new Set<string>()
+    const usedIds = new Set<string>()
+    const clusters: Cluster[] = []
+
+    for (const seedTerm of seeds) {
+        const members = records.filter(r => !assigned.has(r.pmid) && termsByPmid.get(r.pmid)!.has(seedTerm))
+        if (members.length < minClusterSize) continue
+
+        for (const r of members) assigned.add(r.pmid)
+        clusters.push({
+            id: uniqueSlug(seedTerm, usedIds),
+            label: seedTerm,   // overwritten by labelClusters() below; the raw MeSH term is still an honest placeholder until then
+            meshTerms: topMeshTerms(members, seedTerm, termsByPmid),
+            pmids: members.map(r => r.pmid),
+        })
+    }
+
+    // e. Everyone never claimed by a seed — including step d's fallthrough — gets one home. Never
+    // silently dropped.
+    const leftover = records.filter(r => !assigned.has(r.pmid))
+    if (leftover.length) {
+        clusters.push({
+            id: 'uncategorized',
+            label: 'Uncategorized / no dominant MeSH topic',
+            meshTerms: [],
+            pmids: leftover.map(r => r.pmid),
+            isUncategorized: true,
+        })
+    }
+
+    return { clusters }
+}
+
+// ---------------------------------------------------------------------------
+// PHASE 5b — the one Bedrock call this file makes: turn each cluster's MeSH terms into a phrase a
+// human would actually say. "Laryngoscopy, Video; Intubation, Intratracheal" is a MeSH heading
+// list; "Videolaryngoscopy vs. direct laryngoscopy" is a topic label. Only a model does that
+// rewrite.
+//
+// ONE CALL FOR ALL CLUSTERS, NOT ONE PER CLUSTER. An earlier draft of the design doc had this as a
+// per-cluster call; that is the same "batch, don't loop" instinct screenRecords() already applies
+// to 50 records in a single call rather than 50 separate ones — cheaper, and there is nothing about
+// naming one cluster that benefits from the model being blind to the other 24 while it does it.
+const CLUSTER_LABEL_TOOL = {
+    name: 'submit_cluster_labels',
+    description: 'Return a short, human-readable topic label for EVERY cluster supplied.',
+    input_schema: {
+        type: 'object' as const,
+        properties: {
+            labels: {
+                type: 'array',
+                description: 'Exactly one entry per cluster supplied. Never omit a cluster, never invent one.',
+                items: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'string', description: 'The cluster id, exactly as supplied.' },
+                        label: {
+                            type: 'string',
+                            description: 'A short phrase naming the shared topic, e.g. "Videolaryngoscopy vs. direct laryngoscopy". Not a MeSH term list, not the cluster id.',
+                        },
+                    },
+                    required: ['id', 'label'],
+                },
+            },
+        },
+        required: ['labels'],
+    },
+}
+
+const CLUSTER_LABEL_PROMPT = `You are naming the topic clusters found in a corpus of biomedical literature, from each cluster's own dominant MeSH descriptors and record count. You have not been shown the papers themselves — only their shared MeSH headings.
+
+Rules:
+- Return a label for EVERY cluster supplied. Never skip one, never merge two, never invent a cluster id.
+- The label is a SHORT, HUMAN-READABLE PHRASE naming what the cluster is actually about — the way a clinician would describe it out loud. NOT a MeSH term list, NOT the cluster id restated.
+  Good: "Videolaryngoscopy vs. direct laryngoscopy"
+  Bad: "Laryngoscopy, Video; Intubation, Intratracheal" (that is just the MeSH terms restated)
+  Bad: "cluster-laryngoscopy-video" (that is the id)
+- Base the label only on the MeSH terms and record count given for that cluster. You have no other information about it.`
+
+function buildClusterPrompt(clusters: Cluster[]): string {
+    return clusters
+        .map(c => `Cluster ${c.id} (${c.pmids.length} records) — top MeSH terms: ${c.meshTerms.join(', ')}`)
+        .join('\n')
+}
+
+export async function labelClusters(clusters: Cluster[]): Promise<{ clusters: Cluster[]; usage: UsageLog }> {
+    // 'uncategorized' is a fixed label, never sent to the model and never overwritten.
+    const labelable = clusters.filter(c => !c.isUncategorized)
+    if (!labelable.length) return { clusters, usage: { inputTokens: 0, outputTokens: 0 } }
+
+    // invoke()'s default 2000-token ceiling, not LONG_MAX_TOKENS: this is up to maxClusters worth
+    // of ONE-LINE labels, not 50 records' worth of one-clause screening reasons (SCREEN_TOOL, which
+    // was measured at 4.0k+ output tokens and is why LONG_MAX_TOKENS exists at all). A phrase per
+    // cluster is an order of magnitude smaller than a reason per record.
+    const { input, usage } = await invoke(CLUSTER_LABEL_PROMPT, CLUSTER_LABEL_TOOL, buildClusterPrompt(labelable))
+
+    const labels = new Map<string, string>()
+    for (const l of (input?.labels || [])) {
+        const id = String(l?.id ?? '').trim()
+        const label = String(l?.label ?? '').trim()
+        if (id && label) labels.set(id, label)
+    }
+
+    // The same lost-in-the-middle risk screenRecords() documents at length can drop a cluster's
+    // label here too — but nothing here re-asks for it the way that function re-asks for a dropped
+    // verdict, because the consequence is not remotely the same shape. A dropped screening verdict
+    // hides a paper from the reader; a dropped cluster label costs nothing about the cluster itself
+    // — its MeSH terms and every one of its PMIDs are already correct and already on the page. So a
+    // cheap, honest, always-available fallback (the cluster's own top MeSH terms) is enough: it
+    // never blocks the response and it never invents a name the model didn't give it.
+    const missing: string[] = []
+    const relabeled = clusters.map(c => {
+        if (c.isUncategorized) return c
+        const label = labels.get(c.id)
+        if (label) return { ...c, label }
+        missing.push(c.id)
+        return { ...c, label: c.meshTerms.slice(0, 2).join(' / ') }
+    })
+
+    if (missing.length) {
+        console.error(JSON.stringify({
+            tag: 'literature-cluster-label-missing',
+            ids: missing,
+            why: 'the model returned no label for these clusters; falling back to their top MeSH terms',
+        }))
+    }
+
+    return { clusters: relabeled, usage }
+}

--- a/controllers/literatureSearch.controller.ts
+++ b/controllers/literatureSearch.controller.ts
@@ -48,8 +48,10 @@
 // single file is 2,000+ lines: strategy (query assembly + types), counting (arithmetic over PubMed
 // counts), records (fetch/shape/evidence tiers), llm (every Bedrock call), experts (the MeSH→panel
 // bridge), build (the Mode 1 multi-database orchestration), corpus (Mode 4 Phases 2-4: sharded
-// retrieval, evidence filtering, bibliometric stats). Consumers — the API route and the check
-// harnesses — import from here, so the split changed no call site.
+// retrieval, evidence filtering, bibliometric stats), cluster (Mode 4 Phase 5: keyword/topic
+// clustering), score (Mode 4 Phase 6: impact/relevance scoring + justifications), narrative (Mode 4
+// Phase 7: per-cluster synthesis + deterministic whole-review assembly). Consumers — the API route
+// and the check harnesses — import from here, so the split changed no call site.
 export * from './literatureSearch.strategy'
 export * from './literatureSearch.counting'
 export * from './literatureSearch.records'
@@ -57,3 +59,6 @@ export * from './literatureSearch.llm'
 export * from './literatureSearch.experts'
 export * from './literatureSearch.build'
 export * from './literatureSearch.corpus'
+export * from './literatureSearch.cluster'
+export * from './literatureSearch.score'
+export * from './literatureSearch.narrative'

--- a/controllers/literatureSearch.llm.ts
+++ b/controllers/literatureSearch.llm.ts
@@ -51,7 +51,11 @@ const billed = (message: string, usage: UsageLog) => Object.assign(new Error(mes
 // a 30-record synthesis was measured at 4.0k output tokens, hit max_tokens=4000 exactly, and
 // stopped mid-sentence. A truncated synthesis does not look broken — it looks like prose. Give
 // the long calls 8000 (see LONG_MAX_TOKENS).
-async function invoke(system: string, tool: any, user: string, maxTokens = 2000) {
+//
+// Exported so Mode 4 Phase 5's labelClusters() (literatureSearch.cluster.ts) can make its own
+// forced-tool Bedrock call without a second copy of this primitive — same STRATEGY_TOOL/SCREEN_TOOL
+// convention (system prompt + one forced tool + a user message), just a different tool.
+export async function invoke(system: string, tool: any, user: string, maxTokens = 2000) {
     const modelId = process.env.BEDROCK_MODEL_ID
     if (!modelId) throw new Error('BEDROCK_MODEL_ID is not configured')
 
@@ -713,7 +717,11 @@ export async function suggestFixes(
 // Double it. Screening gets the same ceiling: 50 one-clause reasons is nowhere near 8,000 tokens,
 // but a run that silently drops the last eight verdicts is the same failure wearing a different
 // hat, and the ceiling costs nothing when it is not reached.
-const LONG_MAX_TOKENS = 8000
+//
+// Exported so Mode 4 Phase 6's scoreRelevance() (literatureSearch.score.ts) can give its own
+// batch-of-50-justifications call the same ceiling, rather than hand-copying the number and the
+// reasoning behind it.
+export const LONG_MAX_TOKENS = 8000
 
 // One first pass plus two re-asks. Three, not "until complete": a model that has skipped the same record
 // twice is telling you something, and an unbounded loop over a paid call is how a screen quietly costs
@@ -1000,7 +1008,12 @@ const SYNTH_TOOL = {
 // Rules 1-4 and 6 are IDENTICAL for both synthesis modes and are therefore written ONCE. A
 // paraphrase in a second prompt would drift, and rule 2 is the sentence standing between this
 // feature and an invented effect size on a grand rounds slide. Only rule 5 differs — see below.
-const SYNTH_RULES_HEAD = `1. EVERY claim cites the paper it came from, inline, as [PMID 12345678]. A sentence that makes a claim and carries no PMID is a sentence you may not write. Cite multiple PMIDs when several papers support the same point.
+//
+// Exported so Mode 4 Phase 7's synthesizeCluster() (literatureSearch.narrative.ts) can reuse it
+// VERBATIM for its own per-cluster synthesis call, rather than hand-copying rules 1-4 into a
+// second prompt that could quietly drift from this one — see this comment's own point, one
+// paragraph up, about why a paraphrase is not acceptable here.
+export const SYNTH_RULES_HEAD = `1. EVERY claim cites the paper it came from, inline, as [PMID 12345678]. A sentence that makes a claim and carries no PMID is a sentence you may not write. Cite multiple PMIDs when several papers support the same point.
 2. NEVER state a number that is not written in the abstract you were given. No effect sizes, no risk ratios, no confidence intervals, no p values, no sample sizes, no percentages — unless that exact figure appears in the abstract, in which case state it and cite it. If the abstracts do not report an effect size, SAY that they do not. Do not estimate it, pool it, average it, or infer it from the direction of the findings.
 3. NEVER mention a paper you were not given, and never a PMID that is not in the list supplied. You have no other sources.
 4. Where the papers disagree, say so plainly and cite both sides. Do not resolve a disagreement the evidence does not resolve, and do not smooth it into a consensus.`
@@ -1177,7 +1190,11 @@ export async function synthesize(
 //
 // "(no abstract in PubMed)" is stated rather than left blank, because an empty field invites the
 // model to fill it in from memory, and a blank line invites it to assume the record was truncated.
-function renderRecords(records: PubRecord[]): string {
+//
+// Exported so Mode 4 Phase 6's scoreRelevance() (literatureSearch.score.ts) renders its own batches
+// through the exact same block — one place that knows how a PubRecord becomes model-readable text,
+// not a second copy of this that could drift from what screenRecords()/synthesize() actually see.
+export function renderRecords(records: PubRecord[]): string {
     return records.map(r => [
         `PMID ${r.pmid} | ${r.design} | ${r.authors || 'unknown author'} | ${r.journal || 'unknown journal'} ${r.year}`,
         `TITLE: ${r.title}`,

--- a/controllers/literatureSearch.narrative.ts
+++ b/controllers/literatureSearch.narrative.ts
@@ -1,0 +1,245 @@
+// Mode 4 (bibliometric review) — Phase 7: narrative synthesis, restructured for a whole corpus. Split
+// out the same way clustering (Phase 5) and scoring (Phase 6) are; the design contract lives in
+// Projects/ReCiter-Publication-Manager/literature-search/PLAN-literature-mode4-bibliometric-review.md
+// (not in this repo — planning docs live in Projects, code lives here).
+//
+// TWO FUNCTIONS, TWO DIFFERENT SHAPES, and the split is the whole design, the same instinct
+// impactScoreOf() / scoreRelevance() and clusterByMesh() / labelClusters() already apply:
+//
+//   synthesizeCluster() is the one Bedrock call this file makes. It writes ONE cited paragraph
+//   over a small shortlist of records for a SINGLE cluster — the same job synthesize() does for
+//   Mode 2, reusing its own canonical rules (SYNTH_RULES_HEAD) rather than a paraphrased copy.
+//
+//   assembleNarrativeReview() is PURE — no network, no LLM, no further model call of any kind.
+//   See its own comment below for why that is deliberate, not merely convenient.
+import { PubRecord } from './literatureSearch.records'
+import { Cluster } from './literatureSearch.cluster'
+import { UsageLog, invoke, renderRecords, LONG_MAX_TOKENS, SYNTH_RULES_HEAD } from './literatureSearch.llm'
+import { YearCount, EvidenceMixByYear } from './literatureSearch.corpus'
+
+// ---------------------------------------------------------------------------
+// PHASE 7a — synthesizeCluster(). The one Bedrock call this file makes.
+
+export type ClusterNarrative = {
+    clusterId: string
+    label: string
+    paragraph: string
+    citedPmids: string[]
+    // The model's own contamination, carried ON THE WIRE — same rule Synthesis.invented follows
+    // in literatureSearch.llm.ts, and for the same reason: a detection nobody sees is not a
+    // detection.
+    invented?: string[]
+}
+
+const CLUSTER_SYNTH_TOOL = {
+    name: 'submit_cluster_synthesis',
+    description: 'Return a narrative paragraph synthesizing the supplied papers for ONE cluster of a larger bibliometric review.',
+    input_schema: {
+        type: 'object' as const,
+        properties: {
+            paragraph: {
+                type: 'string',
+                description: 'The narrative synthesis for this cluster only. Every claim cites its source inline as [PMID 12345678]. Plain prose, one paragraph, no headings, no markdown.',
+            },
+        },
+        required: ['paragraph'],
+    },
+}
+
+// Rule 5 is the only rule that differs from Mode 2's synthesize() — see RULE_5_NARRATIVE and
+// RULE_5_PICO in literatureSearch.llm.ts for the sibling amendments this one belongs beside. This
+// job's version exists because a cluster paragraph is read as ONE SECTION of a document the model
+// never sees in full: it has no idea what the other clusters say, and nothing stops it reaching for
+// a comparison ("unlike the surgical-management cluster...") that sounds plausible and is entirely
+// invented, since it was never shown that cluster's papers.
+const RULE_5_CLUSTER = `5. This paragraph is ONE SECTION of a larger bibliometric review. It covers ONLY the cluster named below. Do not generalize beyond it, and do not compare it to other clusters — you have not been shown their papers and cannot know what they say.`
+
+const CLUSTER_SYNTH_PROMPT = `You are writing one section of a bibliometric literature review: a narrative paragraph synthesizing the papers in ONE topic cluster. You are given the same abstracts a clinician would read, and nothing else.
+
+THESE RULES ARE ABSOLUTE. They are the reason this tool exists:
+${SYNTH_RULES_HEAD}
+${RULE_5_CLUSTER}
+
+Style: ONE paragraph of plain clinical prose. No headings, no bullet points, no markdown, no bold. Write for a clinician who will check your citations.`
+
+// ONE CALL PER CLUSTER, unlike labelClusters()'s one-call-for-all-clusters. The two are not the same
+// shape: labelClusters() reads a few MeSH terms per cluster (cheap, and every cluster benefits from
+// being named consistently against the others), while this reads up to a dozen full abstracts per
+// cluster — batching clusters together here would mean either every cluster's shortlist competing
+// for the SAME context window (the lost-in-the-middle risk SCREEN_ATTEMPTS exists to fight, now
+// spread across paragraphs instead of records) or one call per cluster anyway, just with worse
+// isolation between them. The caller (not this function) is expected to fire these in whatever
+// concurrency it can afford; nothing here assumes it is called once.
+//
+// `records` is ALREADY the shortlist for this one cluster — typically ~8-12 records the caller
+// picked by ranking impactScore + relevanceScore (Phase 6). This function does no ranking of its
+// own; it synthesizes over exactly what it is given, the same contract synthesize() has with the
+// records a human already ticked.
+export async function synthesizeCluster(
+    topic: string,
+    cluster: Cluster,
+    records: PubRecord[],
+): Promise<{ narrative: ClusterNarrative; usage: UsageLog }> {
+    const byPmid = new Map(records.map(r => [r.pmid, r]))
+
+    // LONG_MAX_TOKENS, the same ceiling synthesize() uses for a full 3-5 paragraph, up-to-50-record
+    // document — generous for a single paragraph over ~12 records, but a paragraph cut off mid-
+    // sentence is exactly the failure invoke() already refuses on (its own max_tokens check), and the
+    // ceiling costs nothing on the calls that never reach it.
+    const { input, usage } = await invoke(
+        CLUSTER_SYNTH_PROMPT,
+        CLUSTER_SYNTH_TOOL,
+        `Review topic: ${topic}\n\nCluster: ${cluster.label}\n\nThe ${records.length} papers selected for this cluster:\n\n${renderRecords(records)}`,
+        LONG_MAX_TOKENS,
+    )
+
+    const paragraph = String(input?.paragraph ?? '').trim()
+    if (!paragraph) throw new Error('model did not return a synthesis')
+
+    // Same detection synthesize() runs on its prose: regex out every [PMID \d+], compare against
+    // the records ACTUALLY SUPPLIED to this call (this cluster's shortlist, not the whole corpus),
+    // and anything outside that set is contamination. The prose is never rewritten to remove it —
+    // silently editing the model's own output would be a second fabrication laid over the first —
+    // it is only ever reported, loudly, so a reader (and the export builder) can see it.
+    const cited = new Set((paragraph.match(/\[PMID\s+(\d+)\]/gi) || [])
+        .map(m => (m.match(/\d+/) || [''])[0]).filter(Boolean))
+    const invented = Array.from(cited).filter(p => !byPmid.has(p))
+    if (invented.length) {
+        console.error(JSON.stringify({
+            tag: 'literature-narrative-bad-citation', clusterId: cluster.id, pmids: invented,
+            why: 'the cluster synthesis cites PMIDs that were not among the records supplied for this cluster',
+        }))
+    }
+
+    return {
+        narrative: {
+            clusterId: cluster.id,
+            label: cluster.label,
+            paragraph,
+            citedPmids: Array.from(cited).filter(p => byPmid.has(p)),
+            ...(invented.length ? { invented } : {}),
+        },
+        usage,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PHASE 7b — assembleNarrativeReview(). PURE, deterministic. NO further Bedrock call to "stitch"
+// the per-cluster paragraphs and the corpus-wide trend stats into one whole-review narrative.
+//
+// THIS IS A DELIBERATE DEVIATION from an earlier draft of the design doc, which proposed exactly
+// that: one more LLM call, handed every cluster's finished paragraph plus publicationsPerYear and
+// evidenceMixByYear, asked to write the connective introduction and stitch it all into a review.
+//
+// SYNTH_RULES_HEAD rule 2 — "never state a number that is not written in the abstract you were
+// given" — exists specifically because a model asked to summarize evidence will supply the
+// CONNECTIVE TISSUE a reader expects: a pooled trend, a rough sense of "growing interest", a claim
+// that one cluster's evidence is stronger than another's. None of that appears in any single
+// abstract, all of it reads exactly like the sentences around it, and a "stitch these cluster
+// paragraphs and these corpus-wide stats into one narrative" prompt is EXACTLY the shape of request
+// that invites an overarching trend claim no single cited paper grounds — the model would be
+// synthesizing across sources (the per-cluster paragraphs, the stats) that are not abstracts and
+// carry no PMID to cite, so rule 1 (every claim cites a PMID) and rule 2 both stop applying to the
+// one part of the document that would need them most: the INTRO, which is read first and trusted
+// most.
+//
+// Deterministic assembly cannot invent anything — every number in the intro below is arithmetic
+// over corpusStats, full stop — so it is the safer choice for a whole-review intro in particular,
+// even though it costs a Bedrock call less than the design doc's earlier draft. Cheaper AND safer
+// is not usually the trade-off; here it is.
+const HIGHER_TIER_LABELS = new Set(['RCT', 'Meta-analysis', 'Systematic review'])
+
+// One-sentence disclosure, present only when the caller says the corpus actually carries a
+// probable-case-series flag — see flagProbableCaseSeries() in literatureSearch.corpus.ts, whose own
+// comment states the same honest gap this note discloses to the reader.
+const CASE_SERIES_NOTE = "Case series can't be cleanly tagged in PubMed; papers matching a probable-case-series heuristic are marked as such, not confirmed."
+
+export function assembleNarrativeReview(
+    topic: string,
+    corpusStats: {
+        publicationsPerYear: YearCount[]
+        evidenceMixByYear: EvidenceMixByYear
+        totalRecords: number
+        fromYear: number
+        toYear: number
+    },
+    clusters: Cluster[],
+    clusterNarratives: ClusterNarrative[],
+    hasCaseSeriesFlags: boolean,
+): { intro: string; sections: ClusterNarrative[]; caseSeriesNote?: string } {
+    const realClusters = clusters.filter(c => !c.isUncategorized)
+
+    // The evidence-mix headline: sum evidenceMixByYear across every year, into exactly the three
+    // buckets the intro reports. `mixTotal` is its OWN denominator — deliberately not assumed equal
+    // to corpusStats.totalRecords, which may count a different pool (e.g. before/after an exclusion
+    // this file has no visibility into). Never divide by a number this function did not itself sum.
+    let higherTier = 0, observational = 0, otherDesign = 0, mixTotal = 0
+    for (const yearCounts of Object.values(corpusStats.evidenceMixByYear)) {
+        for (const [label, n] of Object.entries(yearCounts)) {
+            mixTotal += n
+            if (HIGHER_TIER_LABELS.has(label)) higherTier += n
+            else if (label === 'Observational') observational += n
+            else otherDesign += n
+        }
+    }
+    // No evidenceMixByYear data is not "0% everything" — that would read as three arithmetic-
+    // looking percentages that do not actually describe anything. Say nothing about the mix rather
+    // than publish a headline with no records behind it.
+    const mixSentence = mixTotal
+        ? ` Of the evidence indexed by year, ${pct(higherTier, mixTotal)}% is RCT, meta-analysis or `
+        + `systematic-review evidence; ${pct(observational, mixTotal)}% is observational; the `
+        + `remaining ${pct(otherDesign, mixTotal)}% is guidelines, narrative reviews, case reports `
+        + `and other designs.`
+        : ''
+
+    // Optional trend note: mean of the first half of publicationsPerYear vs. the second half.
+    // Simple, no forecasting — see the function's own header comment for why nothing fancier
+    // belongs here. Skipped outright below two years of data (nothing to compare) or when both
+    // halves are empty (nothing happened either way).
+    const trendSentence = trendNote(corpusStats.publicationsPerYear)
+
+    const intro = `This review covers ${corpusStats.totalRecords.toLocaleString()} records published `
+        + `between ${corpusStats.fromYear} and ${corpusStats.toYear}, organized into `
+        + `${realClusters.length} topic cluster${realClusters.length === 1 ? '' : 's'}.`
+        + mixSentence
+        + trendSentence
+
+    // clusterNarratives filtered to real clusters (a narrative for the uncategorized bucket, or for
+    // any id that is no longer a real cluster, is simply absent from `sizeById` and drops out here),
+    // ordered by that cluster's own size descending — the plan's own mockup ("Keyword clusters ...
+    // sort: size"). Cluster id is the tie-break, for a deterministic order when two clusters land on
+    // the same size, the same instinct clusterByMesh()'s own seed walk applies.
+    const sizeById = new Map(realClusters.map(c => [c.id, c.pmids.length]))
+    const sections = clusterNarratives
+        .filter(n => sizeById.has(n.clusterId))
+        .sort((a, b) => (sizeById.get(b.clusterId)! - sizeById.get(a.clusterId)!) || a.clusterId.localeCompare(b.clusterId))
+
+    return {
+        intro,
+        sections,
+        ...(hasCaseSeriesFlags ? { caseSeriesNote: CASE_SERIES_NOTE } : {}),
+    }
+}
+
+const pct = (n: number, total: number): number => Math.round((n / total) * 100)
+
+function trendNote(years: YearCount[]): string {
+    if (years.length < 2) return ''
+
+    const mid = Math.floor(years.length / 2)
+    const mean = (xs: YearCount[]) => xs.reduce((a, y) => a + y.count, 0) / xs.length
+    const firstMean = mean(years.slice(0, mid))
+    const secondMean = mean(years.slice(mid))
+    if (firstMean === 0 && secondMean === 0) return ''
+
+    const round1 = (n: number) => Math.round(n * 10) / 10
+    // A 10% band counts as "held roughly steady" rather than forcing every small wobble into "rose"
+    // or "declined" — the same coarse-and-honest posture flagProbableCaseSeries() takes on a fuzzier
+    // signal. firstMean === 0 with a nonzero secondMean is an unambiguous rise (any growth from
+    // nothing), handled by the Infinity ratio falling into the "increased" branch below.
+    const ratio = firstMean === 0 ? Infinity : secondMean / firstMean
+    const direction = ratio > 1.1 ? 'increased' : ratio < 0.9 ? 'declined' : 'held roughly steady'
+
+    return ` Yearly publication volume ${direction} across the window — a mean of ${round1(firstMean)} `
+        + `per year in the earlier half of the range versus ${round1(secondMean)} in the later half.`
+}

--- a/controllers/literatureSearch.pure.check.js
+++ b/controllers/literatureSearch.pure.check.js
@@ -304,9 +304,392 @@ const checkXlsxTruncationGuard = (xp, q) => {
     console.log(`exports:      the .xlsx REFUSES its AI verdict column when the sample is truncated, and keeps it when it is not`)
 }
 
+// =======================================================================================
+// MODE 4, PHASE 5 — clusterByMesh(). PURE, deterministic, NO LLM (labelClusters(), the one
+// Bedrock call in literatureSearch.cluster.ts, is out of scope for this file by the same rule
+// everything else here follows: it needs the world).
+//
+// A minimal PubRecord-shaped fixture — clusterByMesh() only ever reads .pmid and .mesh, so that
+// is all a record needs here, the same minimalism checkXlsxTruncationGuard already uses for its
+// own record fixtures.
+const meshRec = (pmid, mesh) => ({ pmid, title: `Study ${pmid}`, mesh })
+
+// THE STOPLIST TRAP THIS FIXTURE IS SHAPED AROUND. In real PubMed data "Humans" and "Adult" are
+// the MOST common MeSH terms on the page, by a wide margin — every clinical paper about people
+// carries them. So the fixture below puts "Humans" on ALL 20 records and "Adult" on 14 of them,
+// deliberately making both terms MORE frequent than either real topic. If MESH_STOPLIST ever
+// stopped being applied before the frequency count, "Humans" (freq 20) would out-rank both real
+// seeds and swallow the entire corpus into one meaningless cluster — a bug that would look
+// completely plausible on screen (a cluster IS formed, it just isn't about anything) and would
+// never be caught by eyeballing a demo corpus too small for "Humans" to visibly dominate.
+const checkClusterByMesh = (lit) => {
+    const diabetes = Array.from({ length: 8 }, (_, i) =>
+        meshRec(`d${i + 1}`, ['Diabetes Mellitus, Type 2', 'Humans', 'Adult']))
+    const hypertension = Array.from({ length: 6 }, (_, i) =>
+        meshRec(`h${i + 1}`, ['Hypertension', 'Humans', 'Adult']))
+    // Stoplist-only: no real topic term at all, so these MUST fall through to 'uncategorized' —
+    // there is no seed they could ever match.
+    const adminOnly = [meshRec('u1', ['Humans', 'Female']), meshRec('u2', ['Humans', 'Female'])]
+    // One-off real terms: each appears on exactly one record, so freq (1) never clears the
+    // threshold (3 at this corpus size) and none of them may become its own cluster either —
+    // a corpus is not obligated to have a topic for every paper in it.
+    const rareTerms = ['Rare Condition A', 'Rare Condition B', 'Rare Condition C', 'Rare Condition D']
+    const oneOffs = rareTerms.map((t, i) => meshRec(`r${i + 1}`, [t, 'Humans']))
+
+    const records = [...diabetes, ...hypertension, ...adminOnly, ...oneOffs]   // 20 total
+
+    const result = lit.clusterByMesh(records)
+    const real = result.clusters.filter(c => !c.isUncategorized)
+    const uncategorized = result.clusters.find(c => c.isUncategorized)
+
+    assert.strictEqual(real.length, 2, 'exactly two real topics were built into this fixture (Diabetes, Hypertension) — a different count means the seed/threshold logic drifted')
+    const diabetesCluster = real.find(c => c.meshTerms[0] === 'Diabetes Mellitus, Type 2')
+    const hypertensionCluster = real.find(c => c.meshTerms[0] === 'Hypertension')
+    assert.ok(diabetesCluster && hypertensionCluster, 'both real seed terms must each head their own cluster')
+    assert.strictEqual(diabetesCluster.pmids.length, 8, 'the Diabetes cluster must claim exactly its 8 members, no more, no fewer')
+    assert.strictEqual(hypertensionCluster.pmids.length, 6, 'the Hypertension cluster must claim exactly its 6 members')
+
+    // THE STOPLIST ASSERTION ITSELF: neither real cluster's seed (meshTerms[0], set by
+    // topMeshTerms()) is an administrative checktag — if MESH_STOPLIST filtering broke, "Humans"
+    // (freq 20, the single most common raw term in this fixture) would out-rank both real seeds
+    // and this assertion is what would catch it.
+    for (const c of real) {
+        assert.ok(!['Humans', 'Adult', 'Female'].includes(c.meshTerms[0]),
+            `a cluster's seed term must never be an administrative checktag — got "${c.meshTerms[0]}" for cluster "${c.id}"`)
+    }
+
+    assert.ok(uncategorized, 'the stoplist-only and one-off records must land somewhere — an uncategorized bucket is required by this fixture')
+    assert.strictEqual(uncategorized.pmids.length, 6, 'uncategorized must hold exactly the 2 stoplist-only + 4 one-off records this fixture built for it')
+
+    // NOTHING THAT GOES IN MAY SILENTLY VANISH — the same invariant checkRecordsColumnRendering
+    // and checkXlsxTruncationGuard already police, one layer down: every pmid handed to
+    // clusterByMesh() must come back in EXACTLY ONE cluster's pmids — never dropped, never
+    // counted twice across two clusters.
+    const allOutputPmids = result.clusters.flatMap(c => c.pmids)
+    assert.strictEqual(allOutputPmids.length, records.length,
+        `every input record must appear exactly once across all clusters — got ${allOutputPmids.length} pmids total for ${records.length} input records (a mismatch means a record was dropped or double-counted)`)
+    assert.deepStrictEqual([...allOutputPmids].sort(), records.map(r => r.pmid).sort(),
+        'the SET of pmids across all clusters must equal the set of input pmids exactly — not just the same count')
+
+    // DETERMINISM. Same input, same output, byte for byte — a librarian re-running the same
+    // corpus (or the UI re-rendering after an unrelated state change) must never see the topic
+    // clusters reshuffle underneath them.
+    const again = lit.clusterByMesh(records)
+    assert.deepStrictEqual(again, result, 'clusterByMesh() must be a pure function of its input — the same corpus must produce byte-identical clusters on a second call')
+
+    console.log(`cluster:      ${real.length} real clusters (Diabetes=${diabetesCluster.pmids.length}, Hypertension=${hypertensionCluster.pmids.length}), uncategorized=${uncategorized.pmids.length}, no drops, no stoplist seed, deterministic`)
+}
+
+// =======================================================================================
+// MODE 4, PHASE 6a — preFilterForScoring(). PURE, deterministic, NO LLM. Decides which records
+// in each cluster are worth a Bedrock relevance-scoring call, under a caller-supplied budget.
+//
+// A minimal PubRecord-shaped fixture again: preFilterForScoring() (via rankForScoring()) only
+// ever reads .pmid, .tier.rank, .nihPercentile and .year.
+const scoreRec = (pmid, tierRank, opts = {}) => ({
+    pmid,
+    tier: { rank: tierRank, label: `tier${tierRank}`, phrase: `tier ${tierRank} phrase` },
+    year: opts.year ?? '2020',
+    ...(typeof opts.pct === 'number' ? { nihPercentile: opts.pct } : {}),
+})
+
+const checkPreFilterForScoring = (lit) => {
+    // A big cluster (100 members) and a small one (4 members), plus a 4-member cluster built
+    // specifically to test the missing-vs-zero-percentile ranking rule, plus an uncategorized
+    // bucket that must get nothing. budget=20 is chosen (not the 200 default) so every number
+    // below is small enough to hand-verify by arithmetic, the same posture this whole file takes.
+    const big = Array.from({ length: 100 }, (_, i) => scoreRec(`big-${i + 1}`, 5))
+    const small = Array.from({ length: 4 }, (_, i) => scoreRec(`small-${i + 1}`, 5))
+    const rankRecords = [
+        scoreRec('rt-1', 5, { pct: 80 }),
+        scoreRec('rt-2', 5, { pct: 50 }),
+        scoreRec('rt-3', 5, { pct: 0 }),      // a REAL zero — scored by iCite, genuinely at the bottom
+        scoreRec('rt-4', 5, {}),              // MISSING — never scored at all, could be excellent
+    ]
+    const uncat = Array.from({ length: 50 }, (_, i) => scoreRec(`uncat-${i + 1}`, 5))
+
+    const clusters = [
+        { id: 'big', label: 'Big', meshTerms: [], pmids: big.map(r => r.pmid) },
+        { id: 'small', label: 'Small', meshTerms: [], pmids: small.map(r => r.pmid) },
+        { id: 'ranktest', label: 'RankTest', meshTerms: [], pmids: rankRecords.map(r => r.pmid) },
+        { id: 'uncat', label: 'Uncategorized', meshTerms: [], pmids: uncat.map(r => r.pmid), isUncategorized: true },
+    ]
+    const byPmid = new Map([...big, ...small, ...rankRecords, ...uncat].map(r => [r.pmid, r]))
+
+    const budget = 20
+    const result = lit.preFilterForScoring(clusters, byPmid, budget)
+
+    // THE UNCATEGORIZED CLUSTER GETS NOTHING. It is the fallthrough for records no seed MeSH
+    // term claimed, not a topic worth spending a Bedrock call on — see preFilterForScoring()'s
+    // own comment.
+    assert.strictEqual(result.uncat, undefined, 'the isUncategorized cluster must receive zero scoring budget — it is a fallthrough bucket, not a topic')
+
+    // THE FLOOR IS RESPECTED FOR A SMALL CLUSTER. At this budget, a purely proportional split
+    // (4 members out of 108 total real-cluster members) would round DOWN TO ZERO for "small" —
+    // it is the floor, not the proportional share, that guarantees it SCORE_FLOOR records rather
+    // than none at all.
+    assert.strictEqual(result.small.length, lit.SCORE_FLOOR,
+        `a 4-record cluster must still get its floor of ${lit.SCORE_FLOOR} records scored even though its proportional share of a ${budget}-record budget rounds to zero — a small cluster must never be zeroed out by a big one's share`)
+
+    // THE TOTAL SELECTED NEVER EXCEEDS THE BUDGET — across every real cluster, not per-cluster.
+    const total = Object.values(result).reduce((a, arr) => a + arr.length, 0)
+    assert.ok(total <= budget, `preFilterForScoring must never hand back more records than the ${budget}-record budget it was given — got ${total}`)
+    // The exact arithmetic this fixture works out to (floors 3+3+3=9, then a proportional share
+    // of the remaining 11 split 100:4:4) — an exact check, not just an upper bound, so a change
+    // to the allocation formula that stays under budget but silently shortchanges every cluster
+    // still gets caught.
+    assert.strictEqual(total, 19, `expected exactly 19 records selected for this fixture's floors-then-proportional-share arithmetic, got ${total} — the allocation formula changed`)
+
+    // A RECORD WITH nihPercentile: 0 MUST NOT BE CONFUSED WITH A RECORD THAT HAS NO PERCENTILE
+    // AT ALL. Same tier, same year — the only difference is 0 (real, scored, genuinely at the
+    // bottom of its field) versus missing (never scored, could be anything). With a floor of 3
+    // out of 4 candidates, exactly one gets cut — and it must be the missing one, never the real
+    // zero, because coercing "missing" into looking like a real 0 would let an unscored record
+    // silently outrank (or wrongly tie with) one iCite actually looked at.
+    const rankedSelection = result.ranktest.map(r => r.pmid)
+    assert.ok(rankedSelection.includes('rt-3'), 'a record with a REAL nihPercentile: 0 must be kept over a same-tier record with no percentile at all — 0 is scored data, missing is not')
+    assert.ok(!rankedSelection.includes('rt-4'), 'the record with a missing nihPercentile must be the one cut when the cluster exceeds its floor, never a record with a real (even if low) percentile in its place')
+
+    console.log(`prefilter:    small cluster floor=${result.small.length}, total selected=${total}/${budget}, uncategorized=none, real-0 kept over missing-percentile`)
+}
+
+// =======================================================================================
+// MODE 4, PHASE 6a — impactScoreOf(). PURE, deterministic, NO LLM. See the file's own header
+// comment for the two-score design (this one is free arithmetic over tier + iCite; the other,
+// scoreRelevance(), is the one Bedrock call and is out of scope here).
+const checkImpactScoreOf = (lit) => {
+    // RETRACTION OVERRIDES EVERYTHING — a RETRACTED record scores exactly 0 no matter how high
+    // its citation percentile is. This mirrors tierOf()'s own override in literatureSearch.records.ts:
+    // PubMed adds "Retracted Publication" ALONGSIDE a paper's original types rather than replacing
+    // them, so a retracted RCT with a sky-high percentile must not buy back any impact score at all.
+    const retracted = scoreRec('ret-1', 9, { pct: 99 })
+    retracted.tier.label = 'RETRACTED'
+    retracted.tier.phrase = 'a RETRACTED publication, which must not be relied on'
+    const retractedResult = lit.impactScoreOf(retracted)
+    assert.strictEqual(retractedResult.score, 0, 'a RETRACTED record must score exactly 0 regardless of a high nihPercentile — retraction overrides everything, no blend, no partial credit')
+    assert.strictEqual(retractedResult.justification, retracted.tier.phrase, "the RETRACTED record's justification must be the tier's own phrase — the one thing that matters here")
+
+    // TIER ORDERING SURVIVES WHEN PERCENTILE IS ABSENT. A rank-2 (Meta-analysis) record with no
+    // percentile must still score higher than a rank-5 (Observational) record with no
+    // percentile — the tier component alone must preserve the hierarchy, not collapse to a tie
+    // just because neither record has been cited yet.
+    const metaNoPct = scoreRec('meta-1', 2)
+    const obsNoPct = scoreRec('obs-1', 5)
+    const metaScore = lit.impactScoreOf(metaNoPct).score
+    const obsScore = lit.impactScoreOf(obsNoPct).score
+    assert.ok(metaScore > obsScore, `a rank-2 (Meta-analysis) record with no percentile (scored ${metaScore}) must score HIGHER than a rank-5 (Observational) record with no percentile (scored ${obsScore}) — tier ordering must survive when percentile is absent`)
+
+    // MISSING NEVER SILENTLY BECOMES A 0. Two otherwise-identical rank-5 records: one has a
+    // GENUINE nihPercentile of 0 (iCite scored it and it sits at the bottom of its field), the
+    // other has no percentile at all (never scored — could be excellent, could be terrible, it
+    // is simply unknown). If a missing percentile were ever coerced to 0 in the blend, these two
+    // scores would come out IDENTICAL — so the assertion is exactly that they must differ.
+    const zeroPct = scoreRec('zero-1', 5, { pct: 0 })
+    const missingPct = scoreRec('missing-1', 5)
+    const zeroScore = lit.impactScoreOf(zeroPct).score
+    const missingScore = lit.impactScoreOf(missingPct).score
+    assert.notStrictEqual(zeroScore, missingScore,
+        `a record with a genuine nihPercentile: 0 (scored ${zeroScore}) must score differently from an otherwise-identical record with NO percentile at all (scored ${missingScore}) — if missing silently became 0 in the blend these would be equal, and that would brand every unscored recent paper with the same number as the worst-cited paper in the corpus`)
+    // And the missing-percentile score specifically must equal the tier component ALONE — never
+    // a blend with a phantom 0.
+    assert.strictEqual(missingScore, 0.45, 'a rank-5 record with no percentile must score exactly its tier component (0.45) — the tier alone, never blended with a percentile it does not have')
+
+    console.log(`impact:       RETRACTED=${retractedResult.score}, Meta-analysis(no pct)=${metaScore} > Observational(no pct)=${obsScore}, zero-pct=${zeroScore} != missing-pct=${missingScore}`)
+}
+
+// =======================================================================================
+// MODE 4, PHASE 7b — assembleNarrativeReview(). PURE, deterministic, NO further Bedrock call —
+// see this function's own header comment in literatureSearch.narrative.ts for why the whole-
+// review intro is assembled by arithmetic rather than one more model call that would invent the
+// connective tissue between clusters.
+const checkAssembleNarrativeReview = (lit) => {
+    const clusters = [
+        { id: 'c-small', label: 'Small topic', meshTerms: [], pmids: ['s1', 's2', 's3'] },                                             // size 3
+        { id: 'c-big', label: 'Big topic', meshTerms: [], pmids: Array.from({ length: 10 }, (_, i) => `b${i + 1}`) },                  // size 10
+        { id: 'c-mid', label: 'Mid topic', meshTerms: [], pmids: Array.from({ length: 6 }, (_, i) => `m${i + 1}`) },                   // size 6
+        { id: 'uncat', label: 'Uncategorized', meshTerms: [], pmids: ['u1', 'u2', 'u3', 'u4'], isUncategorized: true },
+    ]
+    const clusterNarratives = [
+        { clusterId: 'c-small', label: 'Small topic', paragraph: 'Small topic prose [PMID s1].', citedPmids: ['s1'] },
+        { clusterId: 'c-big', label: 'Big topic', paragraph: 'Big topic prose [PMID b1].', citedPmids: ['b1'] },
+        { clusterId: 'c-mid', label: 'Mid topic', paragraph: 'Mid topic prose [PMID m1].', citedPmids: ['m1'] },
+        // Included ON PURPOSE, exactly as the task requires: a narrative for the uncategorized
+        // bucket exists in the input, and the assertion below is that it must never reach
+        // `sections` — assembleNarrativeReview() filters sections against REAL clusters only.
+        { clusterId: 'uncat', label: 'Uncategorized', paragraph: 'This must never appear in the output.', citedPmids: [] },
+    ]
+    const corpusStats = {
+        publicationsPerYear: [{ year: '2020', count: 5 }, { year: '2021', count: 8 }],
+        evidenceMixByYear: { '2020': { RCT: 3, Observational: 2 }, '2021': { RCT: 5, Review: 3 } },
+        totalRecords: 23,
+        fromYear: 2020,
+        toYear: 2021,
+    }
+
+    const withFlags = lit.assembleNarrativeReview('Do probiotics help depression?', corpusStats, clusters, clusterNarratives, true)
+    const withoutFlags = lit.assembleNarrativeReview('Do probiotics help depression?', corpusStats, clusters, clusterNarratives, false)
+
+    // SECTIONS SORTED BY CLUSTER SIZE DESCENDING — the plan's own mockup instruction, restated
+    // as arithmetic: c-big (10) before c-mid (6) before c-small (3).
+    assert.deepStrictEqual(withFlags.sections.map(s => s.clusterId), ['c-big', 'c-mid', 'c-small'],
+        'narrative sections must be ordered by their cluster size descending — a reader expects the biggest topic first, not build order or alphabetical order')
+
+    // THE UNCATEGORIZED NARRATIVE NEVER APPEARS IN sections, even though this fixture deliberately
+    // supplied one for it — the fallthrough bucket gets a roster row (in bibliometricDoc's cluster
+    // table) but never a written section, because 'Uncategorized / no dominant MeSH topic' is not
+    // a topic a narrative paragraph can honestly be about.
+    assert.strictEqual(withFlags.sections.find(s => s.clusterId === 'uncat'), undefined,
+        'a narrative supplied for the isUncategorized cluster must never appear in `sections`, even when the caller included one in its input')
+
+    // caseSeriesNote PRESENT IFF hasCaseSeriesFlags WAS TRUE — both branches asserted, because a
+    // note that shows up regardless of the flag is exactly as wrong as one that never shows up.
+    assert.ok(typeof withFlags.caseSeriesNote === 'string' && withFlags.caseSeriesNote.length > 0,
+        'hasCaseSeriesFlags: true must produce a non-empty caseSeriesNote — the reader needs to be told case series are heuristically flagged, not confirmed')
+    assert.strictEqual(withoutFlags.caseSeriesNote, undefined,
+        'hasCaseSeriesFlags: false must produce NO caseSeriesNote — a disclosure that applies whether or not the corpus actually has any flagged records is not a disclosure, it is boilerplate')
+
+    console.log(`narrative:    sections ordered [${withFlags.sections.map(s => s.clusterId).join(', ')}], uncategorized excluded, caseSeriesNote present=${!!withFlags.caseSeriesNote}/absent=${withoutFlags.caseSeriesNote === undefined}`)
+}
+
+// =======================================================================================
+// MODE 4, PHASE 8 — corpusSheet(). PURE, deterministic — this is a renderer, not a network call
+// or a model call, the same status literatureExport.ts's other builders have.
+const checkCorpusSheet = (xp) => {
+    const scored = {
+        pmid: '1', title: 'Probiotics and depression', authors: 'Nikolova et al.', year: '2023',
+        journal: 'JAMA Psychiatry', design: 'RCT', caseSeriesProbable: true, clusterLabel: 'Probiotics / microbiome',
+        impactScore: 0.72, impactJustification: 'a randomized controlled trial; 80th percentile citation impact (iCite)',
+        relevanceScore: 0.9, relevanceJustification: 'primary RCT of the intervention in the stated population',
+    }
+    // Never sent to a scorer at all — preFilterForScoring()'s shortlist did not include it. No
+    // cluster label either, and no case-series flag: caseSeriesProbable is simply absent, the
+    // same "never screened" shape a real un-shortlisted record has.
+    const unscored = { pmid: '2', title: 'An unrelated paper', authors: 'Someone et al.', year: '2021', journal: 'J Misc', design: 'Observational' }
+    // caseSeriesProbable EXPLICITLY false — must render exactly like "absent", never a checked
+    // "No", because false here just means the heuristic did not fire, not that a human confirmed
+    // this is not a case series.
+    const explicitlyNotCaseSeries = { pmid: '3', title: 'A case report', authors: 'Third et al.', year: '2019', journal: 'J Case', design: 'Case report', caseSeriesProbable: false }
+
+    const facts = { db: 'pubmed', query: 'probiotic*[tiab] AND depress*[tiab]', hits: 500, runDate: '2026-07-13', model: 'us.anthropic.claude-opus-4-8', fromYear: 2019, toYear: 2023 }
+    const sheets = xp.corpusSheet([scored, unscored, explicitlyNotCaseSeries], facts)
+    const recordsSheet = sheets.find(s => s.name === 'Records')
+    assert.ok(recordsSheet, 'corpusSheet must produce a Records sheet')
+
+    // EVERY ROW HAS EXACTLY AS MANY CELLS AS THE HEAD — the exact same invariant, and the exact
+    // same reason, as checkXlsxTruncationGuard's assertion on recordSheets(): a short row silently
+    // shifts every later value into the wrong column, for that record alone.
+    recordsSheet.rows.forEach((row, i) => {
+        assert.strictEqual(row.length, recordsSheet.head.length,
+            `row ${i} (pmid ${row[0]}) must have exactly ${recordsSheet.head.length} cells to match the head — a short row silently shifts every later cell into the wrong column for that record alone`)
+    })
+
+    const col = name => recordsSheet.head.indexOf(name)
+    const rowFor = pmid => recordsSheet.rows.find(r => r[0] === pmid)
+
+    // AN UNSCORED RECORD'S IMPACT/RELEVANCE CELLS ARE EMPTY STRING, NEVER 0 AND NEVER "N/A" —
+    // Number(undefined) coerced to 0 would read as "scored, and scored at rock bottom," when the
+    // truth is "never sent to a scorer at all."
+    const unscoredRow = rowFor('2')
+    for (const field of ['Impact score', 'Impact justification', 'Relevance score', 'Relevance justification']) {
+        assert.strictEqual(unscoredRow[col(field)], '', `an unscored record's "${field}" cell must be the empty string, not 0 and not "N/A" — a blank cell is the only honest rendering of "not in the shortlist"`)
+    }
+
+    // A caseSeriesProbable: true RECORD'S CASE SERIES CELL IS NON-EMPTY; AN UNSET (OR EXPLICITLY
+    // FALSE) ONE'S CELL IS EMPTY STRING — NEVER A CHECKED "No". Three states, not two: the flag is
+    // a heuristic, never a confirmed verdict, so its absence must not be printed as a negative claim.
+    assert.strictEqual(rowFor('1')[col('Case series')], 'Probable', 'a caseSeriesProbable: true record must show a non-empty Case series cell')
+    assert.strictEqual(rowFor('2')[col('Case series')], '', 'a record with no caseSeriesProbable field at all must show an empty Case series cell')
+    assert.strictEqual(rowFor('3')[col('Case series')], '', 'a caseSeriesProbable: false record must ALSO show an empty Case series cell, never a checked "No" — false only means the heuristic did not fire, not that a human confirmed it is not a case series')
+
+    console.log(`corpusSheet:  ${recordsSheet.rows.length} rows all match the ${recordsSheet.head.length}-column head; unscored cells blank; case-series is Probable/blank never No`)
+}
+
+// =======================================================================================
+// MODE 4, PHASE 8 — bibliometricDoc(). PURE, deterministic.
+const checkBibliometricDoc = (xp) => {
+    // "Umbrella review" appears NOWHERE in TIERS (literatureSearch.records.ts) — it is a made-up
+    // label chosen specifically so that a HARDCODED tier-label list (e.g. one lazily copied from
+    // TIERS instead of derived from the fixture itself) would silently drop this column. If this
+    // assertion ever stops catching that, the fixture has stopped doing its job.
+    const evidenceMixByYear = {
+        '2020': { 'Umbrella review': 2, RCT: 3 },
+        '2021': { RCT: 4, Guideline: 1 },
+    }
+    const percentileTrend = [
+        { year: '2020', median: 42, n: 10, scored: 8 },
+        // A year with zero scored records: no median to report. Must render as an EMPTY cell,
+        // never "N/A" and never 0 — same rule impactScoreOf() applies to a missing percentile,
+        // one layer up.
+        { year: '2021', median: null, n: 5, scored: 0 },
+    ]
+    const clusters = [
+        { id: 'a', label: 'Cluster A', pmids: ['x1', 'x2', 'x3'] },
+        { id: 'b', label: 'Cluster B', pmids: ['y1', 'y2'] },
+    ]
+    const narrative = {
+        intro: 'This is the corpus-wide intro.',
+        sections: [
+            // Carries an invented PMID — the model cited something outside the shortlist it was
+            // actually given for this cluster (see synthesizeCluster()'s own comment).
+            { label: 'Cluster A', paragraph: 'Cluster A prose [PMID 111].', invented: ['999999'] },
+            // No invented PMID — must get NO warning block.
+            { label: 'Cluster B', paragraph: 'Cluster B prose [PMID 222].' },
+        ],
+    }
+    const facts = { db: 'pubmed', query: 'q', hits: 100, runDate: '2026-07-13', model: 'us.anthropic.claude-opus-4-8', fromYear: 2020, toYear: 2021 }
+    const stats = {
+        publicationsPerYear: [{ year: '2020', count: 5 }, { year: '2021', count: 9 }],
+        evidenceMixByYear,
+        journalDistribution: [{ journal: 'J1', count: 5 }],
+        percentileTrend,
+    }
+
+    const blocks = xp.bibliometricDoc('Do X help Y?', facts, stats, clusters, narrative)
+    const h2Index = text => blocks.findIndex(b => b.kind === 'h2' && b.text === text)
+
+    // THE EVIDENCE-MIX COLUMNS ARE THE UNION OF TIER LABELS ACTUALLY PRESENT, NOT A HARDCODED
+    // LIST — "Umbrella review" is not a real TIERS label, so if this table's columns came from an
+    // imported TIERS list rather than from `evidenceMixByYear` itself, this column would silently
+    // vanish and this assertion would fail.
+    const mixIdx = h2Index('Evidence-type mix by year')
+    assert.ok(mixIdx !== -1, 'bibliometricDoc must have an "Evidence-type mix by year" section')
+    const mixTable = blocks[mixIdx + 1]
+    assert.strictEqual(mixTable.kind, 'table', 'the evidence-mix section must be immediately followed by its table')
+    assert.deepStrictEqual(mixTable.head, ['Year', 'Guideline', 'RCT', 'Umbrella review'],
+        `the evidence-mix table's columns must be exactly the union of tier labels present in the data (sorted), including "Umbrella review" which is not a real TIERS label — got ${JSON.stringify(mixTable.head)}. If this ever passes with "Umbrella review" missing, the column list has been hardcoded against TIERS instead of derived from the fixture.`)
+
+    // A NULL PERCENTILE-TREND MEDIAN RENDERS AS AN EMPTY CELL, NOT "N/A" AND NOT 0.
+    const trendIdx = h2Index('Citation percentile trend (iCite)')
+    const trendTable = blocks[trendIdx + 1]
+    const row2021 = trendTable.rows.find(r => r[0] === '2021')
+    const row2020 = trendTable.rows.find(r => r[0] === '2020')
+    assert.strictEqual(row2021[1], '', 'a year with zero scored records (median: null) must render its median cell as the empty string, not "N/A" and not 0')
+    assert.strictEqual(row2020[1], '42', 'a year with a real median must still print it — this is the control for the assertion above')
+
+    // A CLUSTER NARRATIVE WITH AN invented PMID PRODUCES A WARNING BLOCK IN THE ACTUAL Block[] —
+    // asserted on its presence, not eyeballed.
+    const clusterAParaIdx = blocks.findIndex(b => b.kind === 'p' && b.text === 'Cluster A prose [PMID 111].')
+    assert.ok(clusterAParaIdx !== -1, "Cluster A's paragraph must appear in the document")
+    const warningIndices = blocks.reduce((acc, b, i) => (b.kind === 'h2' && /^WARNING/.test(b.text) ? [...acc, i] : acc), [])
+    assert.strictEqual(warningIndices.length, 1,
+        `exactly one WARNING block is expected — Cluster A cited an invented PMID and Cluster B did not — got ${warningIndices.length}`)
+    assert.strictEqual(warningIndices[0], clusterAParaIdx + 1,
+        "the WARNING must sit directly after the paragraph it corrects (paragraph-then-warning, per bibliometricDoc's own comment), not before it and not after Cluster B's section")
+    assert.ok(blocks[warningIndices[0] + 1].text.includes('999999'),
+        'the WARNING body must NAME the invented PMID — "some citations may be wrong" is not actionable')
+
+    console.log(`bibliometricDoc: evidence-mix columns=[${mixTable.head.slice(1).join(', ')}] (derived, not hardcoded); null median -> empty cell; 1 WARNING block, correctly placed and naming PMID 999999`)
+}
+
 const { s, q } = checkStrategyBounds(lit)
 const { hits, rc } = checkRecordsColumnRendering(lit, xp, s, q)
 checkMarkdownDocuments(xp, md, s, q, hits, rc)
 checkXlsxTruncationGuard(xp, q)
+checkClusterByMesh(lit)
+checkPreFilterForScoring(lit)
+checkImpactScoreOf(lit)
+checkAssembleNarrativeReview(lit)
+checkCorpusSheet(xp)
+checkBibliometricDoc(xp)
 
 console.log('\nAll pure checks passed. No network, no model, no environment.')

--- a/controllers/literatureSearch.score.ts
+++ b/controllers/literatureSearch.score.ts
@@ -1,0 +1,342 @@
+// Mode 4 (bibliometric review) — Phase 6: impact/relevance scoring + justifications. Split out the
+// same way clustering (Phase 5) is; the design contract lives in
+// Projects/ReCiter-Publication-Manager/literature-search/PLAN-literature-mode4-bibliometric-review.md
+// (not in this repo — planning docs live in Projects, code lives here).
+//
+// TWO SCORES, TWO DIFFERENT SOURCES, and the split is the whole design:
+//
+//   impactScoreOf() is PURE — no network, no LLM. "How strong is this evidence" is a question
+//   PubMed and iCite already answer for free, on every record: the evidence tier (tierOf(), in
+//   literatureSearch.records.ts) and the NIH percentile citation metric. Asking a model to judge
+//   the same thing would just be re-deriving a number that is already sitting on the record —
+//   see ReciterAI's impact.py:score_impact() for this design doc's own precedent of exactly that
+//   move: score what is structured and free deterministically, and spend inference only on what
+//   genuinely needs judgment.
+//
+//   scoreRelevance() is the one Bedrock call this file makes. "How on-topic is this paper, for
+//   THIS review's topic" is not on the record anywhere — it depends on a topic the librarian typed
+//   a moment ago, which only reading the title and abstract (a model, or a human) can judge.
+//
+// preFilterForScoring() sits between the two: it is what makes scoreRelevance() affordable on a
+// corpus that can run into the thousands, by deciding — deterministically, for free — which ~200
+// records are worth spending a Bedrock call on at all. See its own comment below.
+import { PubRecord } from './literatureSearch.records'
+import { Cluster } from './literatureSearch.cluster'
+import { UsageLog, invoke, renderRecords, LONG_MAX_TOKENS } from './literatureSearch.llm'
+import { RECORD_CAP } from './literatureSearch.strategy'
+
+// ---------------------------------------------------------------------------
+// PHASE 6a — impactScoreOf(). PURE, deterministic, NO LLM.
+
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n))
+const round2 = (n: number) => Math.round(n * 100) / 100
+
+// The tier component, keyed by tierOf()'s own `rank` — see the TIERS table in
+// literatureSearch.records.ts, which this is deliberately NOT a copy of: that table orders study
+// designs by risk of bias, strongest first, for Mode 3's evidence hierarchy. This table scores a
+// different axis — how much citation weight a design of this kind tends to carry — and the two
+// axes do not agree everywhere.
+//
+// THE ONE PLACE THEY DISAGREE ON PURPOSE: rank 6 (Case report) scores LOWER than rank 7 (Review),
+// even though Case report outranks Review in tierOf()'s own hierarchy. That is not a mistake here
+// — a case report is one patient, and a narrative review synthesizes a whole literature and tends
+// to be far more cited. Evidence-hierarchy rank answers "how much should this sway a clinical
+// decision"; this component answers "how much impact does a paper of this kind tend to carry". Do
+// not "fix" this into monotonic agreement with TIERS — it is copied from the design doc's own
+// table, not derived from it.
+//
+// Rank 9 (RETRACTED) is NOT in this table. It is special-cased in impactScoreOf() below, to exactly
+// 0, unconditionally — no blend, no partial credit for whatever the original design was.
+const TIER_COMPONENT: Record<number, number> = {
+    1: 1.00,   // Guideline
+    2: 0.90,   // Meta-analysis / Systematic review — both rank 2, see TIERS
+    3: 0.75,   // RCT
+    4: 0.60,   // Clinical trial
+    5: 0.45,   // Observational
+    6: 0.20,   // Case report
+    7: 0.50,   // Review (narrative) / Editorial / Comment / Letter
+    8: 0.30,   // Protocol / Other — both rank 8, see PROTOCOL/OTHER in literatureSearch.records.ts
+}
+
+// A component EVERY real tier maps to. This only fires if literatureSearch.records.ts ever adds a
+// rank this table has not been updated for — never in normal operation, since every rank tierOf()
+// can return today (1-9) is accounted for above or special-cased below.
+const FALLBACK_COMPONENT = TIER_COMPONENT[8]
+
+export function impactScoreOf(record: PubRecord): { score: number; justification: string } {
+    // RETRACTED OVERRIDES EVERYTHING, unconditionally. See RETRACTED in literatureSearch.records.ts
+    // for why: PubMed adds "Retracted Publication" ALONGSIDE a paper's original types rather than
+    // replacing them, so a retracted RCT is still, truthfully, an RCT — and a blended score would
+    // let that original design buy it a nonzero impact number. It must not. The justification is
+    // exactly the tier's own phrase, which already says the one thing that matters here.
+    if (record.tier.rank === 9) return { score: 0, justification: record.tier.phrase }
+
+    const tierComponent = TIER_COMPONENT[record.tier.rank] ?? FALLBACK_COMPONENT
+
+    // MISSING IS NOT ZERO — the same rule withCitationMetrics() enforces one layer down, for the
+    // same reason. A 2024-2026 paper routinely has no iCite percentile yet, simply because it has
+    // not accumulated enough citation history to be scored — not because it scored badly. Folding
+    // that absence into the blend as a 0 would brand exactly the newest, most clinically current
+    // papers on the page as the weakest ones, which is the opposite of true. So an absent percentile
+    // falls back to the tier component ALONE — never a zero blended in, never omitted silently.
+    if (typeof record.nihPercentile !== 'number') {
+        return {
+            score: round2(tierComponent),
+            justification: `${record.tier.phrase}; no iCite percentile yet — recent or unscored`,
+        }
+    }
+
+    // Both components are already within [0,1], so 0.6*tierComponent + 0.4*(pct/100) cannot
+    // mathematically leave [0,1] given a real 0-100 percentile — the clamp is defensive, not load-
+    // bearing, the same posture buildStrategy() takes with checkStrategy() after a value it already
+    // expects to be in range.
+    const percentileComponent = record.nihPercentile / 100
+    const score = round2(clamp01(0.6 * tierComponent + 0.4 * percentileComponent))
+    return {
+        score,
+        justification: `${record.tier.phrase}; ${record.nihPercentile}th percentile citation impact (iCite)`,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PHASE 6b — preFilterForScoring(). PURE, deterministic, NO LLM. Decides WHICH records are worth a
+// Bedrock scoring call, out of a corpus that can run into the thousands — scoreRelevance() below
+// spends money per record, so something has to pick the ~200 that earn it, and picking them by any
+// signal a model would need to look at the abstract for defeats the purpose. Rank and recency are
+// already on the record for free; that is enough to choose a defensible shortlist.
+export type ScoreBudget = Record<string /* clusterId */, PubRecord[]>
+
+// Exported so the pure check harness can assert the actual constant, never a copied-and-drifted
+// "3" of its own — the same reason MAX_CONCEPTS/MAX_LINES/MAX_TERMS are exported from
+// literatureSearch.strategy.ts for checkStrategyBounds() to assert against.
+export const SCORE_FLOOR = 3
+
+// MISSING PERCENTILE SORTS LAST, NEVER AS ZERO — the same rule impactScoreOf() enforces above, on
+// the same signal, for the same reason. A real 0th-percentile paper HAS been scored by iCite and
+// genuinely sits at the bottom of its field; a paper with no percentile has not been scored at all
+// and could be excellent. Coercing "missing" to 0 would tie it with (and, on the tie-break, often
+// beat) a real zero — so the sentinel used for the sort is strictly BELOW the valid 0-100 range,
+// never inside it.
+const NO_PERCENTILE = -1
+
+// tier.rank ascending (stronger evidence first), then nihPercentile descending (missing sorts
+// last, never as 0 — see NO_PERCENTILE), then year descending as the final tie-break.
+function rankForScoring(records: PubRecord[]): PubRecord[] {
+    return [...records].sort((a, b) => {
+        if (a.tier.rank !== b.tier.rank) return a.tier.rank - b.tier.rank
+        const aPct = typeof a.nihPercentile === 'number' ? a.nihPercentile : NO_PERCENTILE
+        const bPct = typeof b.nihPercentile === 'number' ? b.nihPercentile : NO_PERCENTILE
+        if (aPct !== bPct) return bPct - aPct
+        return (Number(b.year) || 0) - (Number(a.year) || 0)
+    })
+}
+
+export function preFilterForScoring(
+    clusters: Cluster[],
+    byPmid: Map<string, PubRecord>,
+    budget = 200,
+): ScoreBudget {
+    // The uncategorized bucket gets no scoring budget — it is the fallthrough for records no seed
+    // MeSH term claimed, not a topic worth spending Bedrock on. A cluster whose pmids all fell out
+    // of byPmid (should not happen by construction — byPmid is built from the same corpus the
+    // clusters were, but this is cheap insurance) contributes nothing and is dropped here too, so
+    // the budget math below never divides by a cluster with no real members.
+    const withMembers = clusters
+        .filter(c => !c.isUncategorized)
+        .map(c => ({ id: c.id, members: c.pmids.map(p => byPmid.get(p)).filter((r): r is PubRecord => !!r) }))
+        .filter(c => c.members.length)
+
+    if (!withMembers.length) return {}
+
+    // Step 1 — every cluster gets its floor first, so a small cluster is never zeroed out by a big
+    // one's share. Capped at the cluster's own member count so a 2-record cluster cannot claim 3.
+    const floors = new Map(withMembers.map(c => [c.id, Math.min(SCORE_FLOOR, c.members.length)]))
+    let floorTotal = [...floors.values()].reduce((a, n) => a + n, 0)
+
+    // ponytail: if the floors alone already exceed the budget, scale every floor down
+    // proportionally (never below 1, so the "never zeroed out" promise still holds) rather than the
+    // full "proportional allocation + floors, scaled to fit" algorithm the spec describes in the
+    // general case. This branch cannot fire at today's ceilings — clusterByMesh() caps at 25
+    // clusters, so the worst case is 25 * 3 = 75, well under the 200 default — and is here only so
+    // the function never silently blows past its own budget if those ceilings ever move. Upgrade
+    // path: if this ever actually fires in production logs, revisit with the fuller algorithm.
+    if (floorTotal > budget) {
+        const scale = budget / floorTotal
+        for (const [id, n] of floors) floors.set(id, Math.max(1, Math.floor(n * scale)))
+        floorTotal = [...floors.values()].reduce((a, n) => a + n, 0)
+    }
+
+    // Step 2 — whatever budget remains is distributed proportionally to cluster size, then capped
+    // at that cluster's own member count (on top of the floor it already has).
+    const remaining = Math.max(0, budget - floorTotal)
+    const totalMembers = withMembers.reduce((a, c) => a + c.members.length, 0)
+
+    const out: ScoreBudget = {}
+    for (const c of withMembers) {
+        const floor = floors.get(c.id)!
+        const share = totalMembers ? Math.floor(remaining * (c.members.length / totalMembers)) : 0
+        const n = Math.min(c.members.length, floor + share)
+        if (n) out[c.id] = rankForScoring(c.members).slice(0, n)
+    }
+    return out
+}
+
+// ---------------------------------------------------------------------------
+// PHASE 6c — scoreRelevance(). The one Bedrock call this file makes.
+//
+// ONE PASS, NOT SCREEN RECORDS' TWO. screenRecords() is cheap-then-dense on purpose: it screens the
+// FULL retrieved corpus (up to RECORD_CAP) with one model call because that corpus was never
+// filtered down first. Here the expensive half of that shape — deciding which records are worth a
+// model's attention — is already done, deterministically and for free, by preFilterForScoring()
+// above. Running a second cheap LLM pass over its ~200-record output before a dense pass would mean
+// paying for a filtering step this design does not need: the filtering already happened, off the
+// model entirely.
+
+// One first pass plus two re-asks, same number and same reasoning as SCREEN_ATTEMPTS in
+// literatureSearch.llm.ts: a model that has dropped the same record twice is telling you something,
+// and an unbounded retry loop over a paid call is how a scoring pass quietly costs real money.
+const SCORE_ATTEMPTS = 3
+
+function chunk<T>(arr: T[], size: number): T[][] {
+    const out: T[][] = []
+    for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+    return out
+}
+
+export async function scoreRelevance(
+    topic: string,
+    criteria: string | undefined,
+    shortlist: PubRecord[],
+): Promise<{ scores: Map<string, { score: number; justification: string }>; usage: UsageLog }> {
+    const byPmid = new Map(shortlist.map(r => [r.pmid, r]))
+    const scores = new Map<string, { score: number; justification: string }>()
+    let usage: UsageLog = { inputTokens: 0, outputTokens: 0 }
+
+    let pending = shortlist
+    for (let attempt = 1; attempt <= SCORE_ATTEMPTS && pending.length; attempt++) {
+        for (const batch of chunk(pending, RECORD_CAP)) {
+            try {
+                const res = await attemptScoreBatch(topic, criteria, batch, byPmid)
+                usage = {
+                    inputTokens: usage.inputTokens + res.usage.inputTokens,
+                    outputTokens: usage.outputTokens + res.usage.outputTokens,
+                }
+                for (const [pmid, s] of res.scores) {
+                    if (!scores.has(pmid)) scores.set(pmid, s)   // first score wins across attempts
+                }
+            } catch (err: any) {
+                // NEVER THROWN OUT OF THIS FUNCTION — the one deliberate divergence from
+                // screenRecords(), which throws on an attempt-1 failure because a screen of nothing
+                // is not a screen and the whole page depends on it. A missing relevanceScore is a
+                // much smaller consequence: the record still appears in every cluster and every
+                // bibliometric stat exactly as before, and only the couple of export columns that
+                // show a relevance number go blank for that row. So every batch failure, including
+                // the very first one, is caught, logged, and left as a gap — never propagated. The
+                // usage it already billed still has to be counted, though: BEDROCK HAS ALREADY
+                // BILLED BY THE TIME AN ANSWER IS REJECTED, same reasoning as billed() in
+                // literatureSearch.llm.ts.
+                usage = {
+                    inputTokens: usage.inputTokens + (err?.usage?.inputTokens || 0),
+                    outputTokens: usage.outputTokens + (err?.usage?.outputTokens || 0),
+                }
+                console.error(JSON.stringify({
+                    tag: 'literature-relevance-batch-failed', attempt, batchSize: batch.length,
+                    error: String(err?.message || err), why: 'these records stay unscored',
+                }))
+            }
+        }
+
+        const before = pending.length
+        pending = pending.filter(r => !scores.has(r.pmid))
+        if (pending.length && pending.length !== before) {
+            console.error(JSON.stringify({
+                tag: 'literature-relevance-reask', attempt, asked: before,
+                answered: before - pending.length, reasking: pending.length,
+            }))
+        }
+    }
+
+    if (pending.length) {
+        console.error(JSON.stringify({
+            tag: 'literature-relevance-missing', pmids: pending.map(r => r.pmid),
+            why: 'the model returned no score for these records after 3 attempts; they render with no relevanceScore',
+        }))
+    }
+
+    return { scores, usage }
+}
+
+const RELEVANCE_TOOL = {
+    name: 'submit_relevance_scores',
+    description: 'Return a relevance score and justification for EVERY record supplied.',
+    input_schema: {
+        type: 'object' as const,
+        properties: {
+            scores: {
+                type: 'array',
+                description: 'Exactly one entry per record supplied. Never omit a record.',
+                items: {
+                    type: 'object',
+                    properties: {
+                        pmid: { type: 'string', description: 'The PMID, exactly as supplied.' },
+                        score: { type: 'number', description: '0 (not about this topic at all) to 1 (squarely on-topic, central to it).' },
+                        justification: { type: 'string', description: 'ONE clause, specific to this paper — why it scored where it did.' },
+                    },
+                    required: ['pmid', 'score', 'justification'],
+                },
+            },
+        },
+        required: ['scores'],
+    },
+}
+
+// Same two forces as SCREEN_PROMPT, in the same tension. This mode is a REPORT, not a filter that
+// hides anything — a low score is a sort key and a caption, never a reason a paper disappears — so
+// there is no "fail open" instinct to encode. What carries over unchanged is the checkability rule:
+// a justification a human cannot verify against the abstract in front of them is worthless, however
+// confident it sounds.
+const RELEVANCE_PROMPT = `You are scoring how relevant a set of biomedical papers is to a specific review topic, by title and abstract, for a clinician assembling a bibliometric review of the literature.
+
+YOUR SCORE IS A SUGGESTION, not a filter. Every paper you score stays in the report regardless of what you give it — the score sorts and captions a table the clinician reads in full, it does not hide anything.
+
+Rules:
+- Return a score for EVERY record. Never skip one, never merge two, never invent a PMID.
+- The score is a number from 0 to 1. 0 means the paper is not about this topic at all. 1 means the paper is squarely on-topic — the topic IS what the paper is about, not something it mentions in passing. Use the range between for a paper that touches the topic without being centered on it.
+- Judge only on what the title and abstract actually say. Never infer relevance from the journal, the authors, the citation count, or your own knowledge of the field.
+- If a record has no abstract, score it from the title alone and say so in the justification — do not guess at what the abstract would have said.
+- The justification is ONE CLAUSE, specific to THIS paper, and it must let a human check your score at a glance. Good: "primary RCT of the intervention in the stated population", "mentions the topic only as a secondary outcome", "different intervention entirely — surgical, not pharmacologic, management". NEVER write "relevant to the topic" or "on-topic" — that is the score restated, and it cannot be checked.
+- Never state a number that is not written in the abstract you were given.`
+
+// One invoke + parse + unknown-PMID-drop + out-of-range-score-drop over a single batch, the exact
+// shape attemptScreenBatch() in literatureSearch.llm.ts uses for the batch the retry loop above
+// calls repeatedly. `byPmid` is deliberately the full shortlist (built once in scoreRelevance), not
+// just this batch, so a batch stays validated against everything the caller ever supplied.
+async function attemptScoreBatch(
+    topic: string,
+    criteria: string | undefined,
+    batch: PubRecord[],
+    byPmid: Map<string, PubRecord>,
+): Promise<{ scores: Map<string, { score: number; justification: string }>; usage: UsageLog }> {
+    const parts = [`Review topic: ${topic}`]
+    if (criteria) parts.push(`Inclusion/exclusion criteria: ${criteria}`)
+    parts.push(`Score all ${batch.length} records below. Return one score per record.\n\n${renderRecords(batch)}`)
+
+    const { input, usage } = await invoke(RELEVANCE_PROMPT, RELEVANCE_TOOL, parts.join('\n\n'), LONG_MAX_TOKENS)
+
+    const scores = new Map<string, { score: number; justification: string }>()
+    for (const s of (input?.scores || [])) {
+        const pmid = String(s?.pmid ?? '').trim()
+        if (!byPmid.has(pmid)) {
+            // A score on a paper we never sent — the same fabrication risk attemptScreenBatch()
+            // guards against, and just as loud, because it means the prompt or the model has drifted.
+            console.error(JSON.stringify({ tag: 'literature-relevance-unknown-pmid', pmid }))
+            continue
+        }
+        const raw = Number(s?.score)
+        if (!Number.isFinite(raw)) continue   // an unparseable score is the same as no score at all
+        const score = clamp01(raw)
+        const justification = String(s?.justification ?? '').trim() || 'No justification given.'
+        if (!scores.has(pmid)) scores.set(pmid, { score, justification })   // first score wins within this batch's own answer
+    }
+    return { scores, usage }
+}


### PR DESCRIPTION
Builds on #863 (Mode 4 Phases 2-4, merged). Adds Phases 5-8 of the bibliometric-review mode for the Dan Cook / Anesthesiology pilot. Design doc: `PLAN-literature-mode4-bibliometric-review.md` / `HANDOFF-literature-mode4-bibliometric-review.md` (Projects, not this repo).

**Review only, same as #824/#863. Do not merge.** Backend-only, no route/UI wiring, nothing deployed.

## What's here

- `literatureSearch.cluster.ts` — Phase 5. `clusterByMesh()`: a pure, deterministic greedy top-MeSH-term partition (no graph-clustering library installed; coarse-and-honest over granular-and-wrong, same call already made for case-series in #863). `labelClusters()`: the one Bedrock call, ONE batched call for every cluster's label (not one call per cluster, as an earlier plan draft had it — cheaper, same "batch don't loop" instinct as `screenRecords()`).
- `literatureSearch.score.ts` — Phase 6. `impactScoreOf()`: pure, tier + iCite percentile blend, retraction forced to 0, missing percentile never coerced to 0. `preFilterForScoring()`: pure, allocates a ~200-record scoring budget per cluster (floor + proportional share) so `scoreRelevance()` never has to touch the full corpus. `scoreRelevance()`: the one Bedrock call, single dense pass (not screenRecords' cheap-then-dense two-pass — the pre-filter already did the cheap half, deterministically, for free).
- `literatureSearch.narrative.ts` — Phase 7. `synthesizeCluster()`: one Bedrock call per cluster, reusing `SYNTH_RULES_HEAD` verbatim. `assembleNarrativeReview()`: pure, deterministic whole-review assembly — **deliberately does NOT make a further "stitch" LLM call**, unlike an earlier plan draft. Rule 2 of `SYNTH_RULES_HEAD` ("never state a number not in the abstract you were given") exists specifically because a model asked to stitch cluster paragraphs + corpus stats into one narrative will supply connective tissue no single cited paper grounds — exactly the failure this feature is built hardest against. The intro is pure arithmetic over Phase 4's stats instead.
- `literatureExport.corpusSheet.ts` / `literatureExport.bibliometricDoc.ts` — Phase 8. Siblings of `sheets.ts`/`synthesisDoc.ts`, not modifications of them (Mode 4's corpus is never a truncated relevance-ranked slice the way Mode 2/3's is, so none of `recordSheets()`'s truncation-refusal logic applies).
- `literatureSearch.pure.check.js` extended with 6 new fixture-based check functions covering every pure/deterministic piece above (clustering determinism + stoplist dominance, budget floor/proportional-share arithmetic, missing-vs-real-zero percentile handling, retraction override, narrative section ordering, export column shape). `npm run check:literature:pure` passes, zero exit code, no network/LLM/env.

Small, additive changes to `literatureSearch.llm.ts`: `invoke()`, `renderRecords()`, `LONG_MAX_TOKENS`, and `SYNTH_RULES_HEAD` are now exported (were module-private) so Phases 5-7 reuse the existing Bedrock-call primitive and the canonical synthesis rules verbatim instead of duplicating them.

## Not in this PR

Route/UI wiring — the mode entry, form changes, progress step list, trend panel, cluster browser (see the plan's "UI changes" section). This backend is inert until wired up, same as #863 was for Phases 2-4.

Live validation against real Bedrock/PubMed (the "two cheap probes" pattern #863's Phases 2-4 got separately, written up in `PROBE-RESULTS-mode4-bibliometric-review.md`) — not run here. Everything in this PR is verified by `check:literature:pure` (deterministic logic only); the three LLM calls (`labelClusters`, `scoreRelevance`, `synthesizeCluster`) are unverified against a live model in this PR, same as `buildStrategy()`/`screenRecords()`/`synthesize()` themselves aren't covered by that check either — by design, that check never calls Bedrock.

## Open, not resolved by this PR

Same 4 decisions #863 already flagged as not engineering calls: deploy timing, case-series methodology sign-off, the allowlist model for a faculty user, and sub-sharding threshold.