### PR TITLE
fix(literature): Mode 4 live-run wiring fixes + open review-ledger items

### DIFF
--- a/controllers/literatureSearch.cluster.ts
+++ b/controllers/literatureSearch.cluster.ts
@@ -153,10 +153,12 @@ export function clusterByMesh(
 }
 
 // ---------------------------------------------------------------------------
-// PHASE 5b — the one Bedrock call this file makes: turn each cluster's MeSH terms into a phrase a
-// human would actually say. "Laryngoscopy, Video; Intubation, Intratracheal" is a MeSH heading
-// list; "Videolaryngoscopy vs. direct laryngoscopy" is a topic label. Only a model does that
-// rewrite.
+// PHASE 5b — the one Bedrock call this file makes: turn each cluster's MeSH terms plus a sample of
+// its own titles into a phrase a human would actually say. "Laryngoscopy, Video; Intubation,
+// Intratracheal" is a MeSH heading list; "Videolaryngoscopy vs. direct laryngoscopy" is a topic
+// label. Only a model does that rewrite — and it needs the titles, not just the headings, because a
+// seed MeSH term is how the papers were FILED, not necessarily what they are ABOUT (measured: three
+// shipped sections opened by disowning their own MeSH-named heading).
 //
 // ONE CALL FOR ALL CLUSTERS, NOT ONE PER CLUSTER. An earlier draft of the design doc had this as a
 // per-cluster call; that is the same "batch, don't loop" instinct screenRecords() already applies
@@ -188,7 +190,7 @@ const CLUSTER_LABEL_TOOL = {
     },
 }
 
-const CLUSTER_LABEL_PROMPT = `You are naming the topic clusters found in a corpus of biomedical literature, from each cluster's own dominant MeSH descriptors and record count. You have not been shown the papers themselves — only their shared MeSH headings.
+const CLUSTER_LABEL_PROMPT = `You are naming the topic clusters found in a corpus of biomedical literature. For each cluster you are shown its dominant MeSH descriptors, its record count, and a sample of its own papers' titles.
 
 Rules:
 - Return a label for EVERY cluster supplied. Never skip one, never merge two, never invent a cluster id.
@@ -196,15 +198,27 @@ Rules:
   Good: "Videolaryngoscopy vs. direct laryngoscopy"
   Bad: "Laryngoscopy, Video; Intubation, Intratracheal" (that is just the MeSH terms restated)
   Bad: "cluster-laryngoscopy-video" (that is the id)
-- Base the label only on the MeSH terms and record count given for that cluster. You have no other information about it.`
+- Base the label on the MeSH terms AND the sample titles given for that cluster. Where they disagree, believe the titles: MeSH is how an indexer filed the papers, the titles are what the papers are actually about.`
 
-function buildClusterPrompt(clusters: Cluster[]): string {
+// Up to 8 sample titles per cluster, in the cluster's own pmid order — enough for the model to
+// notice when the members are not about what the seed MeSH term suggests (the 2026-08-19 run
+// shipped three sections whose MeSH-only names their own text immediately disowned), and cheap
+// enough that the batch stays one short call. Clusters without a record map (or whose pmids miss
+// it) degrade to the MeSH-only line rather than failing.
+function buildClusterPrompt(clusters: Cluster[], byPmid?: Map<string, PubRecord>): string {
     return clusters
-        .map(c => `Cluster ${c.id} (${c.pmids.length} records) — top MeSH terms: ${c.meshTerms.join(', ')}`)
+        .map(c => {
+            const titles = c.pmids.slice(0, 8)
+                .map(p => byPmid?.get(p)?.title)
+                .filter(Boolean)
+                .join(' | ')
+            return `Cluster ${c.id} (${c.pmids.length} records) — top MeSH terms: ${c.meshTerms.join(', ')}`
+                + (titles ? ` — sample titles: ${titles}` : '')
+        })
         .join('\n')
 }
 
-export async function labelClusters(clusters: Cluster[]): Promise<{ clusters: Cluster[]; usage: UsageLog }> {
+export async function labelClusters(clusters: Cluster[], byPmid?: Map<string, PubRecord>): Promise<{ clusters: Cluster[]; usage: UsageLog }> {
     // 'uncategorized' is a fixed label, never sent to the model and never overwritten.
     const labelable = clusters.filter(c => !c.isUncategorized)
     if (!labelable.length) return { clusters, usage: { inputTokens: 0, outputTokens: 0 } }
@@ -213,7 +227,7 @@ export async function labelClusters(clusters: Cluster[]): Promise<{ clusters: Cl
     // of ONE-LINE labels, not 50 records' worth of one-clause screening reasons (SCREEN_TOOL, which
     // was measured at 4.0k+ output tokens and is why LONG_MAX_TOKENS exists at all). A phrase per
     // cluster is an order of magnitude smaller than a reason per record.
-    const { input, usage } = await invoke(CLUSTER_LABEL_PROMPT, CLUSTER_LABEL_TOOL, buildClusterPrompt(labelable))
+    const { input, usage } = await invoke(CLUSTER_LABEL_PROMPT, CLUSTER_LABEL_TOOL, buildClusterPrompt(labelable, byPmid))
 
     const labels = new Map<string, string>()
     for (const l of (input?.labels || [])) {

--- a/controllers/literatureSearch.narrative.ts
+++ b/controllers/literatureSearch.narrative.ts
@@ -6,9 +6,11 @@
 // TWO FUNCTIONS, TWO DIFFERENT SHAPES, and the split is the whole design, the same instinct
 // impactScoreOf() / scoreRelevance() and clusterByMesh() / labelClusters() already apply:
 //
-//   synthesizeCluster() is the one Bedrock call this file makes. It writes ONE cited paragraph
+//   synthesizeCluster() is the one Bedrock call this file makes. It writes ONE cited section
 //   over a small shortlist of records for a SINGLE cluster — the same job synthesize() does for
 //   Mode 2, reusing its own canonical rules (SYNTH_RULES_HEAD) rather than a paraphrased copy.
+//   (The field is still named `paragraph` — see ClusterNarrative — though the prose is now 2-4
+//   short paragraphs; renaming it would ripple through every renderer for no reader-visible gain.)
 //
 //   assembleNarrativeReview() is PURE — no network, no LLM, no further model call of any kind.
 //   See its own comment below for why that is deliberate, not merely convenient.
@@ -33,13 +35,13 @@ export type ClusterNarrative = {
 
 const CLUSTER_SYNTH_TOOL = {
     name: 'submit_cluster_synthesis',
-    description: 'Return a narrative paragraph synthesizing the supplied papers for ONE cluster of a larger bibliometric review.',
+    description: 'Return a short narrative synthesis of the supplied papers for ONE cluster of a larger bibliometric review.',
     input_schema: {
         type: 'object' as const,
         properties: {
             paragraph: {
                 type: 'string',
-                description: 'The narrative synthesis for this cluster only. Every claim cites its source inline as [PMID 12345678]. Plain prose, one paragraph, no headings, no markdown.',
+                description: 'The narrative synthesis for this cluster only. Every claim cites its source inline as [PMID 12345678]. Plain prose, 2-4 short paragraphs separated by a blank line, no headings, no markdown.',
             },
         },
         required: ['paragraph'],
@@ -52,15 +54,15 @@ const CLUSTER_SYNTH_TOOL = {
 // never sees in full: it has no idea what the other clusters say, and nothing stops it reaching for
 // a comparison ("unlike the surgical-management cluster...") that sounds plausible and is entirely
 // invented, since it was never shown that cluster's papers.
-const RULE_5_CLUSTER = `5. This paragraph is ONE SECTION of a larger bibliometric review. It covers ONLY the cluster named below. Do not generalize beyond it, and do not compare it to other clusters — you have not been shown their papers and cannot know what they say.`
+const RULE_5_CLUSTER = `5. This section is ONE SECTION of a larger bibliometric review. It covers ONLY the cluster named below. Do not generalize beyond it, and do not compare it to other clusters — you have not been shown their papers and cannot know what they say.`
 
-const CLUSTER_SYNTH_PROMPT = `You are writing one section of a bibliometric literature review: a narrative paragraph synthesizing the papers in ONE topic cluster. You are given the same abstracts a clinician would read, and nothing else.
+const CLUSTER_SYNTH_PROMPT = `You are writing one section of a bibliometric literature review: a short narrative synthesis of the papers in ONE topic cluster. You are given the same abstracts a clinician would read, and nothing else.
 
 THESE RULES ARE ABSOLUTE. They are the reason this tool exists:
 ${SYNTH_RULES_HEAD}
 ${RULE_5_CLUSTER}
 
-Style: ONE paragraph of plain clinical prose. No headings, no bullet points, no markdown, no bold. Write for a clinician who will check your citations.`
+Style: 2-4 short paragraphs of plain clinical prose, separated by a blank line. No headings, no bullet points, no markdown, no bold. Write for a clinician who will check your citations.`
 
 // ONE CALL PER CLUSTER, unlike labelClusters()'s one-call-for-all-clusters. The two are not the same
 // shape: labelClusters() reads a few MeSH terms per cluster (cheap, and every cluster benefits from
@@ -162,6 +164,11 @@ export function assembleNarrativeReview(
         totalRecords: number
         fromYear: number
         toYear: number
+        // Supplied by the CALLER, never read from the clock here — this function is pure and
+        // pure-checked (see literatureSearch.pure.check.js), and a new Date() inside it would make
+        // the check's answer depend on the day it ran. trendNote() needs it to keep the partial
+        // current year out of a mean — see its own comment below.
+        currentYear: number
     },
     clusters: Cluster[],
     clusterNarratives: ClusterNarrative[],
@@ -205,9 +212,9 @@ export function assembleNarrativeReview(
 
     // Optional trend note: mean of the first half of publicationsPerYear vs. the second half.
     // Simple, no forecasting — see the function's own header comment for why nothing fancier
-    // belongs here. Skipped outright below two years of data (nothing to compare) or when both
-    // halves are empty (nothing happened either way).
-    const trendSentence = trendNote(corpusStats.publicationsPerYear)
+    // belongs here. Skipped outright below two complete years of data (nothing to compare) or when
+    // both halves are empty (nothing happened either way).
+    const trendSentence = trendNote(corpusStats.publicationsPerYear, corpusStats.currentYear)
 
     // clusterNarratives filtered to real clusters (a narrative for the uncategorized bucket, or for
     // any id that is no longer a real cluster, is simply absent from `sizeById` and drops out here),
@@ -248,13 +255,18 @@ export function assembleNarrativeReview(
 
 const pct = (n: number, total: number): number => Math.round((n / total) * 100)
 
-function trendNote(years: YearCount[]): string {
-    if (years.length < 2) return ''
+function trendNote(years: YearCount[], currentYear: number): string {
+    // COMPLETE YEARS ONLY. The current year is a partial count — a corpus pulled in August holds
+    // eight months of it — and folding it into the later-half mean reads every mid-year run as a
+    // publication cliff that never happened. A count is not a mean: the per-year tables and charts
+    // still show the partial year; only this comparison drops it.
+    const complete = years.filter(y => Number(y.year) < currentYear)
+    if (complete.length < 2) return ''
 
-    const mid = Math.floor(years.length / 2)
+    const mid = Math.floor(complete.length / 2)
     const mean = (xs: YearCount[]) => xs.reduce((a, y) => a + y.count, 0) / xs.length
-    const firstMean = mean(years.slice(0, mid))
-    const secondMean = mean(years.slice(mid))
+    const firstMean = mean(complete.slice(0, mid))
+    const secondMean = mean(complete.slice(mid))
     if (firstMean === 0 && secondMean === 0) return ''
 
     const round1 = (n: number) => Math.round(n * 10) / 10
@@ -265,6 +277,14 @@ function trendNote(years: YearCount[]): string {
     const ratio = firstMean === 0 ? Infinity : secondMean / firstMean
     const direction = ratio > 1.1 ? 'increased' : ratio < 0.9 ? 'declined' : 'held roughly steady'
 
-    return ` Yearly publication volume ${direction} across the window — a mean of ${round1(firstMean)} `
-        + `per year in the earlier half of the range versus ${round1(secondMean)} in the later half.`
+    // The sentence names the window it actually measured, and discloses the exclusion only when a
+    // partial year was really in the data — a review whose range ended years ago excluded nothing,
+    // and saying otherwise would be a false disclaimer in a document whose claim is checkability.
+    const first = complete[0].year
+    const last = complete[complete.length - 1].year
+    const excludedPartial = complete.length < years.length
+    return ` Yearly publication volume ${direction} across ${first}–${last} — a mean of ${round1(firstMean)} `
+        + `per year in the earlier half of that range versus ${round1(secondMean)} in the later half`
+        + (excludedPartial ? ` (${currentYear} is excluded from this comparison as an incomplete year)` : '')
+        + `.`
 }

--- a/controllers/literatureSearch.pure.check.js
+++ b/controllers/literatureSearch.pure.check.js
@@ -768,6 +768,9 @@ const checkAssembleNarrativeReview = (lit) => {
         totalRecords: 23,
         fromYear: 2020,
         toYear: 2021,
+        // Both years above are COMPLETE relative to this — the exclusion assertions further down
+        // use their own stats, where the partial year is actually present.
+        currentYear: 2022,
     }
 
     const withFlags = lit.assembleNarrativeReview('Do probiotics help depression?', corpusStats, clusters, clusterNarratives, true)
@@ -792,7 +795,45 @@ const checkAssembleNarrativeReview = (lit) => {
     assert.strictEqual(withoutFlags.caseSeriesNote, undefined,
         'hasCaseSeriesFlags: false must produce NO caseSeriesNote — a disclosure that applies whether or not the corpus actually has any flagged records is not a disclosure, it is boilerplate')
 
-    console.log(`narrative:    sections ordered [${withFlags.sections.map(s => s.clusterId).join(', ')}], uncategorized excluded, caseSeriesNote present=${!!withFlags.caseSeriesNote}/absent=${withoutFlags.caseSeriesNote === undefined}`)
+    // THE PARTIAL CURRENT YEAR NEVER ENTERS THE TREND MEANS. A corpus pulled in August holds eight
+    // months of the current year, and folding that count into the later-half mean reads every
+    // mid-year run as a publication cliff — a decline that is really a calendar. The per-year
+    // tables keep the partial year — a count is not a mean — so the assertion is on the intro's
+    // comparison sentence alone. The fixture is built so
+    // the leak would FLIP the verdict, not just nudge a decimal: four complete years at a steady 5
+    // read "held roughly steady"; let the 1-record partial 2022 into the later half and the mean
+    // drops to 3.67, through the 10% dead band, and the sentence claims a decline.
+    const partialStats = {
+        ...corpusStats,
+        publicationsPerYear: [
+            { year: '2018', count: 5 }, { year: '2019', count: 5 },
+            { year: '2020', count: 5 }, { year: '2021', count: 5 },
+            { year: '2022', count: 1 },   // the partial current year — 1 record SO FAR, not a collapse
+        ],
+        toYear: 2022,
+        currentYear: 2022,
+    }
+    const partial = lit.assembleNarrativeReview('Do probiotics help depression?', partialStats, clusters, clusterNarratives, false)
+    assert.ok(partial.intro.includes('held roughly steady') && !partial.intro.includes('declined'),
+        `a steady 5/year over the complete years must read "held roughly steady" — a "declined" here means the partial current year leaked into the later-half mean. Intro was: ${partial.intro}`)
+    assert.ok(partial.intro.includes('2018–2021'),
+        `the trend sentence must name the window it actually measured (2018–2021), not the corpus window that includes the partial year. Intro was: ${partial.intro}`)
+    assert.ok(partial.intro.includes('2022 is excluded'),
+        `when a partial current year was dropped from the comparison, the sentence must disclose the exclusion. Intro was: ${partial.intro}`)
+
+    // AND NO FALSE DISCLAIMER THE OTHER WAY: the base fixture's years are all complete, so its
+    // intro must not claim an exclusion that never happened.
+    assert.ok(!withFlags.intro.includes('excluded'),
+        `a corpus whose window ended before the current year excluded nothing, and its intro must not say otherwise. Intro was: ${withFlags.intro}`)
+
+    // FEWER THAN TWO COMPLETE YEARS = NO TREND SENTENCE AT ALL — one complete year plus a partial
+    // one is nothing to compare, and half a comparison is worse than none.
+    const oneComplete = lit.assembleNarrativeReview('Do probiotics help depression?',
+        { ...corpusStats, currentYear: 2021 }, clusters, clusterNarratives, false)
+    assert.ok(!oneComplete.intro.includes('Yearly publication volume'),
+        `with only one complete year (2020) and a partial 2021, no trend sentence belongs in the intro. Intro was: ${oneComplete.intro}`)
+
+    console.log(`narrative:    sections ordered [${withFlags.sections.map(s => s.clusterId).join(', ')}], uncategorized excluded, caseSeriesNote present=${!!withFlags.caseSeriesNote}/absent=${withoutFlags.caseSeriesNote === undefined}, partial-year excluded from trend means`)
 }
 
 // =======================================================================================

--- a/src/components/elements/Literature/ClusterBrowser.tsx
+++ b/src/components/elements/Literature/ClusterBrowser.tsx
@@ -13,8 +13,9 @@ import s from './LiteratureSearch.module.css'
 // Same "first half vs second half, 10% dead band" trend rule assembleNarrativeReview()'s own
 // trendNote() applies to the whole corpus — reused here per cluster rather than reinvented, so a
 // cluster row's "rising"/"declining" means the same thing the intro paragraph's own trend
-// sentence does.
-function trendWord(counts: number[]): string {
+// sentence does. Exported: TrendPanel's publications-per-year summary line uses the same rule,
+// for the same one-taxonomy reason, rather than growing a third copy.
+export function trendWord(counts: number[]): string {
     if (counts.length < 2) return ''
     const mid = Math.floor(counts.length / 2)
     const mean = (xs: number[]) => xs.reduce((a, n) => a + n, 0) / xs.length

--- a/src/components/elements/Literature/TrendPanel.tsx
+++ b/src/components/elements/Literature/TrendPanel.tsx
@@ -1,8 +1,9 @@
 // MODE 4, OVERVIEW TAB — publications/year, evidence-type mix/year, citation-percentile trend.
-// Plain CSS bars and one small inline SVG sparkline, per the plan's own "nothing here justifies a
-// charting dependency" — ~10 data points a series, which a handful of divs and one polyline render
+// Plain CSS bars and two small inline SVG sparklines, per the plan's own "nothing here justifies a
+// charting dependency" — ~10 data points a series, which a handful of divs and a polyline render
 // perfectly well.
 import type { CorpusStats } from './LiteratureSearch.types'
+import { trendWord } from './ClusterBrowser'
 import s from './LiteratureSearch.module.css'
 
 // The same 3-bucket split assembleNarrativeReview() sums the intro's own "19% is RCT/meta-
@@ -21,9 +22,37 @@ function mixBuckets(yearCounts: Record<string, number>): { higher: number; obs: 
     return { higher, obs, other, total: higher + obs + other }
 }
 
+// One decimal at most, and Number#toString drops a trailing .0 on its own (29.3, 61.3, 92) — the
+// live run printed "29.299999999999997th pct", a float's full residue in front of a reader. And no
+// ordinal suffix anywhere here: a median of percentiles is an average, not a rank, and "92th" is
+// not a word in any case.
+const round1 = (n: number) => Math.round(n * 10) / 10
+
 export function TrendPanel({ stats }: { stats: CorpusStats }) {
     const years = stats.publicationsPerYear
-    const maxCount = Math.max(1, ...years.map(y => y.count))
+    const counts = years.map(y => y.count)
+    const total = counts.reduce((a, n) => a + n, 0)
+    const maxCount = Math.max(1, ...counts)
+
+    // ONE SENTENCE AND A SPARKLINE, not a bar per year — eleven near-identical bars at the top of
+    // the Overview said one sentence's worth ("volume is flat") in a third of the viewport. The
+    // trend word shares the first-half/second-half, 10%-dead-band rule with the cluster rows and
+    // the narrative intro, and — like the narrative's trend sentence — it is computed over complete
+    // years only: a partial current year annualizes to anything, and a truncated bucket must not be
+    // allowed to flip the word to "declining" in August. Per-year numbers stay reachable on the
+    // svg's own title/aria-label; the docx export keeps its full year table.
+    const thisYear = String(new Date().getFullYear())
+    const lastIsPartial = years.length > 0 && years[years.length - 1].year === thisYear
+    const volumeTrend = trendWord(lastIsPartial ? counts.slice(0, -1) : counts)
+    const perYearText = years.map(y => `${y.year}: ${y.count.toLocaleString()}`).join(', ')
+    const volPoint = (i: number) => ({
+        x: years.length === 1 ? 0 : (i / (years.length - 1)) * 100,
+        y: 38 - (counts[i] / maxCount) * 36,
+    })
+    // The current year is a partial count and would read as a publication cliff at the right edge —
+    // so its segment is drawn dashed (and named as partial in the sentence) instead of solid.
+    const solidPoints = years.slice(0, lastIsPartial ? -1 : years.length)
+        .map((_, i) => { const p = volPoint(i); return `${p.x},${p.y}` }).join(' ')
 
     const scoredYears = stats.percentileTrend.filter(p => p.median !== null)
     const maxPct = 100 // nihPercentile is always 0-100, so the sparkline's own scale never depends on the data
@@ -31,18 +60,43 @@ export function TrendPanel({ stats }: { stats: CorpusStats }) {
     return (
         <div className={s.card}>
             <span className={s.eyebrow}>Publications per year</span>
-            <div className={s.trendBars}>
-                {years.map(y => (
-                    <div className={s.trendBarRow} key={y.year}>
-                        <span className={s.trendBarYear}>{y.year}</span>
-                        <span className={s.trendBarTrack}>
-                            <span className={s.trendBarFill} style={{ width: `${Math.max(2, (y.count / maxCount) * 100)}%` }} />
-                        </span>
-                        <span className={s.trendBarCount}>{y.count.toLocaleString()}</span>
-                    </div>
-                ))}
-                {!years.length && <p className={s.help}>No records to chart.</p>}
-            </div>
+            {years.length ? (
+                <>
+                    <p className={s.help}>
+                        {total.toLocaleString()} records, {years[0].year}&ndash;{years[years.length - 1].year}
+                        {volumeTrend ? `; volume ${volumeTrend}` : ''}.
+                        {lastIsPartial ? ` ${thisYear} is a partial year (dashed).` : ''}
+                    </p>
+                    {years.length >= 2 && (
+                        <svg className={s.sparkline} viewBox="0 0 100 40" preserveAspectRatio="none" role="img"
+                            aria-label={`Publications per year — ${perYearText}`}>
+                            <title>{perYearText}</title>
+                            <polyline
+                                fill="none"
+                                stroke="var(--accent)"
+                                strokeWidth="2"
+                                vectorEffect="non-scaling-stroke"
+                                points={solidPoints}
+                            />
+                            {lastIsPartial && (() => {
+                                const a = volPoint(years.length - 2)
+                                const b = volPoint(years.length - 1)
+                                return (
+                                    <line
+                                        x1={a.x} y1={a.y} x2={b.x} y2={b.y}
+                                        stroke="var(--accent)"
+                                        strokeWidth="2"
+                                        strokeDasharray="4 3"
+                                        vectorEffect="non-scaling-stroke"
+                                    />
+                                )
+                            })()}
+                        </svg>
+                    )}
+                </>
+            ) : (
+                <p className={s.help}>No records to chart.</p>
+            )}
 
             <div className={s.trendTwoCol}>
                 <div>
@@ -95,7 +149,7 @@ export function TrendPanel({ stats }: { stats: CorpusStats }) {
                     <div className={s.sparkLabels}>
                         {scoredYears.map(p => (
                             <span key={p.year} className={s.sparkLabel}>
-                                {p.year}: median {p.median}th pct ({p.scored}/{p.n} scored)
+                                {p.year}: median {round1(p.median as number)} pct ({p.scored}/{p.n} scored)
                             </span>
                         ))}
                     </div>

--- a/src/pages/api/literature/search.ts
+++ b/src/pages/api/literature/search.ts
@@ -62,6 +62,7 @@ import {
     runStrategy,
     runReview,
     fetchByPmids,
+    withCitationMetrics,
     screenRecords,
     synthesize,
     bedrockConfigured,
@@ -100,6 +101,7 @@ import {
     preFilterForScoring,
     scoreRelevance,
     scoreImpact,
+    SCORING_MODEL_ID,
     ClusterNarrative,
     synthesizeCluster,
     assembleNarrativeReview,
@@ -224,14 +226,15 @@ type SearchBody = {
     databases: any
     edited: any
     seedList: Seed[]
-    // ---- Mode 4 only. `corpus`/`clusters`/`scores` are ECHOED BACK by the client between phases
-    // — see the handleM4* functions below for why that is safe (never abstract text, always
+    // ---- Mode 4 only. `corpus`/`clusters`/`scores`/`impact` are ECHOED BACK by the client between
+    // phases — see the handleM4* functions below for why that is safe (never abstract text, always
     // re-fetched by PMID before a Bedrock call touches it) and bounded (parseM4Corpus).
     evidenceTiers: any
     caseSeries: any
     corpus: any
     clusters: any
     scores: any
+    impact: any
     // Echoed back on every POST after the first, from POST 1's own response — so Phase 4's
     // recomputed stats and the final assembleNarrativeReview() call describe the SAME window the
     // corpus was actually pulled for, not a guessed default. See handleM4Synthesize's fallback for
@@ -596,11 +599,12 @@ async function handleBuildStrategy(req: NextApiRequest, res: NextApiResponse, cw
 //     real abstracts server-side by PMID (fetchByPmids, same call Mode 2/3's screen/synthesize
 //     phases already use) for exactly the shortlist preFilterForScoring() picked. So the one thing
 //     that must never come from the client — the text a paid model call reads — still never does.
-//   - labelClusters() DOES read client-echoed data (each cluster's MeSH terms), but MeSH terms are
-//     short, controlled-vocabulary-shaped strings with none of the injection surface free-text
-//     abstract content has, and the worst case of a tampered one is a mislabeled cluster, not a
-//     fabricated citation or a hijacked prompt. Same bounded-trust posture parseStrategy() already
-//     takes on a re-counted query's term lines.
+//   - labelClusters() DOES read client-echoed data (each cluster's MeSH terms, plus a small sample
+//     of record titles), but those are short, length-capped strings (parseM4Corpus bounds a title
+//     at 500 chars) with none of the injection surface free-text abstract content has, and the
+//     worst case of a tampered one is a mislabeled cluster, not a fabricated citation or a
+//     hijacked prompt. Same bounded-trust posture parseStrategy() already takes on a re-counted
+//     query's term lines.
 // parseM4Corpus/parseM4Clusters/parseM4Scores below are the guards: bounded size, coerced types,
 // abstract forcibly blanked — the same posture parseStrategy/parsePmids already take on this route.
 
@@ -629,6 +633,10 @@ function parseM4Corpus(raw: any): PubRecord[] {
         abstract: '',
         mesh: Array.isArray(r?.mesh) ? r.mesh.slice(0, 40).map((m: any) => s(m, 120)) : [],
         ...(Number.isFinite(r?.nihPercentile) ? { nihPercentile: Number(r.nihPercentile) } : {}),
+        // apt must survive the round-trip or impactScoreOf()'s 'apt' fallback can never fire on the
+        // final decorated corpus — the 2025-26 rows iCite has no percentile for would all land on
+        // 'tier-only', which is exactly what the first live run showed before this line existed.
+        ...(Number.isFinite(r?.apt) ? { apt: Number(r.apt) } : {}),
         ...(r?.caseSeriesProbable === true ? { caseSeriesProbable: true } : {}),
     }))
 }
@@ -719,6 +727,10 @@ function decorateCorpus(
             // decision the table makes when a reader picks a sort, not a number baked into the row.
             evidenceScore: prior.score,
             evidenceJustification: prior.justification,
+            // Which SOURCE the prior was computed from ('percentile' | 'apt' | 'tier-only') — the
+            // field that makes a blank-vs-zero percentile distinguishable in the xlsx (see the
+            // "Evidence basis" column in corpusSheet.ts) rather than inferred from the number.
+            evidenceBasis: prior.evidenceBasis,
             ...(judged ? { impactScore: judged.score, impactJustification: judged.justification } : {}),
             ...(rel ? { relevanceScore: rel.score, relevanceJustification: rel.justification } : {}),
         }
@@ -851,7 +863,11 @@ async function handleM4Cluster(req: NextApiRequest, res: NextApiResponse, cwid: 
     try {
         const corpus = parseM4Corpus(body.corpus)
         const { clusters: raw } = clusterByMesh(corpus)
-        const { clusters, usage } = await labelClusters(raw)
+        // The record map is what lets labelClusters() see sample TITLES, not just MeSH — three
+        // shipped section headings on the 2026-08-19 run were named blind from MeSH alone and
+        // opened by disowning themselves. Titles are client-echoed like the MeSH terms, and
+        // bounded the same way (parseM4Corpus caps them at 500 chars).
+        const { clusters, usage } = await labelClusters(raw, new Map(corpus.map(r => [r.pmid, r])))
         logCost('bibliometric-review:cluster', cwid, usage, { corpusSize: corpus.length, clusters: clusters.length })
         return res.status(200).send({ statusCode: 200, clusters })
     } catch (err: any) {
@@ -880,7 +896,13 @@ async function handleM4Score(req: NextApiRequest, res: NextApiResponse, cwid: st
         // RE-FETCHED, never taken from the echoed corpus — the metadata round-trip never carries an
         // abstract (parseM4Corpus forces it blank), so scoring the actual text means going back to
         // PubMed for it, same discipline Mode 2/3's screen/synthesize phases already apply.
-        const withAbstracts = shortlistPmids.length ? await fetchByPmids(shortlistPmids) : []
+        // AND RE-ENRICHED: fetchByPmids alone returns no iCite fields (only fetchCorpus applies
+        // withCitationMetrics), so without this wrap renderForImpact's Citation Count / NIH
+        // Percentile / RCR lines were silently absent from every impact prompt — the one signal the
+        // ReciterAI anchors calibrate on. ~200 PMIDs is two batched iCite GETs, free.
+        const withAbstracts = shortlistPmids.length
+            ? await withCitationMetrics(await fetchByPmids(shortlistPmids))
+            : []
 
         // TWO INDEPENDENT AXES, SCORED CONCURRENTLY. Relevance answers "is this paper about the
         // topic the librarian typed"; impact answers "how strong a paper is it, on its own terms".
@@ -903,6 +925,12 @@ async function handleM4Score(req: NextApiRequest, res: NextApiResponse, cwid: st
         }
         logCost('bibliometric-review:score', cwid, totalUsage, {
             shortlist: shortlistPmids.length, scored: scores.size, impactScored: imp.scores.size,
+            // OVERRIDES logCost's default `model` (the `...extra` spread lands after it). Both
+            // scoring calls are pinned to Sonnet (see SCORING_MODEL_ID's own comment in
+            // literatureSearch.llm.ts), not to BEDROCK_MODEL_ID — and the log line's whole value
+            // is that its tokens can be priced later BY ITS MODEL FIELD (see logCost's header),
+            // so a line that says Opus for a Sonnet call misprices every token on it.
+            model: SCORING_MODEL_ID,
         })
         return res.status(200).send({
             statusCode: 200,
@@ -927,7 +955,7 @@ async function handleM4Synthesize(req: NextApiRequest, res: NextApiResponse, cwi
         const corpus = parseM4Corpus(body.corpus)
         const clusters = parseM4Clusters(body.clusters)
         const scores = parseM4Scores(body.scores)
-        const impactJudged = parseM4Impact((body as any).impact)
+        const impactJudged = parseM4Impact(body.impact)
         const byPmid = new Map(corpus.map(r => [r.pmid, r]))
         const topic = String(question || '')
 
@@ -1033,6 +1061,9 @@ async function handleM4Synthesize(req: NextApiRequest, res: NextApiResponse, cwi
                 totalRecords: corpus.length,
                 fromYear: Number(body.fromYear) || new Date().getFullYear() - 10,
                 toYear: Number(body.toYear) || new Date().getFullYear(),
+                // The clock stays HERE, on the route — assembleNarrativeReview() is pure and
+                // pure-checked, so it takes the year as data rather than reading new Date() itself.
+                currentYear: new Date().getFullYear(),
             },
             clusters, narratives, hasCaseSeriesFlags,
         )
@@ -1096,7 +1127,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         mode, phase, question, criteria, seeds, dateId, typeId, sort, pmids, proceed, pico, databases,
         strategy: edited,
         // Mode 4 only.
-        evidenceTiers, caseSeries, corpus, clusters, scores, fromYear, toYear,
+        evidenceTiers, caseSeries, corpus, clusters, scores, impact, fromYear, toYear,
     } = req.body || {}
 
     // A seed is an identifier WITH A KIND (PMID or DOI), never a bare PMID — a Scopus-only record
@@ -1122,7 +1153,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const body: SearchBody = {
         mode, phase, question, criteria, seeds, dateId, typeId, sort, pmids, proceed, pico, databases, edited, seedList,
-        evidenceTiers, caseSeries, corpus, clusters, scores, fromYear, toYear,
+        evidenceTiers, caseSeries, corpus, clusters, scores, impact, fromYear, toYear,
     }
 
     // ---- SCREEN (Mode 2, phase 2). ------------------------------------------------------------


### PR DESCRIPTION
## What this is

The first live execution of Mode 4 rev 3 (merged in #871) against real Bedrock and PubMed surfaced four wiring bugs that no pure check could see, plus this fixes four open items from the 2026-08-19 output review ledger.

## Live-run findings (P1 unless noted)

- **Impact scores were silently dropped on the synthesize round-trip.** The route's body whitelist (`const { mode, phase, ... } = req.body` and the rebuilt `body` literal) never carried `impact`, so `parseM4Impact` always received `undefined` and all 192 model-judged impact scores vanished between the score phase and the final corpus. The xlsx `Impact score (0-100)` / `Impact justification` columns were empty on every row while `relevanceScore` (which was whitelisted) survived.
- **`evidenceBasis` never reached the decorated row** — `decorateCorpus` copied `prior.score` and `prior.justification` but dropped `prior.evidenceBasis`.
- **`apt` did not survive `parseM4Corpus`**, so the rev-3 apt fallback could never fire on the final output: every 2025–26 row landed on `tier-only`.
- **The scoring shortlist re-fetch never re-attached iCite metrics** (`fetchByPmids` alone returns none; only `fetchCorpus` applies `withCitationMetrics`), so `renderForImpact`'s Citation Count / NIH Percentile / RCR lines were absent from every impact prompt — the signal the ported ReciterAI anchors calibrate on.
- (P2) The score-phase usage log reported `BEDROCK_MODEL_ID` (Opus) while the calls ran on `SCORING_MODEL_ID` (Sonnet 5), mispricing the phase.
- (P2) Percentile trend labels printed raw float residue ("29.299999999999997th pct") and a fake ordinal.

## Ledger items (REVIEW-mode4-outputs-2026-08-19)

- **Issue 6** — cluster labels were named from MeSH alone by a model told it had not seen the papers; three shipped sections opened by disowning their own heading. `labelClusters` now also sees up to 8 sample titles per cluster and is told to believe titles over MeSH on disagreement.
- **Issue 10** — the eleven near-identical publications-per-year bars are demoted to one sentence plus a sparkline; the partial current year is drawn dashed, named as partial, and excluded from the trend word.
- **Issue 12** — `trendNote` excludes the partial current year from the earlier/later-half means, names the window it measured, and discloses the exclusion only when a partial year was actually present.
- **Issue 13** — narrative sections are prompted to 2–4 short paragraphs instead of one ~800-word block. Prompt-only change; every renderer already splits on blank lines.

## Verification

- `npx tsc --noEmit`, `npx next lint` (changed dirs), `npm run check:literature:pure` — all green; the pure check gained assertions for trendNote's current-year exclusion (leak flips the verdict; window naming; no false disclaimer).
- **Full live run on this branch** (NMB-reversal proxy topic, local dev + live Bedrock/PubMed/iCite): impact populated 192/192 with a 10–90 spread across 34 distinct values; `Evidence basis` splits `percentile` (2016–2024) / `apt` (2025–26) exactly as designed; score phase logs `us.anthropic.claude-sonnet-5`; no tool-call scaffolding in the docx; sections render as multiple paragraphs; sparkline + rounded medians confirmed in the UI.

## Deliberately not touched

- Ledger issue 7 (two non-discriminating buckets) and the `NARROW_LADDER_ABOVE` threshold — both are judgement calls the handoff wants decided with Dan Cook's real-topic numbers in hand.
- One observation for that discussion: on one live run the strategy came out broader (3,784 base records) and the ladder fired for the first time — with no seeds provided, its seed guard is vacuous, and the line it dropped was the residual-block/monitoring/reversal free-text line, i.e. the question's own core vocabulary. Disclosed in the UI exactly as designed, but worth a look before the real pilot topic runs.