### PR TITLE
Wire AAR scopus reject/dismiss/reopen to the durable FeedbackLog endpoint

### DIFF
--- a/config/local.js
+++ b/config/local.js
@@ -112,6 +112,12 @@ export const reciterConfig = {
         reciterExternalArticleEndpoint:
                 process.env.RECITER_API_BASE_URL + '/reciter/external-article/by/uid',
         /**
+         * External-article feedback (curator reject/dismiss/reopen, faculty dispute) —
+         * appends durable FeedbackLog rows on the Java side. Same ingress + admin api-key.
+         */
+        reciterExternalArticleFeedbackEndpoint:
+                process.env.RECITER_API_BASE_URL + '/reciter/external-article/feedback',
+        /**
          * This endpoints serves to do CRUD on user feedback. This is used to track the publication feedback in the application. When refreshed
          * the feedback is erased from the database.
          */

--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -4,7 +4,7 @@ import { getToken } from "next-auth/jwt";
 import models from "../../src/db/sequelize";
 import { reciterConfig } from "../../config/local";
 import { updatePendingArticleCount } from "./person.controller";
-import { addExternalArticle, deleteExternalArticle, recordExternalArticleFeedback } from "../externalArticle.controller";
+import { addExternalArticle, deleteExternalArticle, getExternalArticles, recordExternalArticleFeedback } from "../externalArticle.controller";
 
 // Columns returned to the Authorships tab (one row per unassigned WCM authorship).
 // Multi-source: `source`/`external_id`/`pub_type`/`container_id` drive the Scopus lane
@@ -289,14 +289,27 @@ function dupConflict(body: any): { blocked: boolean; message: string } {
 // Durable FeedbackLog write for a scopus row — the MySQL status column is overwritten on
 // every transition, so this is the only lasting record of a reject/dismiss/reopen (the
 // original AAR durability gap). Gates like writeGoldStandard: a failed write fails the
-// action, EXCEPT 404 (uid unknown to ReCiter — departed/inactive): the local queue action
-// is still valid for such a person, so note it and proceed. Returns false after replying.
+// action with 502 before the MySQL update. Two deliberate skip-and-proceed cases:
+// - the article is already live in the person's record (manual-add or the other env's
+//   queue — dev and prod share the ExternalArticle table): the queue action is pure
+//   housekeeping then, and a REJECTED row would both contradict the live accept and
+//   suppress the visible publication (the Java PATCH flips suppressed on existing rows);
+// - the uid is unknown to ReCiter (departed/inactive faculty): matched on the endpoint's
+//   INVALID body, not the bare 404, so an unrouted endpoint (e.g. not yet deployed) still
+//   fails loudly instead of silently disabling every write.
 async function logScopusFeedback(
   res: NextApiResponse, uid: string, externalId: any, action: "REJECTED" | "PENDING", actor: string,
 ): Promise<boolean> {
   if (!externalId) { console.log(`[authorships] feedback ${action} skipped — row has no external_id`); return true; }
-  const resp = await recordExternalArticleFeedback(uid, `SCOPUS:${externalId}`, action, actor);
-  if (resp.statusCode === 404) {
+  const articleId = `SCOPUS:${externalId}`;
+  const live = await getExternalArticles(uid);
+  if (live.statusCode === 200 && Array.isArray(live.statusText)
+      && (live.statusText as any[]).some((r: any) => r?.articleId === articleId)) {
+    console.log(`[authorships] feedback ${action} skipped — ${articleId} already live in ${uid}'s record`);
+    return true;
+  }
+  const resp = await recordExternalArticleFeedback(uid, articleId, action, actor);
+  if (resp.statusCode === 404 && (resp.statusText as any)?.status === "INVALID") {
     console.log(`[authorships] feedback ${action} skipped — ${uid} not in ReCiter Identity`);
     return true;
   }

--- a/controllers/db/authorships.controller.ts
+++ b/controllers/db/authorships.controller.ts
@@ -4,7 +4,7 @@ import { getToken } from "next-auth/jwt";
 import models from "../../src/db/sequelize";
 import { reciterConfig } from "../../config/local";
 import { updatePendingArticleCount } from "./person.controller";
-import { addExternalArticle, deleteExternalArticle } from "../externalArticle.controller";
+import { addExternalArticle, deleteExternalArticle, recordExternalArticleFeedback } from "../externalArticle.controller";
 
 // Columns returned to the Authorships tab (one row per unassigned WCM authorship).
 // Multi-source: `source`/`external_id`/`pub_type`/`container_id` drive the Scopus lane
@@ -286,6 +286,27 @@ function dupConflict(body: any): { blocked: boolean; message: string } {
   };
 }
 
+// Durable FeedbackLog write for a scopus row — the MySQL status column is overwritten on
+// every transition, so this is the only lasting record of a reject/dismiss/reopen (the
+// original AAR durability gap). Gates like writeGoldStandard: a failed write fails the
+// action, EXCEPT 404 (uid unknown to ReCiter — departed/inactive): the local queue action
+// is still valid for such a person, so note it and proceed. Returns false after replying.
+async function logScopusFeedback(
+  res: NextApiResponse, uid: string, externalId: any, action: "REJECTED" | "PENDING", actor: string,
+): Promise<boolean> {
+  if (!externalId) { console.log(`[authorships] feedback ${action} skipped — row has no external_id`); return true; }
+  const resp = await recordExternalArticleFeedback(uid, `SCOPUS:${externalId}`, action, actor);
+  if (resp.statusCode === 404) {
+    console.log(`[authorships] feedback ${action} skipped — ${uid} not in ReCiter Identity`);
+    return true;
+  }
+  if (resp.statusCode !== 200) {
+    res.status(502).send(`Feedback log write failed (${resp.statusCode})`);
+    return false;
+  }
+  return true;
+}
+
 // ExternalArticle payload for a scopus row (no PMID → not gold standard). articleId is
 // "SCOPUS:<numericId>" where numericId = external_id (dc:identifier minus SCOPUS_ID:).
 function scopusExternalPayload(row: any) {
@@ -387,7 +408,9 @@ export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse
         if (!cwid) return res.status(409).send("No proposed identity to reject");
         if (!row.single_candidate) return res.status(409).send("Multiple candidates — use \"Pick one\" to assign");
         if (isScopus) {
-          // scopus reject = local dismissal, never gold standard (no PMID to reject).
+          // scopus reject: never gold standard (no PMID), but durably logged as REJECTED
+          // in FeedbackLog — the actor being a curator is what marks it a curator reject.
+          if (!(await logScopusFeedback(res, cwid, row.external_id, "REJECTED", reviewer))) return;
           await models.AuthorshipReview.update({ status: "rejected", reviewer, resolved_at: new Date() }, { where: { id } });
           break;
         }
@@ -404,16 +427,27 @@ export const authorshipAction = async (req: NextApiRequest, res: NextApiResponse
         break;
       }
       case "dismiss": {
+        // Dismiss and reject are deliberately one REJECTED value in FeedbackLog (design
+        // decision, 2026-08-20). Only scopus rows with a proposed identity have a uid to
+        // log against; pmid dismisses stay queue-local (they never touch gold standard).
+        if (isScopus && cwid) {
+          if (!(await logScopusFeedback(res, cwid, row.external_id, "REJECTED", reviewer))) return;
+        }
         await models.AuthorshipReview.update({ status: "dismissed", reviewer, resolved_at: new Date() }, { where: { id } });
         break;
       }
       case "reopen": {
         const reverseCwid = row.resolution_cwid || cwid;
         if (isScopus) {
-          // undo a scopus accept/assign = revoke the ExternalArticle (reject/dismiss wrote none).
+          // undo a scopus accept/assign = revoke the ExternalArticle (reject/dismiss wrote
+          // none); the Java delete path logs PENDING with the actor passed here.
           if ((row.status === "accepted" || row.status === "assigned") && reverseCwid) {
-            const resp = await deleteExternalArticle(reverseCwid, `SCOPUS:${row.external_id}`);
+            const resp = await deleteExternalArticle(reverseCwid, `SCOPUS:${row.external_id}`, reviewer);
             if (resp.statusCode !== 200) return res.status(502).send(`ExternalArticle revoke failed (${resp.statusCode})`);
+          } else if ((row.status === "rejected" || row.status === "dismissed") && reverseCwid) {
+            // undo a scopus reject/dismiss: no row to restore, but the reopen belongs in
+            // the durable history (PENDING = back to no assertion).
+            if (!(await logScopusFeedback(res, reverseCwid, row.external_id, "PENDING", reviewer))) return;
           }
         } else if ((row.status === "accepted" || row.status === "assigned") && reverseCwid) {
           const gs = await writeGoldStandard(reverseCwid, pmid as number, "known", "DELETE", curator.userID);

--- a/controllers/externalArticle.controller.ts
+++ b/controllers/externalArticle.controller.ts
@@ -58,15 +58,37 @@ export async function addExternalArticle(uid: string, body: any, addedBy: string
         })
 }
 
-// DELETE (= revoke) an external article by articleId.
-export async function deleteExternalArticle(uid: string, articleId: string) {
-    return fetch(`${base()}?uid=${encodeURIComponent(uid)}&articleId=${encodeURIComponent(articleId)}`, {
+// DELETE (= revoke) an external article by articleId. actorPersonIdentifier (curator CWID
+// from the JWT, never the client) lets the Java side stamp its PENDING FeedbackLog row.
+export async function deleteExternalArticle(uid: string, articleId: string, actorPersonIdentifier?: string) {
+    let uri = `${base()}?uid=${encodeURIComponent(uid)}&articleId=${encodeURIComponent(articleId)}`
+    if (actorPersonIdentifier) uri += `&actorPersonIdentifier=${encodeURIComponent(actorPersonIdentifier)}`
+    return fetch(uri, {
         method: 'DELETE',
         headers: javaHeaders(),
     })
         .then(async (res) => ({ statusCode: res.status, statusText: await readBody(res) }))
         .catch((error) => {
             console.log('ReCiter external-article DELETE is not reachable: ' + error)
+            return { statusCode: error.status || 500, statusText: error }
+        })
+}
+
+// PATCH feedback (durable FeedbackLog row on the Java side): curator reject/dismiss log
+// REJECTED, reopen logs PENDING, dispute-retract/resolve log ACCEPTED — who acted is the
+// discriminator, so actorPersonIdentifier is stamped from the JWT, never the client.
+export async function recordExternalArticleFeedback(
+    uid: string, articleId: string, action: 'ACCEPTED' | 'REJECTED' | 'PENDING',
+    actorPersonIdentifier: string, note?: string,
+) {
+    return fetch(reciterConfig.reciter.reciterExternalArticleFeedbackEndpoint, {
+        method: 'PATCH',
+        headers: javaHeaders(),
+        body: JSON.stringify({ uid, articleId, action, actorPersonIdentifier, note }),
+    })
+        .then(async (res) => ({ statusCode: res.status, statusText: await readBody(res) }))
+        .catch((error) => {
+            console.log('ReCiter external-article feedback PATCH is not reachable: ' + error)
             return { statusCode: error.status || 500, statusText: error }
         })
 }


### PR DESCRIPTION
Closes the original AAR durability gap: scopus-row curator actions wrote only the mutable `authorship_review.status` column — overwritten on every transition, no lasting record of who rejected/dismissed what. They now also append rows to ReCiter's `FeedbackLog` table via the new `PATCH /reciter/external-article/feedback` (ReCiter #708, **already live on reciter-dev**; prod-line port is ReCiter #707).

- **reject / dismiss** → `REJECTED` (deliberately one value — the actor being a curator marks it a curator action; design record in the ReCiter Research repo's `docs/HANDOFF_2026-08-20_external-article-feedback-log.md`)
- **reopen** of a rejected/dismissed row → `PENDING`; reopen of an accepted/assigned row now passes the actor so the Java delete path stamps its `PENDING` row
- **accept/assign** need no change — the Java add path logs `ACCEPTED` (actor = `addedBy`) since #708
- **snooze** stays unlogged (pure scheduling, by design)

Gating mirrors `writeGoldStandard`: failed log write → 502 before the MySQL update; 404 (uid unknown to ReCiter, e.g. departed faculty) → console note and proceed, since the local queue action is still valid. PMID rows unchanged. The actor CWID is stamped server-side from the JWT (`reviewer`), never from the client.

Verified: `tsc --noEmit` clean; the Java endpoint itself is smoke-tested end-to-end on reciter-dev (full lifecycle on test uid `zzt9002`).