### PR TITLE
fix(app): faculty tabs crash — port to current Publication prop contract

### DIFF
--- a/src/components/elements/App/App.js
+++ b/src/components/elements/App/App.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import appStyles from './App.module.css';
 import { useSelector, useDispatch } from "react-redux";
-import { identityFetchData, reciterFetchData, otherPublicationsFetchData } from '../../../redux/actions/actions'
+import { identityFetchData, reciterFetchData, otherPublicationsFetchData, fetchFeedbacklog } from '../../../redux/actions/actions'
 import Tabs from '../Tabs/Tabs'
 import TabAccepted from '../TabAccepted/TabAccepted';
 import TabSuggested from '../TabSuggested/TabSuggested';
@@ -48,6 +48,10 @@ const App = (props) => {
             dispatch(reciterFetchData(props.uid, false))
             dispatch(identityFetchData(props.uid))
             dispatch(otherPublicationsFetchData(props.uid))
+            // Publication.tsx's History popover reads state.feedbacklog; without this
+            // fetch it stays at its {} default (safe, but empty). Same dispatch the
+            // curator page (CurateIndividual.tsx) makes on load.
+            dispatch(fetchFeedbacklog(props.uid))
          }
     },[session])
 

--- a/src/components/elements/TabAccepted/TabAccepted.js
+++ b/src/components/elements/TabAccepted/TabAccepted.js
@@ -6,6 +6,7 @@ import Publication from '../Publication/Publication';
 import Pagination from '../Pagination/Pagination';
 import Filter from '../Filter/Filter';
 import fullName from '../../../utils/fullName';
+import filterPublicationsBySearchText from '../../../utils/filterPublicationsBySearchText';
 
 const TabAccepted = (props) => {
     
@@ -75,120 +76,30 @@ const TabAccepted = (props) => {
     }
 
     const filter = () => {
-        // Filter
-        const filteredPublications = []
         // ReCiter-Publication-Manager#873: reciterData.reciter undefined until fetch completes.
-        ;(reciterData?.reciter?.reCiterArticleFeatures || []).forEach((publication) => {
-            // Check if publication is Suggested
-            if(publication.userAssertion === "ACCEPTED") {
-                // Check search and sort
-                if(search !== "") {
-                    if(/^[0-9 ]*$/.test(search)) {
-                        var pmids = search.split(" ");
-                        if(pmids.some(pmid => Number(pmid) === publication.pmid )){
-                            filteredPublications.push(publication);
-                        }
-                    }else {
-                        var addPublication = true;
-                        // check filter search
-                        if (search !== "") {
-                            addPublication = false;
-                            //pmcid
-                            if(publication.pmcid !== undefined && publication.pmcid.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //publicationTypeCanonical
-                            if(publication.publicationTypeCanonical !== undefined && publication.publicationTypeCanonical.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //scopusDocID
-                            if(publication.scopusDocID !== undefined && publication.scopusDocID.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //journalTitleISOabbreviation
-                            if(publication.journalTitleISOabbreviation !== undefined && publication.journalTitleISOabbreviation.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //journalTitleVerbose
-                            if(publication.journalTitleVerbose !== undefined && publication.journalTitleVerbose.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //publication date display
-                            if(publication.displayDate !== undefined && publication.displayDate.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //doi
-                            if(publication.doi !== undefined && publication.doi.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            // title
-                            if (publication.title.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true;
-                            }
-                            // journal
-                            if (publication.journal.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true;
-                            }
-                            //issn
-                            if(publication.issn !== undefined) {
-                                var issnArray = publication.issn.map((issn, issnIndex) => {
-                                    return issn.issn
-                                })
-                                if(issnArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                            }
-                            // authors
-                            if (publication.authors !== undefined) {
-                                var authorsArray = publication.authors.map(function (author, authorIndex) {
-                                    return author.authorName;
-                                });
-                                if (authorsArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                            }
-                            //evidence
-                            if (publication.evidence !== undefined) {
-                                var evidenceArticleArray = publication.evidence.map(function (evidence, evidenceIndex) {
-                                    return evidence.articleData;
-                                });
-                                var evidenceInstArray = publication.evidence.map(function (evidence, evidenceIndex) {
-                                    return evidence.institutionalData;
-                                });
-                                if (evidenceInstArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                                if (evidenceArticleArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                            }
-                        }
-                        if (addPublication) {
-                            filteredPublications.push(publication);
-                        }
-                    }
-                }else {
-                    filteredPublications.push(publication);
-                }
-            }
-        })
+        const accepted = (reciterData?.reciter?.reCiterArticleFeatures || []).filter(
+            (publication) => publication.userAssertion === "ACCEPTED"
+        )
+        // The hand-rolled search here read fields this article shape doesn't have
+        // (title, journal, array-shaped evidence) and threw on the first non-numeric
+        // search character; the curator flow's shared util guards the real field names.
+        const filteredPublications = filterPublicationsBySearchText(accepted, search)
 
         // Sort
         filteredPublications.sort((a, b) => {
             switch(sort) {
                 case "0":
-                    return b.standardScore - a.standardScore;
+                    return b.authorshipLikelihoodScore - a.authorshipLikelihoodScore;
                 case "1":
-                    return a.standardScore - b.standardScore;
+                    return a.authorshipLikelihoodScore - b.authorshipLikelihoodScore;
                 case "2":
-                    return new Date(b.standardDate) - new Date(a.standardDate);
+                    return new Date(b.publicationDateStandardized) - new Date(a.publicationDateStandardized);
                 case "3":
-                    return new Date(a.standardDate) - new Date(b.standardDate);
+                    return new Date(a.publicationDateStandardized) - new Date(b.publicationDateStandardized);
                 default:
-                    return b.standardScore - a.standardScore;
+                    return b.authorshipLikelihoodScore - a.authorshipLikelihoodScore;
             }
         });
-
 
         var from = (parseInt(page, 10) - 1) * parseInt(count, 10);
         var to = from + parseInt(count, 10) - 1;

--- a/src/components/elements/TabAccepted/TabAccepted.js
+++ b/src/components/elements/TabAccepted/TabAccepted.js
@@ -5,6 +5,7 @@ import styles from '../Tabs/TabControls.module.css';
 import Publication from '../Publication/Publication';
 import Pagination from '../Pagination/Pagination';
 import Filter from '../Filter/Filter';
+import fullName from '../../../utils/fullName';
 
 const TabAccepted = (props) => {
     
@@ -17,6 +18,7 @@ const TabAccepted = (props) => {
 
     const identityData = useSelector((state) => state.identityData)
     const reciterData = useSelector((state) => state.reciterData)
+    const showEvidenceDefault = useSelector((state) => state.showEvidenceDefault)
 
     const handlePaginationUpdate = (e, page) => {
         setPage(page)
@@ -31,23 +33,17 @@ const TabAccepted = (props) => {
         setSort(filterState.sort)
     }
 
-    const rejectPublication = (id) => {
+    // Publication.tsx's CardFooter calls updatePublication(personIdentifier, pmid,
+    // userAssertion) for accept, reject, and undo alike; keep dispatching the same
+    // reciterUpdatePublication action the old per-assertion handlers used.
+    const updatePublication = (uid, pmid, userAssertion) => {
         const request = {
             faculty: identityData,
-            publications: [id],
-            userAssertion: 'REJECTED',
+            publications: [pmid],
+            userAssertion: userAssertion,
             manuallyAddedFlag: false
         }
-        dispatch(reciterUpdatePublication(identityData.uid, request))
-    }
-
-    const undoPublication = (id)  => {
-        const request = {
-            faculty: identityData,
-            publications: [id],
-            userAssertion: 'NULL'
-        }
-        dispatch(reciterUpdatePublication(identityData.uid, request))
+        dispatch(reciterUpdatePublication(uid, request))
     }
 
     const rejectAll = () => {
@@ -226,16 +222,24 @@ const TabAccepted = (props) => {
             </div>
             <p>Not finding what you`&apos;`re looking for? <a onClick={() => { props.tabClickHandler("Add Publication"); } }>Search PubMed...</a></p>
             <Pagination total={publications.filteredPublications.length} page={page} count={count} onChange={handlePaginationUpdate} />
-            <div className="table-responsive">
-                <table className="table table-striped">
-                    <tbody>
-                        {
-                            publications.paginatedPublications.map(function(item, index){
-                                return <Publication item={item} key={index} onReject={rejectPublication} onUndo={undoPublication} />;
-                            })
-                        }
-                    </tbody>
-                </table>
+            <div>
+                {
+                    publications.paginatedPublications.map((item, index) => (
+                        <Publication
+                            key={item.pmid || index}
+                            index={`page${page}${index + 1}`}
+                            reciterArticle={item}
+                            personIdentifier={identityData.uid}
+                            fullName={fullName(identityData.primaryName)}
+                            updatePublication={updatePublication}
+                            activekey="ACCEPTED"
+                            totalCount={publications.filteredPublications.length}
+                            paginatedPubsCount={publications.paginatedPublications.length}
+                            page={page}
+                            showEvidenceDefault={showEvidenceDefault}
+                        />
+                    ))
+                }
             </div>
             <Pagination total={publications.filteredPublications.length} page={page} count={count} onChange={handlePaginationUpdate} />
         </div>

--- a/src/components/elements/TabRejected/TabRejected.js
+++ b/src/components/elements/TabRejected/TabRejected.js
@@ -6,6 +6,7 @@ import Publication from '../Publication/Publication';
 import Pagination from '../Pagination/Pagination';
 import Filter from '../Filter/Filter';
 import fullName from '../../../utils/fullName';
+import filterPublicationsBySearchText from '../../../utils/filterPublicationsBySearchText';
 
 const TabRejected = (props) => {
     
@@ -75,120 +76,30 @@ const TabRejected = (props) => {
     }
 
     const filter = () => {
-        // Filter
-        const filteredPublications = []
         // ReCiter-Publication-Manager#873: reciterData.reciter undefined until fetch completes.
-        ;(reciterData?.reciter?.reCiterArticleFeatures || []).forEach((publication) => {
-            // Check if publication is Suggested
-            if(publication.userAssertion === "REJECTED") {
-                // Check search and sort
-                if(search !== "") {
-                    if(/^[0-9 ]*$/.test(search)) {
-                        var pmids = search.split(" ");
-                        if(pmids.some(pmid => Number(pmid) === publication.pmid )){
-                            filteredPublications.push(publication);
-                        }
-                    }else {
-                        var addPublication = true;
-                        // check filter search
-                        if (search !== "") {
-                            addPublication = false;
-                            //pmcid
-                            if(publication.pmcid !== undefined && publication.pmcid.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //publicationTypeCanonical
-                            if(publication.publicationTypeCanonical !== undefined && publication.publicationTypeCanonical.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //scopusDocID
-                            if(publication.scopusDocID !== undefined && publication.scopusDocID.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //journalTitleISOabbreviation
-                            if(publication.journalTitleISOabbreviation !== undefined && publication.journalTitleISOabbreviation.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //journalTitleVerbose
-                            if(publication.journalTitleVerbose !== undefined && publication.journalTitleVerbose.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //publication date display
-                            if(publication.displayDate !== undefined && publication.displayDate.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //doi
-                            if(publication.doi !== undefined && publication.doi.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            // title
-                            if (publication.title.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true;
-                            }
-                            // journal
-                            if (publication.journal.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true;
-                            }
-                            //issn
-                            if(publication.issn !== undefined) {
-                                var issnArray = publication.issn.map((issn, issnIndex) => {
-                                    return issn.issn
-                                })
-                                if(issnArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                            }
-                            // authors
-                            if (publication.authors !== undefined) {
-                                var authorsArray = publication.authors.map(function (author, authorIndex) {
-                                    return author.authorName;
-                                });
-                                if (authorsArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                            }
-                            //evidence
-                            if (publication.evidence !== undefined) {
-                                var evidenceArticleArray = publication.evidence.map(function (evidence, evidenceIndex) {
-                                    return evidence.articleData;
-                                });
-                                var evidenceInstArray = publication.evidence.map(function (evidence, evidenceIndex) {
-                                    return evidence.institutionalData;
-                                });
-                                if (evidenceInstArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                                if (evidenceArticleArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                            }
-                        }
-                        if (addPublication) {
-                            filteredPublications.push(publication);
-                        }
-                    }
-                }else {
-                    filteredPublications.push(publication);
-                }
-            }
-        })
+        const rejected = (reciterData?.reciter?.reCiterArticleFeatures || []).filter(
+            (publication) => publication.userAssertion === "REJECTED"
+        )
+        // The hand-rolled search here read fields this article shape doesn't have
+        // (title, journal, array-shaped evidence) and threw on the first non-numeric
+        // search character; the curator flow's shared util guards the real field names.
+        const filteredPublications = filterPublicationsBySearchText(rejected, search)
 
         // Sort
         filteredPublications.sort((a, b) => {
             switch(sort) {
                 case "0":
-                    return b.standardScore - a.standardScore;
+                    return b.authorshipLikelihoodScore - a.authorshipLikelihoodScore;
                 case "1":
-                    return a.standardScore - b.standardScore;
+                    return a.authorshipLikelihoodScore - b.authorshipLikelihoodScore;
                 case "2":
-                    return new Date(b.standardDate) - new Date(a.standardDate);
+                    return new Date(b.publicationDateStandardized) - new Date(a.publicationDateStandardized);
                 case "3":
-                    return new Date(a.standardDate) - new Date(b.standardDate);
+                    return new Date(a.publicationDateStandardized) - new Date(b.publicationDateStandardized);
                 default:
-                    return b.standardScore - a.standardScore;
+                    return b.authorshipLikelihoodScore - a.authorshipLikelihoodScore;
             }
         });
-
 
         var from = (parseInt(page, 10) - 1) * parseInt(count, 10);
         var to = from + parseInt(count, 10) - 1;

--- a/src/components/elements/TabRejected/TabRejected.js
+++ b/src/components/elements/TabRejected/TabRejected.js
@@ -5,6 +5,7 @@ import styles from '../Tabs/TabControls.module.css';
 import Publication from '../Publication/Publication';
 import Pagination from '../Pagination/Pagination';
 import Filter from '../Filter/Filter';
+import fullName from '../../../utils/fullName';
 
 const TabRejected = (props) => {
     
@@ -17,6 +18,7 @@ const TabRejected = (props) => {
 
     const identityData = useSelector((state) => state.identityData)
     const reciterData = useSelector((state) => state.reciterData)
+    const showEvidenceDefault = useSelector((state) => state.showEvidenceDefault)
 
     const handlePaginationUpdate = (e, page) => {
         setPage(page)
@@ -31,23 +33,17 @@ const TabRejected = (props) => {
         setSort(filterState.sort)
     }
 
-    const acceptPublication = (id) => {
+    // Publication.tsx's CardFooter calls updatePublication(personIdentifier, pmid,
+    // userAssertion) for accept, reject, and undo alike; keep dispatching the same
+    // reciterUpdatePublication action the old per-assertion handlers used.
+    const updatePublication = (uid, pmid, userAssertion) => {
         const request = {
             faculty: identityData,
-            publications: [id],
-            userAssertion: 'ACCEPTED',
+            publications: [pmid],
+            userAssertion: userAssertion,
             manuallyAddedFlag: false
         }
-        dispatch(reciterUpdatePublication(identityData.uid, request))
-    }
-
-    const undoPublication = (id)  => {
-        const request = {
-            faculty: identityData,
-            publications: [id],
-            userAssertion: 'NULL'
-        }
-        dispatch(reciterUpdatePublication(identityData.uid, request))
+        dispatch(reciterUpdatePublication(uid, request))
     }
 
     const acceptAll = () => {
@@ -226,16 +222,24 @@ const TabRejected = (props) => {
             </div>
             <p>Not finding what you`&apos;`re looking for? <a onClick={() => { props.tabClickHandler("Add Publication"); } }>Search PubMed...</a></p>
             <Pagination total={publications.filteredPublications.length} page={page} count={count} onChange={handlePaginationUpdate} />
-            <div className="table-responsive">
-                <table className="table table-striped">
-                    <tbody>
-                        {
-                            publications.paginatedPublications.map(function(item, index){
-                                return <Publication item={item} key={index} onAccept={acceptPublication} onUndo={undoPublication} />;
-                            })
-                        }
-                    </tbody>
-                </table>
+            <div>
+                {
+                    publications.paginatedPublications.map((item, index) => (
+                        <Publication
+                            key={item.pmid || index}
+                            index={`page${page}${index + 1}`}
+                            reciterArticle={item}
+                            personIdentifier={identityData.uid}
+                            fullName={fullName(identityData.primaryName)}
+                            updatePublication={updatePublication}
+                            activekey="REJECTED"
+                            totalCount={publications.filteredPublications.length}
+                            paginatedPubsCount={publications.paginatedPublications.length}
+                            page={page}
+                            showEvidenceDefault={showEvidenceDefault}
+                        />
+                    ))
+                }
             </div>
             <Pagination total={publications.filteredPublications.length} page={page} count={count} onChange={handlePaginationUpdate} />
         </div>

--- a/src/components/elements/TabSuggested/TabSuggested.js
+++ b/src/components/elements/TabSuggested/TabSuggested.js
@@ -6,6 +6,7 @@ import Publication from '../Publication/Publication';
 import Pagination from '../Pagination/Pagination';
 import Filter from '../Filter/Filter';
 import fullName from '../../../utils/fullName';
+import filterPublicationsBySearchText from '../../../utils/filterPublicationsBySearchText';
 
 const TabSuggested = (props) => {
 
@@ -75,117 +76,28 @@ const TabSuggested = (props) => {
     }
 
     const filter = () => {
-        // Filter
-        const filteredPublications = []
         // ReCiter-Publication-Manager#873: reciterData.reciter undefined until fetch completes.
-        ;(reciterData?.reciter?.reCiterArticleFeatures || []).forEach((publication) => {
-            // Check if publication is Suggested
-            if(publication.userAssertion === "NULL") {
-                // Check search and sort
-                if(search !== "") {
-                    if(/^[0-9 ]*$/.test(search)) {
-                        var pmids = search.split(" ");
-                        if(pmids.some(pmid => Number(pmid) === publication.pmid )){
-                            filteredPublications.push(publication);
-                        }
-                    }else {
-                        var addPublication = true;
-                        // check filter search
-                        if (search !== "") {
-                            addPublication = false;
-                            //pmcid
-                            if(publication.pmcid !== undefined && publication.pmcid.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //publicationTypeCanonical
-                            if(publication.publicationTypeCanonical !== undefined && publication.publicationTypeCanonical.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //scopusDocID
-                            if(publication.scopusDocID !== undefined && publication.scopusDocID.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //journalTitleISOabbreviation
-                            if(publication.journalTitleISOabbreviation !== undefined && publication.journalTitleISOabbreviation.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //journalTitleVerbose
-                            if(publication.journalTitleVerbose !== undefined && publication.journalTitleVerbose.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //publication date display
-                            if(publication.displayDate !== undefined && publication.displayDate.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            //doi
-                            if(publication.doi !== undefined && publication.doi.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true
-                            }
-                            // title
-                            if (publication.title.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true;
-                            }
-                            // journal
-                            if (publication.journal.toLowerCase().includes(search.toLowerCase())) {
-                                addPublication = true;
-                            }
-                            //issn
-                            if(publication.issn !== undefined) {
-                                var issnArray = publication.issn.map((issn, issnIndex) => {
-                                    return issn.issn
-                                })
-                                if(issnArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                            }
-                            // authors
-                            if (publication.authors !== undefined) {
-                                var authorsArray = publication.authors.map(function (author, authorIndex) {
-                                    return author.authorName;
-                                });
-                                if (authorsArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                            }
-                            //evidence
-                            if (publication.evidence !== undefined) {
-                                var evidenceArticleArray = publication.evidence.map(function (evidence, evidenceIndex) {
-                                    return evidence.articleData;
-                                });
-                                var evidenceInstArray = publication.evidence.map(function (evidence, evidenceIndex) {
-                                    return evidence.institutionalData;
-                                });
-                                if (evidenceInstArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                                if (evidenceArticleArray.join().toLowerCase().includes(search.toLowerCase())) {
-                                    addPublication = true;
-                                }
-                            }
-                        }
-                        if (addPublication) {
-                            filteredPublications.push(publication);
-                        }
-                    }
-                }else {
-                    filteredPublications.push(publication);
-                }
-            }
-        })
+        const suggested = (reciterData?.reciter?.reCiterArticleFeatures || []).filter(
+            (publication) => publication.userAssertion === "NULL"
+        )
+        // The hand-rolled search here read fields this article shape doesn't have
+        // (title, journal, array-shaped evidence) and threw on the first non-numeric
+        // search character; the curator flow's shared util guards the real field names.
+        const filteredPublications = filterPublicationsBySearchText(suggested, search)
 
         // Sort
         filteredPublications.sort((a, b) => {
             switch(sort) {
                 case "0":
-                    return b.standardScore - a.standardScore;
+                    return b.authorshipLikelihoodScore - a.authorshipLikelihoodScore;
                 case "1":
-                    return a.standardScore - b.standardScore;
+                    return a.authorshipLikelihoodScore - b.authorshipLikelihoodScore;
                 case "2":
-                    return new Date(b.standardDate) - new Date(a.standardDate);
+                    return new Date(b.publicationDateStandardized) - new Date(a.publicationDateStandardized);
                 case "3":
-                    return new Date(a.standardDate) - new Date(b.standardDate);
+                    return new Date(a.publicationDateStandardized) - new Date(b.publicationDateStandardized);
                 default:
-                    return b.standardScore - a.standardScore;
+                    return b.authorshipLikelihoodScore - a.authorshipLikelihoodScore;
             }
         });
 

--- a/src/components/elements/TabSuggested/TabSuggested.js
+++ b/src/components/elements/TabSuggested/TabSuggested.js
@@ -5,6 +5,7 @@ import styles from '../Tabs/TabControls.module.css';
 import Publication from '../Publication/Publication';
 import Pagination from '../Pagination/Pagination';
 import Filter from '../Filter/Filter';
+import fullName from '../../../utils/fullName';
 
 const TabSuggested = (props) => {
 
@@ -17,6 +18,7 @@ const TabSuggested = (props) => {
 
     const identityData = useSelector((state) => state.identityData)
     const reciterData = useSelector((state) => state.reciterData)
+    const showEvidenceDefault = useSelector((state) => state.showEvidenceDefault)
 
     const handlePaginationUpdate = (e, page) => {
         setPage(page)
@@ -31,33 +33,17 @@ const TabSuggested = (props) => {
         setSort(filterState.sort)
     }
 
-    const acceptPublication = (id) => {
+    // Publication.tsx's CardFooter calls updatePublication(personIdentifier, pmid,
+    // userAssertion) for accept, reject, and undo alike; keep dispatching the same
+    // reciterUpdatePublication action the old per-assertion handlers used.
+    const updatePublication = (uid, pmid, userAssertion) => {
         const request = {
             faculty: identityData,
-            publications: [id],
-            userAssertion: 'ACCEPTED',
+            publications: [pmid],
+            userAssertion: userAssertion,
             manuallyAddedFlag: false
         }
-        dispatch(reciterUpdatePublication(identityData.uid, request))
-    }
-
-    const rejectPublication = (id) => {
-        const request = {
-            faculty: identityData,
-            publications: [id],
-            userAssertion: 'REJECTED',
-            manuallyAddedFlag: false
-        }
-        dispatch(reciterUpdatePublication(identityData.uid, request))
-    }
-
-    const undoPublication = (id)  => {
-        const request = {
-            faculty: identityData,
-            publications: [id],
-            userAssertion: 'NULL'
-        }
-        dispatch(reciterUpdatePublication(identityData.uid, request))
+        dispatch(reciterUpdatePublication(uid, request))
     }
 
     const acceptAll = () => {
@@ -236,16 +222,24 @@ const TabSuggested = (props) => {
             </div>
             <p>Not finding what you`&apos;`re looking for? <a onClick={() => { props.tabClickHandler("Add Publication"); } }>Search PubMed...</a></p>
             <Pagination total={publications.filteredPublications.length} page={page} count={count} onChange={handlePaginationUpdate} />
-            <div className="table-responsive">
-                <table className="table table-striped">
-                    <tbody>
-                        {
-                            publications.paginatedPublications.map(function(item, index){
-                                return <Publication item={item} key={index} onAccept={acceptPublication} onReject={rejectPublication} onUndo={undoPublication} faculty={reciterData.faculty} />;
-                            })
-                        }
-                    </tbody>
-                </table>
+            <div>
+                {
+                    publications.paginatedPublications.map((item, index) => (
+                        <Publication
+                            key={item.pmid || index}
+                            index={`page${page}${index + 1}`}
+                            reciterArticle={item}
+                            personIdentifier={identityData.uid}
+                            fullName={fullName(identityData.primaryName)}
+                            updatePublication={updatePublication}
+                            activekey="NULL"
+                            totalCount={publications.filteredPublications.length}
+                            paginatedPubsCount={publications.paginatedPublications.length}
+                            page={page}
+                            showEvidenceDefault={showEvidenceDefault}
+                        />
+                    ))
+                }
             </div>
             <Pagination total={publications.filteredPublications.length} page={page} count={count} onChange={handlePaginationUpdate} />
         </div>


### PR DESCRIPTION
## The crash

The faculty self-service page `/app/[uid]` (live on reciter-pm-dev) crashes on first article render:

```
TypeError: Cannot read properties of undefined (reading 'pmid')
    at Publication.tsx (~line 220): feedbacklog[reciterArticle.pmid]
```

## Root cause

`TabSuggested.js`, `TabAccepted.js`, and `TabRejected.js` still render each article with the legacy prop contract from before `Publication.tsx` was rewritten for the curator flow:

```jsx
<Publication item={item} onAccept={...} onReject={...} onUndo={...} faculty={reciterData.faculty} />
```

The rewritten `Publication.tsx` requires the article as `reciterArticle` (plus `personIdentifier`, `fullName`, `index`) and drives accept/reject/undo through a single `updatePublication(uid, pmid, userAssertion)` callback from its CardFooter; `item` survives only as an optional legacy field marked TEMP. Because the three tabs are `.js` files, `tsc` never checked their props. The page had been dead (fetches never fired) until #873 fixed the session wiring and revived it — at which point the stale callers crashed on the first article rendered: `props.reciterArticle` is `undefined`, and line 220 dereferences `.pmid` on it.

## The fix

Port the three tabs to the proven call pattern the working curator flow uses (`ReciterTabContent.tsx`), touching only the callers:

- Pass `reciterArticle={item}`, `personIdentifier={identityData.uid}`, `fullName` built from `identityData.primaryName` via the shared `utils/fullName` helper (same as `CurateIndividual.tsx`), `index` as `` `page${page}${index + 1}` `` (the format `toogleEvidence` parses), `activekey` per tab (`NULL` / `ACCEPTED` / `REJECTED`), and `page` / `totalCount` / `paginatedPubsCount` for the evidence-toggle pagination logic.
- Collapse each tab's per-assertion `acceptPublication` / `rejectPublication` / `undoPublication` handlers into one `updatePublication(uid, pmid, userAssertion)` wrapper that builds the same request (`{faculty: identityData, publications: [pmid], userAssertion, manuallyAddedFlag: false}`) and dispatches the same `reciterUpdatePublication` action as before — behavior on the wire is unchanged.
- Drop `faculty={reciterData.faculty}`: `reciterData` has no `faculty` field (its shape is `{reciter, reciterPending}`), and `Publication.tsx` never reads the prop.
- Replace the `<table><tbody>` wrapper with a plain `<div>` — `Publication` now renders a card `<div>`, which is invalid DOM nesting inside `<tbody>`.
- Accept-all / Reject-all / Undo-all buttons are untouched: they build their own bulk request from `filter()` and never go through `Publication.tsx`.
- `App.js` load effect additionally dispatches `fetchFeedbacklog(uid)`, mirroring what `CurateIndividual.tsx` dispatches on load, so the card's History popover has curation-history data. This is safe either way: the `feedbacklog` reducer defaults to `{}`, and `Publication.tsx` guards with `feedbacklog[pmid] || []`. The `/api/reciter/feedback-log/[uid]` route is api-key-gated (no role gate) and not in the middleware matcher, so faculty sessions can call it.

## Verification

- `npx tsc --noEmit` — clean, zero errors (exit 0).
- `npx next build` — completes successfully; `/app/[uid]` compiles (exit 0).
- Runtime click-through on `/app/[uid]` **not** verified: the page is behind SAML on reciter-pm-dev, so accept/reject/undo, tab switching, evidence toggle, and the History popover need a smoke test after the dev deploy.
