### PR TITLE
fix(literature): echo seeds on the M4 score and synthesize POSTs

### DIFF
--- a/src/components/elements/Literature/LiteratureSearch.tsx
+++ b/src/components/elements/Literature/LiteratureSearch.tsx
@@ -559,7 +559,10 @@ export default function LiteratureSearch() {
             const res = await fetch('/api/literature/search', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ mode, phase: 'm4-synthesize', question, corpus, clusters, scores, impact, fromYear, toYear }),
+                // `seeds` must ride every M4 phase POST, not just retrieve: the server re-derives
+                // the scoring shortlist from seedList each phase, and an absent seeds field makes
+                // seed-forcing silently no-op (seeds only got scored when tier rank admitted them).
+                body: JSON.stringify({ mode, phase: 'm4-synthesize', question, seeds, corpus, clusters, scores, impact, fromYear, toYear }),
             })
             const data = await res.json()
             if (!res.ok) {
@@ -587,7 +590,7 @@ export default function LiteratureSearch() {
             const res = await fetch('/api/literature/search', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ mode, phase: 'm4-score', question, criteria, corpus, clusters }),
+                body: JSON.stringify({ mode, phase: 'm4-score', question, criteria, seeds, corpus, clusters }),
             })
             const data = await res.json()
             if (!res.ok) {


### PR DESCRIPTION
One-file client fix, same bug family as #874's round-trip drops.

**What was wrong:** the `m4-score` and `m4-synthesize` POST bodies omitted `seeds`, so `parseSeeds()` built an empty `seedList` server-side and `preFilterForScoring`'s seed-forcing (added in rev 3 / #871) silently no-oped. A seed only got scored if its evidence tier earned it a shortlist slot anyway.

**Live evidence (5-seed airway-pharmacology run):** before — exactly the two non-meta-analysis seeds came back with no relevance or impact score; after — the shortlist grew 191 → 193 and all five seeds carry scores (relevance 1.00 each). Also observed working on the same run: the narrowing ladder took one step and `seedsRetrieved: 5` — the seed guard now actually gates because the seeds reach the server on every phase.

**Verification:** `tsc --noEmit` and `next lint` clean; full live Mode 4 run on this branch confirmed the before/after above. Server-side seed-forcing logic is untouched (already pure-checked); this only makes the client send the field the server was already reading.