### PR TITLE
fix(app): sort dropdown stuck open, stale filter callbacks, stray backticks

### DIFF
--- a/src/components/elements/Dropdown/Dropdown.tsx
+++ b/src/components/elements/Dropdown/Dropdown.tsx
@@ -94,7 +94,7 @@ const Dropdown: FunctionComponent<FuncProps> = (props) => {
             >
                 Sort by <span className={sortClass}>{sortBy}</span>
             </button>
-            <div className={`${styles.dropdownMenu} dropdown-menu-right ${isOpen ? " show" : ""}`} aria-labelledby="dropdownMenuButton">
+            <div className={`${styles.dropdownMenu} dropdown-menu dropdown-menu-right ${isOpen ? " show" : ""}`} aria-labelledby="dropdownMenuButton">
                 <span
                     className={(sortBy === "Score")?sortClass:""}
                     onClick={(event) => handleClick(event, "Score")}

--- a/src/components/elements/Filter/Filter.tsx
+++ b/src/components/elements/Filter/Filter.tsx
@@ -14,23 +14,17 @@ const Filter: FunctionComponent<FuncProps> = (props) => {
     const [sort, setSort] = useState<string>("0")
     const [search, setSearch] = useState<string>("")
 
+    // setState is async — pass the incoming value straight through instead of
+    // reading the state variable, which still holds the previous keystroke/sort.
     const handleSearchUpdate = (event: React.ChangeEvent<HTMLInputElement>) => {
         setSearch(event.target.value)
         if (props.isFrom === "pubMed") props.onSearch(event.target.value)
-        else onFilterUpdate()
-        
+        else props.onChange({ sort, search: event.target.value })
     }
 
     const handleSortUpdate = (sortValue: string) => {
         setSort(sortValue)
-        onFilterUpdate()
-    }
-
-    const onFilterUpdate = () => {
-        props.onChange({
-            sort,
-            search
-        })
+        props.onChange({ sort: sortValue, search })
     }
 
     return (

--- a/src/components/elements/TabAccepted/TabAccepted.js
+++ b/src/components/elements/TabAccepted/TabAccepted.js
@@ -131,7 +131,7 @@ const TabAccepted = (props) => {
                     onClick={rejectAll}
                 >Reject all on page</button>
             </div>
-            <p>Not finding what you`&apos;`re looking for? <a onClick={() => { props.tabClickHandler("Add Publication"); } }>Search PubMed...</a></p>
+            <p>Not finding what you&apos;re looking for? <a onClick={() => { props.tabClickHandler("Add Publication"); } }>Search PubMed...</a></p>
             <Pagination total={publications.filteredPublications.length} page={page} count={count} onChange={handlePaginationUpdate} />
             <div>
                 {

--- a/src/components/elements/TabRejected/TabRejected.js
+++ b/src/components/elements/TabRejected/TabRejected.js
@@ -131,7 +131,7 @@ const TabRejected = (props) => {
                     onClick={acceptAll}
                 >Accept all on page</button>
             </div>
-            <p>Not finding what you`&apos;`re looking for? <a onClick={() => { props.tabClickHandler("Add Publication"); } }>Search PubMed...</a></p>
+            <p>Not finding what you&apos;re looking for? <a onClick={() => { props.tabClickHandler("Add Publication"); } }>Search PubMed...</a></p>
             <Pagination total={publications.filteredPublications.length} page={page} count={count} onChange={handlePaginationUpdate} />
             <div>
                 {

--- a/src/components/elements/TabSuggested/TabSuggested.js
+++ b/src/components/elements/TabSuggested/TabSuggested.js
@@ -132,7 +132,7 @@ const TabSuggested = (props) => {
                     onClick={rejectAll}
                 >Reject all on page</button>
             </div>
-            <p>Not finding what you`&apos;`re looking for? <a onClick={() => { props.tabClickHandler("Add Publication"); } }>Search PubMed...</a></p>
+            <p>Not finding what you&apos;re looking for? <a onClick={() => { props.tabClickHandler("Add Publication"); } }>Search PubMed...</a></p>
             <Pagination total={publications.filteredPublications.length} page={page} count={count} onChange={handlePaginationUpdate} />
             <div>
                 {


### PR DESCRIPTION
Follow-up to #876, from the first real click-through of the revived faculty page (/app/[uid]).

## What

- **Sort dropdown rendered permanently expanded** — the menu div in `Dropdown.tsx` had `dropdown-menu-right` and toggled `show`, but was missing Bootstrap's base `dropdown-menu` class, so it never had `display:none` when closed. One-word fix. (This component exists in a single commit — "add app page" — and had never executed until #873 revived the page.)
- **Filter callbacks reported stale state** — `Filter.tsx` called `onChange` reading the `sort`/`search` state variables immediately after `setState`, so every search keystroke and sort click reported the *previous* value. Now passes the incoming value through.
- **Literal backticks** in the tabs' "Not finding what you`'`re looking for?" text.

## Verification

- `npx tsc --noEmit` clean; `npx next build` clean.
- Only importer of `Dropdown.tsx` is `Filter.tsx` (faculty tabs only), so no curator-flow surface is touched.
- Live click-through of the dropdown open/close still needs the dev deploy (SAML-walled).