### PR TITLE
Faculty dispute actions in the per-source external-publication tabs

### DIFF
--- a/controllers/db/notifications/externalArticleDispute.controller.ts
+++ b/controllers/db/notifications/externalArticleDispute.controller.ts
@@ -1,0 +1,74 @@
+import models from '../../../src/db/sequelize'
+import { sendEmailNotification } from '../../../src/utils/emailUtilityHelper'
+
+// Decision 7 (docs/README-other-publications-tab.md): curator discovery of a faculty
+// dispute is push, not pull. When a non-curator logs a REJECTED on an external row,
+// email the curator who added it (the row's addedBy CWID -> admin_users.email) and
+// append an admin_notification_log row — same infra as the accepted/suggested digest,
+// new event type. No new subsystem; the digest stored proc is publication-specific,
+// so this calls sendEmailNotification directly (like sendNotifiationPrefEmail does).
+//
+// Failures here must never fail the dispute itself: every skip logs and returns.
+// Note: admin_notification_log.pmid is INTEGER — a "SCOPUS:..." articleId does not fit,
+// so the article reference travels in the email body and the FeedbackLog row instead.
+
+const escapeHtml = (value: any): string => String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+
+export async function notifyExternalArticleDisputed(params: {
+    uid: string,
+    articleId: string,
+    title?: string,
+    actorPersonIdentifier: string,
+    addedBy: string,
+    note?: string,
+    origin?: string,
+}): Promise<void> {
+    const { uid, articleId, title, actorPersonIdentifier, addedBy, note, origin } = params
+
+    const adminUser: any = await models.AdminUser.findOne({
+        where: { personIdentifier: addedBy },
+        attributes: ['userID', 'email'],
+    })
+    if (!adminUser || !adminUser.email) {
+        console.log(`[external-article] dispute notification skipped — no admin user email for addedBy ${addedBy}`)
+        return
+    }
+
+    const fromAddress = process.env.NODE_ENV === 'production'
+        ? '"Reciter Pub Manager" <publications@med.cornell.edu>'
+        : '"Reciter Pub Manager Test" <doNotReply@med.cornell.edu>'
+
+    const curateLink = origin ? `${origin}/curate/${encodeURIComponent(uid)}` : ''
+    const emailBody = `<div style="font-family: Arial; font-size: 11pt">
+        <p>${escapeHtml(actorPersonIdentifier)} has disputed an external publication that was added to ${escapeHtml(uid)}'s profile:</p>
+        <p><b>${escapeHtml(title || articleId)}</b><br/>ID: ${escapeHtml(articleId)}</p>
+        ${note ? `<p>Note from ${escapeHtml(actorPersonIdentifier)}: &ldquo;${escapeHtml(note)}&rdquo;</p>` : ''}
+        <p>The publication is now hidden from the profile and flagged for curator review.${curateLink
+            ? ` Review it at <a href="${escapeHtml(curateLink)}" style="text-decoration:none" target="_blank">${escapeHtml(curateLink)}</a>.`
+            : ''}</p>
+    </div>`
+
+    const sent = await sendEmailNotification({
+        from: fromAddress,
+        to: adminUser.email,
+        subject: `Disputed external publication on ${uid}'s profile`,
+        html: emailBody,
+    })
+    if (!sent) {
+        console.error(`[external-article] dispute notification email to ${adminUser.email} failed for ${articleId}`)
+        return
+    }
+
+    // Log only after a successful send, matching saveNotificationsLog.
+    await models.AdminNotificationLog.create({
+        userID: adminUser.userID,
+        email: adminUser.email,
+        dateSent: new Date(),
+        createTimestamp: new Date(),
+        notificationType: 'ExternalArticleDisputed',
+    })
+}

--- a/controllers/db/notifications/externalArticleDispute.controller.ts
+++ b/controllers/db/notifications/externalArticleDispute.controller.ts
@@ -25,9 +25,8 @@ export async function notifyExternalArticleDisputed(params: {
     actorPersonIdentifier: string,
     addedBy: string,
     note?: string,
-    origin?: string,
 }): Promise<void> {
-    const { uid, articleId, title, actorPersonIdentifier, addedBy, note, origin } = params
+    const { uid, articleId, title, actorPersonIdentifier, addedBy, note } = params
 
     const adminUser: any = await models.AdminUser.findOne({
         where: { personIdentifier: addedBy },
@@ -42,7 +41,11 @@ export async function notifyExternalArticleDisputed(params: {
         ? '"Reciter Pub Manager" <publications@med.cornell.edu>'
         : '"Reciter Pub Manager Test" <doNotReply@med.cornell.edu>'
 
-    const curateLink = origin ? `${origin}/curate/${encodeURIComponent(uid)}` : ''
+    // Server-configured base only — never the request's Origin header, which the
+    // client controls and would let a forged request plant an arbitrary URL in an
+    // email the curator is told to click.
+    const baseUrl = (process.env.NEXTAUTH_URL || '').replace(/\/+$/, '')
+    const curateLink = baseUrl ? `${baseUrl}/curate/${encodeURIComponent(uid)}` : ''
     const emailBody = `<div style="font-family: Arial; font-size: 11pt">
         <p>${escapeHtml(actorPersonIdentifier)} has disputed an external publication that was added to ${escapeHtml(uid)}'s profile:</p>
         <p><b>${escapeHtml(title || articleId)}</b><br/>ID: ${escapeHtml(articleId)}</p>

--- a/src/components/elements/CurateIndividual/ExternalPublicationCard.module.css
+++ b/src/components/elements/CurateIndividual/ExternalPublicationCard.module.css
@@ -297,3 +297,157 @@
 .btnReject:hover {
     background: #f1f3f7;
 }
+
+/* Faculty dispute lifecycle (docs/README-other-publications-tab.md). The left rail
+   mirrors Publication.tsx's statusStrip convention, keyed by dispute state; the row
+   stays in its own source tab, struck through + muted, never moved to another list. */
+.cardDisputed {
+    border-left: 3px solid #dc2626;
+}
+
+.cardDisputed .title {
+    text-decoration: line-through;
+    text-decoration-color: #dc2626;
+    color: #8a94a6;
+}
+
+.cardDisputed .authors,
+.cardDisputed .meta {
+    color: #a9b1c2;
+}
+
+.disputedTag {
+    font-size: 11px;
+    font-weight: 700;
+    color: #b91c1c;
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 10px;
+    padding: 2px 8px;
+}
+
+.selfTag {
+    font-size: 11px;
+    font-weight: 600;
+    color: #3538cd;
+    background: #eef2ff;
+    border: 1px solid #c7d2fe;
+    border-radius: 10px;
+    padding: 2px 8px;
+}
+
+.disputedNote {
+    margin-top: 6px;
+    font-size: 12px;
+    color: #b45309;
+}
+
+.btnDispute {
+    border: 1px solid #cbd3e0;
+    background: #fff;
+    color: #b31b1b;
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.btnDispute:hover {
+    background: #fdecec;
+    border-color: #fdecec;
+}
+
+.btnDispute:disabled {
+    color: #d9a0a0;
+    cursor: default;
+}
+
+/* Reversible, compact — mirrors Publication.tsx's "Accepted — Undo" pattern */
+.btnUndoDispute {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border: 1px solid #fecaca;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.btnUndoDispute:hover {
+    filter: brightness(0.97);
+}
+
+.btnUndoDispute:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
+.disputeForm {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px dashed #e3e8ef;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.disputeTextarea {
+    width: 100%;
+    font: inherit;
+    font-size: 12.5px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    border: 1px solid #cbd3e0;
+    background: #f7f8fa;
+    color: #1f2733;
+    resize: vertical;
+    min-height: 44px;
+}
+
+.disputeFormRow {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.btnGhost {
+    border: 1px solid #cbd3e0;
+    background: transparent;
+    color: #55607a;
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.btnGhost:hover {
+    background: #f1f3f7;
+}
+
+.btnSolid {
+    border: none;
+    background: #b31b1b;
+    color: #fff;
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 6px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.btnSolid:hover {
+    background: #991616;
+}
+
+.btnSolid:disabled {
+    background: #e3a1a1;
+    cursor: default;
+}

--- a/src/components/elements/CurateIndividual/ExternalPublicationCard.tsx
+++ b/src/components/elements/CurateIndividual/ExternalPublicationCard.tsx
@@ -1,7 +1,8 @@
-import React, { FunctionComponent } from "react"
+import React, { FunctionComponent, useState } from "react"
 import styles from './ExternalPublicationCard.module.css'
 import CheckIcon from '@mui/icons-material/Check'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import UndoIcon from '@mui/icons-material/Undo'
 
 // PM#771 — a source-badged external publication row. Deliberately NO authorship
 // score tile (external pubs are not scored by ReCiter). Two modes:
@@ -10,6 +11,12 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 //               we steer the curator to the scored PubMed path instead of adding an
 //               unscored external record.
 //   'list'    — an already-added external pub, with a Delete (= revoke) affordance
+//               for curators, and (when onDispute/onRetractDispute are wired) the
+//               faculty dispute lifecycle from docs/README-other-publications-tab.md:
+//               "This isn't mine" -> inline note form -> Disputed state -> Undo.
+// Suppression has two distinct causes (Decision 5/6): superseded (suppressed with a
+// supersededByPmid — a duplicate of an accepted PubMed record, muted) and disputed
+// (suppressed with NO supersededByPmid — struck through, red rail, reversible).
 const doiUrl = 'https://doi.org/'
 const pubMedUrl = 'https://www.ncbi.nlm.nih.gov/pubmed/'
 
@@ -58,6 +65,14 @@ interface FuncProps {
     // Option C (docs/README-other-publications-tab.md, Decision 3): the active source
     // tab already names the source, so the per-card badge is redundant there.
     hideSourceBadge?: boolean,
+    // Faculty dispute lifecycle (list mode). Dispute logs REJECTED, retract logs
+    // ACCEPTED — both via the PM PATCH route, which stamps the actor server-side.
+    onDispute?: (articleId: string, note?: string) => void,
+    onRetractDispute?: (articleId: string) => void,
+    disputeBusy?: boolean,
+    // The signed-in viewer's CWID, for the Decision 4 split: a row the viewer added
+    // themselves shows "Added by you" and no dispute affordance.
+    viewerUid?: string,
 }
 
 // Map the server's duplicate match type(s) to a state-specific, actionable headline.
@@ -76,6 +91,9 @@ function blockedHeadline(matches?: Array<{ type?: string }>): string {
 const ExternalPublicationCard: FunctionComponent<FuncProps> = (props) => {
     const { item, mode, addState } = props
 
+    const [disputeFormOpen, setDisputeFormOpen] = useState(false)
+    const [disputeNote, setDisputeNote] = useState('')
+
     const sourceType: string = item.sourceType || 'OPENALEX'
     const sourceLabel = SOURCE_LABELS[sourceType] || sourceType
 
@@ -93,7 +111,22 @@ const ExternalPublicationCard: FunctionComponent<FuncProps> = (props) => {
     const doi = item.doi
     const pmid = item.pmid
     const suppressed = mode === 'list' && !!item.suppressed
+    // Two suppression causes (Decision 5/6): a superseding PMID means "duplicate of an
+    // accepted PubMed record" (hideable); no superseding PMID means the row is disputed
+    // (must stay visible and reversible — the Java PATCH clears supersededByPmid on REJECTED).
+    const superseded = suppressed && item.supersededByPmid != null
+    const disputed = suppressed && item.supersededByPmid == null
+    const selfAdded = mode === 'list' && !!(props.viewerUid && item.addedBy && String(item.addedBy) === props.viewerUid)
     const status = addState?.status || 'idle'
+
+    const submitDispute = () => {
+        if (props.onDispute) {
+            const note = disputeNote.trim()
+            props.onDispute(item.articleId, note ? note : undefined)
+        }
+        setDisputeFormOpen(false)
+        setDisputeNote('')
+    }
 
     // The work is in PubMed if OpenAlex gave us a PMID, or a DOI lookup found one.
     // In that case steer to the scored PubMed path rather than an unscored external add.
@@ -105,16 +138,18 @@ const ExternalPublicationCard: FunctionComponent<FuncProps> = (props) => {
     const recStatus = (pubmedPmid && props.recordStatusOf) ? props.recordStatusOf(pubmedPmid) : null
 
     return (
-        <div className={`${styles.card} ${suppressed ? styles.cardSuppressed : ''}`}>
+        <div className={`${styles.card} ${superseded ? styles.cardSuppressed : ''} ${disputed ? styles.cardDisputed : ''}`}>
             <div className={styles.main}>
                 <div className={styles.headerRow}>
                     {!props.hideSourceBadge && <span className={styles.sourceBadge}>{sourceLabel}</span>}
                     <span className={styles.noScoreBadge}>No authorship score</span>
-                    {suppressed && (
+                    {selfAdded && <span className={styles.selfTag}>Added by you</span>}
+                    {superseded && (
                         <span className={styles.suppressedTag}>
-                            Superseded{item.supersededByPmid ? ` by PMID ${item.supersededByPmid}` : ''}
+                            Superseded by PMID {item.supersededByPmid}
                         </span>
                     )}
+                    {disputed && <span className={styles.disputedTag}>Disputed</span>}
                 </div>
 
                 <div className={styles.title}>{item.title || '(untitled)'}</div>
@@ -138,6 +173,40 @@ const ExternalPublicationCard: FunctionComponent<FuncProps> = (props) => {
                             : item.articleId}</span>
                     )}
                 </div>
+
+                {/* Disputed caption (faculty view only) — plain-language suppression meaning */}
+                {disputed && props.onRetractDispute && (
+                    <div className={styles.disputedNote}>
+                        Disputed &mdash; hidden from your profile, flagged for curator review
+                    </div>
+                )}
+
+                {/* Inline dispute form: optional note to the curator, then Submit */}
+                {mode === 'list' && !disputed && disputeFormOpen && props.onDispute && (
+                    <div className={styles.disputeForm}>
+                        <textarea
+                            className={styles.disputeTextarea}
+                            placeholder={'Optional note for the curator (e.g. “different Dana Reyes, not me”)'}
+                            value={disputeNote}
+                            onChange={(e) => setDisputeNote(e.target.value)}
+                        />
+                        <div className={styles.disputeFormRow}>
+                            <button
+                                className={styles.btnGhost}
+                                onClick={() => { setDisputeFormOpen(false); setDisputeNote('') }}
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                className={styles.btnSolid}
+                                disabled={props.disputeBusy}
+                                onClick={submitDispute}
+                            >
+                                {props.disputeBusy ? 'Submitting…' : 'Submit'}
+                            </button>
+                        </div>
+                    </div>
+                )}
 
                 {/* Already in this person's record — inform, no add */}
                 {mode === 'preview' && pubmedPmid && recStatus && status !== 'added' && (
@@ -239,6 +308,27 @@ const ExternalPublicationCard: FunctionComponent<FuncProps> = (props) => {
                         onClick={() => props.onDelete && props.onDelete(item.articleId)}
                     >
                         <DeleteOutlineIcon style={{ fontSize: 15 }} /> Delete
+                    </button>
+                )}
+                {/* Faculty dispute lifecycle — one affordance at a time (mockup): idle rows
+                    get "This isn't mine"; disputed rows get a single reversible Undo. A row
+                    the viewer added themselves gets neither (Remove is a future item). */}
+                {mode === 'list' && disputed && props.onRetractDispute && (
+                    <button
+                        className={styles.btnUndoDispute}
+                        disabled={props.disputeBusy}
+                        onClick={() => props.onRetractDispute && props.onRetractDispute(item.articleId)}
+                    >
+                        <UndoIcon style={{ fontSize: 14 }} /> Disputed &mdash; Undo
+                    </button>
+                )}
+                {mode === 'list' && !disputed && !superseded && !selfAdded && props.onDispute && (
+                    <button
+                        className={styles.btnDispute}
+                        disabled={props.disputeBusy}
+                        onClick={() => setDisputeFormOpen((open) => !open)}
+                    >
+                        This isn&rsquo;t mine
                     </button>
                 )}
             </div>

--- a/src/components/elements/TabExternalSource/TabExternalSource.tsx
+++ b/src/components/elements/TabExternalSource/TabExternalSource.tsx
@@ -1,13 +1,16 @@
-import React, { FunctionComponent } from "react"
-import { useSelector } from "react-redux"
+import React, { FunctionComponent, useState } from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { useSession } from "next-auth/react"
 import ExternalPublicationCard from "../CurateIndividual/ExternalPublicationCard"
+import { otherPublicationsFetchData } from "../../../redux/actions/actions"
+import { reciterConfig } from "../../../../config/local"
 
 // Option C (docs/README-other-publications-tab.md) — one parameterized tab component
 // per live source (Scopus, OpenAlex — Manual Add stays a deferred placeholder), all
 // reading the single otherPublicationsData redux slice App.js already fetches. Faculty
-// self-service is read-only for now: reject/feedback actions land later via the
-// FeedbackLog-based Java endpoint; Delete stays the curator's action in
-// TabAddExternalPublication.tsx.
+// dispute actions ("This isn't mine" -> REJECTED, Undo -> ACCEPTED) go through the PM
+// PATCH route, which stamps the actor from the session server-side; Delete stays the
+// curator's action in TabAddExternalPublication.tsx.
 
 interface FuncProps {
     uid: string,
@@ -17,19 +20,72 @@ interface FuncProps {
 const wrap: React.CSSProperties = { padding: "8px 0 24px" }
 const helpText: React.CSSProperties = { fontSize: 12.5, color: "#8a94a6", marginBottom: 12 }
 const emptyText: React.CSSProperties = { fontSize: 13, color: "#8a94a6", padding: "8px 0" }
+const errorText: React.CSSProperties = { fontSize: 12.5, color: "#b31b1b", marginBottom: 10 }
 
-// A row belongs on this tab unless it's suppressed (a duplicate of an accepted
-// PubMed record, per the supersede rule).
+// Disputed = suppressed with no superseding PMID (the Java PATCH clears
+// supersededByPmid on REJECTED, so the two suppression causes never mix).
+const isDisputed = (row: any) => !!row.suppressed && row.supersededByPmid == null
+
+// A row belongs on this tab unless it's superseded (suppressed as a duplicate of an
+// accepted PubMed record). A dispute-suppressed row still renders — in the disputed
+// state, so the faculty member can undo it (Decision 5/6).
 const visibleFor = (rows: any[], source: string) => rows.filter((row) =>
-    row.sourceType === source && !row.suppressed
+    row.sourceType === source && !(row.suppressed && row.supersededByPmid != null)
 )
 
 const TabExternalSource: FunctionComponent<FuncProps> = (props) => {
-    const { source } = props
+    const { uid, source } = props
+    const dispatch = useDispatch()
+    const { data: session } = useSession() as any
+    const viewerUid = session?.data?.username ? String(session.data.username) : undefined
+
     const otherPublicationsData = useSelector((state: any) => state.otherPublicationsData)
     const otherPublicationsFetching = useSelector((state: any) => state.otherPublicationsFetching)
 
+    const [busyId, setBusyId] = useState<string | null>(null)
+    const [error, setError] = useState<string>("")
+
+    // Dispute (REJECTED) / retract (ACCEPTED) via the PM PATCH route. The actor is
+    // resolved from the session server-side — nothing identity-bearing leaves here.
+    // On success the slice is refetched (there is no per-row OTHERPUBS update method);
+    // on failure the error surfaces in the tab — never a silent success.
+    const sendFeedback = (articleId: string, action: 'REJECTED' | 'ACCEPTED', note?: string) => {
+        setBusyId(articleId)
+        setError("")
+        fetch('/api/reciter/external-article/' + uid, {
+            credentials: "same-origin",
+            method: 'PATCH',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                'Authorization': reciterConfig.backendApiKey,
+            },
+            body: JSON.stringify(note ? { articleId, action, note } : { articleId, action }),
+        })
+            .then(async (response) => {
+                if (response.status !== 200) {
+                    let message = ''
+                    try {
+                        const body = await response.json()
+                        if (typeof body?.message === 'string') message = body.message
+                    } catch (e) { /* no readable body */ }
+                    throw new Error(message || `Request failed (${response.status})`)
+                }
+                dispatch(otherPublicationsFetchData(uid))
+            })
+            .catch((err: any) => {
+                const detail = err?.message ? ` — ${err.message}` : ''
+                setError(action === 'REJECTED'
+                    ? `Could not record the dispute${detail}. Please try again.`
+                    : `Could not undo the dispute${detail}. Please try again.`)
+            })
+            .finally(() => setBusyId(null))
+    }
+
+    // Disputed rows sink below active rows in the same tab, stable otherwise — they
+    // never move to another tab or list (mockup's sortForDisplay).
     const rows = visibleFor(otherPublicationsData || [], source)
+        .sort((a, b) => (isDisputed(a) ? 1 : 0) - (isDisputed(b) ? 1 : 0))
 
     const sourceLabel = source === 'SCOPUS' ? 'Scopus' : 'OpenAlex'
 
@@ -38,6 +94,7 @@ const TabExternalSource: FunctionComponent<FuncProps> = (props) => {
             <p style={helpText}>
                 Publications added from {sourceLabel}. These are not scored by ReCiter.
             </p>
+            {error && <div style={errorText}>{error}</div>}
             {otherPublicationsFetching ? (
                 <div style={emptyText}>Loading…</div>
             ) : rows.length === 0 ? (
@@ -49,6 +106,10 @@ const TabExternalSource: FunctionComponent<FuncProps> = (props) => {
                         item={row}
                         mode="list"
                         hideSourceBadge
+                        viewerUid={viewerUid}
+                        disputeBusy={busyId === row.articleId}
+                        onDispute={(articleId, note) => sendFeedback(articleId, 'REJECTED', note)}
+                        onRetractDispute={(articleId) => sendFeedback(articleId, 'ACCEPTED')}
                     />
                 ))
             )}

--- a/src/components/elements/Tabs/Tabs.js
+++ b/src/components/elements/Tabs/Tabs.js
@@ -7,10 +7,12 @@ import styles from './Tabs.module.css';
 // tab. "PubMed" is an inline label scoped to just Accepted/Suggested/Rejected — the
 // source cluster after the divider stays unlabeled on purpose (Decision 2/3).
 
-// A row counts toward its source tab unless it's suppressed (a duplicate of an
-// accepted PubMed record, per the supersede rule) — matching what the tab renders.
+// A row counts toward its source tab unless it's superseded (suppressed as a duplicate
+// of an accepted PubMed record) — matching what the tab renders. Dispute-suppressed
+// rows (suppressed with no superseding PMID) still render in the disputed state, so
+// they still count.
 const countBySource = (rows, sourceType) => rows.filter((row) =>
-    row.sourceType === sourceType && !row.suppressed
+    row.sourceType === sourceType && !(row.suppressed && row.supersededByPmid != null)
 ).length
 
 const Tabs = (props) => {

--- a/src/pages/api/reciter/external-article/[uid].ts
+++ b/src/pages/api/reciter/external-article/[uid].ts
@@ -125,6 +125,23 @@ export default async function handler(
             }
             const noteText = typeof note === 'string' && note.trim() ? note.trim() : undefined
 
+            // Snapshot the live row BEFORE the write: addedBy for the Decision-7
+            // notification, and the pre-write suppressed state so only the first
+            // REJECTED transition notifies — a repeat dispute of an already-suppressed
+            // row must not email the curator again. Best-effort: a failed read just
+            // means no notification, never a failed dispute.
+            let preRow: any = undefined
+            if (action === 'REJECTED') {
+                try {
+                    const live = await getExternalArticles(uid)
+                    preRow = live.statusCode === 200 && Array.isArray(live.statusText)
+                        ? (live.statusText as any[]).find((r: any) => r?.articleId === articleId)
+                        : undefined
+                } catch (e) {
+                    console.error('[external-article] pre-write row lookup failed (dispute proceeds, notification skipped):', e)
+                }
+            }
+
             const apiResponse = await recordExternalArticleFeedback(uid, articleId, action, actor, noteText)
             // Mirrors logScopusFeedback's status handling, but fails loud in both cases:
             // here the FeedbackLog write IS the action, so an unknown uid (404 with an
@@ -145,13 +162,15 @@ export default async function handler(
                 try {
                     const caps = getCapabilities(parseRoles(token.userRoles))
                     const isCurator = !!(caps.canCurate.all || caps.canCurate.scoped)
-                    if (!isCurator) {
-                        // Resolve addedBy from the server-side row, never the client body.
-                        const live = await getExternalArticles(uid)
-                        const row = live.statusCode === 200 && Array.isArray(live.statusText)
-                            ? (live.statusText as any[]).find((r: any) => r?.articleId === articleId)
-                            : undefined
-                        const addedBy = row?.addedBy ? String(row.addedBy) : undefined
+                    if (isCurator) {
+                        // Curator declines are routine queue work, not disputes — no email.
+                    } else if (!preRow) {
+                        console.log(`[external-article] dispute notification skipped — no live row for ${articleId}`)
+                    } else if (preRow.suppressed) {
+                        console.log(`[external-article] dispute notification skipped — ${articleId} was already suppressed (repeat dispute)`)
+                    } else {
+                        // addedBy comes from the server-side row, never the client body.
+                        const addedBy = preRow.addedBy ? String(preRow.addedBy) : undefined
                         if (!addedBy) {
                             console.log(`[external-article] dispute notification skipped — ${articleId} has no addedBy`)
                         } else if (addedBy === actor) {
@@ -160,11 +179,10 @@ export default async function handler(
                             await notifyExternalArticleDisputed({
                                 uid,
                                 articleId,
-                                title: row?.title,
+                                title: preRow.title,
                                 actorPersonIdentifier: actor,
                                 addedBy,
                                 note: noteText,
-                                origin: typeof req.headers.origin === 'string' ? req.headers.origin : undefined,
                             })
                         }
                     }

--- a/src/pages/api/reciter/external-article/[uid].ts
+++ b/src/pages/api/reciter/external-article/[uid].ts
@@ -4,17 +4,36 @@ import {
     getExternalArticles,
     addExternalArticle,
     deleteExternalArticle,
+    recordExternalArticleFeedback,
 } from '../../../../../controllers/externalArticle.controller'
+import { canCurate } from '../../../../../controllers/db/authorization.controller'
+import { notifyExternalArticleDisputed } from '../../../../../controllers/db/notifications/externalArticleDispute.controller'
+import { getCapabilities } from '../../../../utils/constants'
 import { reciterConfig } from '../../../../../config/local'
 
 // PM#771 — external-source (OpenAlex) manual-add publications for a person.
 //   GET    ?uid=<uid>                       -> all external rows (incl suppressed)
 //   POST   ?uid=<uid>[&force=true]  body    -> add one (201, or 409 BLOCKED/WARNING)
 //   DELETE ?uid=<uid>&articleId=<id>        -> revoke one
+//   PATCH  ?uid=<uid>  body {articleId, action, note?} -> faculty dispute (REJECTED)
+//          or retract (ACCEPTED) via the Java FeedbackLog endpoint
 // Gated on the app backendApiKey, matching every other /api/reciter route on this
 // branch. addedBy (curator CWID) is resolved best-effort from the JWT server-side and
 // never trusted from the client. (Per-person curation-scope authz is an AAR-line
-// feature not present on this branch — see the PR notes.)
+// feature not present on this branch — see the PR notes.) PATCH is stricter: it is a
+// write faculty reach from the unguarded /app page, so it requires a session and passes
+// canCurate (Curator_Self may only act on their own uid) before anything happens.
+
+const parseRoles = (value: any): any[] => {
+    if (Array.isArray(value)) return value
+    if (typeof value !== 'string') return []
+    try {
+        const parsed = JSON.parse(value)
+        return Array.isArray(parsed) ? parsed : []
+    } catch (e) {
+        return []
+    }
+}
 
 type Error = {
     statusCode: number,
@@ -31,8 +50,8 @@ export default async function handler(
     res: NextApiResponse<Error | Data>
 ) {
     const method = req.method || ''
-    if (method !== 'GET' && method !== 'POST' && method !== 'DELETE') {
-        return res.status(400).send({ statusCode: 400, message: 'HTTP Methods supported are GET, POST, DELETE' })
+    if (method !== 'GET' && method !== 'POST' && method !== 'DELETE' && method !== 'PATCH') {
+        return res.status(400).send({ statusCode: 400, message: 'HTTP Methods supported are GET, POST, DELETE, PATCH' })
     }
 
     if (req.headers.authorization === undefined) {
@@ -68,6 +87,93 @@ export default async function handler(
                 return res.status(200).send({ statusCode: 200, external: apiResponse.statusText })
             }
             return res.status(apiResponse.statusCode || 502).send({ statusCode: apiResponse.statusCode || 502, message: apiResponse.statusText })
+        }
+
+        if (method === 'PATCH') {
+            // Faculty dispute ("This isn't mine" -> REJECTED) / retract (-> ACCEPTED).
+            // actorPersonIdentifier is stamped from the JWT server-side — the same trust
+            // boundary as POST's addedBy and goldstandard.ts's curatedBy. Never from the body.
+            let token: any = null
+            try {
+                token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+            } catch (e) {
+                token = null
+            }
+            const actor = token && token.username ? String(token.username) : undefined
+            if (!actor) {
+                return res.status(401).send({ statusCode: 401, message: 'A signed-in session is required' })
+            }
+
+            // Same server-side gate as goldstandard.ts (PM#849): the static backendApiKey
+            // above only proves the request came through this app, not who is behind it.
+            // canCurate lets Curator_All/Scoped act per role and Curator_Self act only on
+            // their own uid — which is exactly the faculty-dispute ownership rule.
+            const allowed = await canCurate(token, uid)
+            if (!allowed) {
+                return res.status(403).send({
+                    statusCode: 403,
+                    message: "You do not have permission to update this person's publications",
+                })
+            }
+
+            const { articleId, action, note } = req.body || {}
+            if (!articleId || typeof articleId !== 'string') {
+                return res.status(400).send({ statusCode: 400, message: 'articleId is required' })
+            }
+            if (action !== 'REJECTED' && action !== 'ACCEPTED') {
+                return res.status(400).send({ statusCode: 400, message: 'action must be REJECTED (dispute) or ACCEPTED (retract)' })
+            }
+            const noteText = typeof note === 'string' && note.trim() ? note.trim() : undefined
+
+            const apiResponse = await recordExternalArticleFeedback(uid, articleId, action, actor, noteText)
+            // Mirrors logScopusFeedback's status handling, but fails loud in both cases:
+            // here the FeedbackLog write IS the action, so an unknown uid (404 with an
+            // INVALID body) or an unrouted Java endpoint (bare 404, e.g. not yet deployed)
+            // must surface as a failure — never a silent success.
+            if (apiResponse.statusCode !== 200) {
+                const uidUnknown = apiResponse.statusCode === 404 && (apiResponse.statusText as any)?.status === 'INVALID'
+                const status = uidUnknown ? 404 : 502
+                const message = uidUnknown
+                    ? `${uid} is not known to ReCiter — feedback was not recorded`
+                    : `Feedback write failed (${apiResponse.statusCode})`
+                return res.status(status).send({ statusCode: status, message })
+            }
+
+            // Decision 7 — a dispute (REJECTED) by a non-curator notifies the curator who
+            // added the row. Best-effort: a notification failure never fails the dispute.
+            if (action === 'REJECTED') {
+                try {
+                    const caps = getCapabilities(parseRoles(token.userRoles))
+                    const isCurator = !!(caps.canCurate.all || caps.canCurate.scoped)
+                    if (!isCurator) {
+                        // Resolve addedBy from the server-side row, never the client body.
+                        const live = await getExternalArticles(uid)
+                        const row = live.statusCode === 200 && Array.isArray(live.statusText)
+                            ? (live.statusText as any[]).find((r: any) => r?.articleId === articleId)
+                            : undefined
+                        const addedBy = row?.addedBy ? String(row.addedBy) : undefined
+                        if (!addedBy) {
+                            console.log(`[external-article] dispute notification skipped — ${articleId} has no addedBy`)
+                        } else if (addedBy === actor) {
+                            console.log(`[external-article] dispute notification skipped — ${articleId} was added by the disputing user`)
+                        } else {
+                            await notifyExternalArticleDisputed({
+                                uid,
+                                articleId,
+                                title: row?.title,
+                                actorPersonIdentifier: actor,
+                                addedBy,
+                                note: noteText,
+                                origin: typeof req.headers.origin === 'string' ? req.headers.origin : undefined,
+                            })
+                        }
+                    }
+                } catch (e) {
+                    console.error('[external-article] dispute notification failed (the dispute itself succeeded):', e)
+                }
+            }
+
+            return res.status(200).send({ statusCode: 200, external: apiResponse.statusText })
         }
 
         // POST — resolve the curating user's CWID from the JWT for addedBy.


### PR DESCRIPTION
Adds the faculty-facing WRITE half of the per-source tabs (read UI landed in #872/#876; curator-side wiring in #875), per the settled FeedbackLog design and Decision 7 in docs/README-other-publications-tab.md.

## What this does

**Dispute / retract (reversible, per the repo mockup):** each curator-added external row on the faculty page gets a "This isn't mine" action with an optional note. It PATCHes the existing `/api/reciter/external-article/[uid]` route, which forwards to Java's `PATCH /reciter/external-article/feedback` (REJECTED on dispute, ACCEPTED on undo). Disputed rows stay in their source tab with a Disputed badge and sink below active rows; Undo restores them. Rows added by the viewer show "Added by you" and no dispute affordance.

**Trust boundary:** the acting person's identifier is stamped server-side from the next-auth JWT, never read from the request body; the route is gated by the same `canCurate` check as the goldstandard route (Curator_Self only on their own uid). Java write failures surface as 404/502 — no silent success, including when the Java endpoint isn't deployed yet.

**Decision-7 notification:** a dispute by a non-curator emails the curator who added the row (resolved server-side from the row's `addedBy` → admin_users email, same email infra as existing notifications) and appends an `admin_notification_log` row (`ExternalArticleDisputed`). Only the first REJECTED transition notifies — repeat disputes of an already-suppressed row send no second email — and the review link derives from `NEXTAUTH_URL`, not the request's Origin header. A notification failure never fails the dispute.

**Suppression split:** superseded rows (`suppressed` + `supersededByPmid`) keep their current hidden treatment; dispute-suppressed rows render, count, and are undoable. `Tabs.js` counts updated in lockstep.

## Verification

- `npx tsc --noEmit` clean; `next lint` — no errors, no warnings in touched files.
- Adversarially reviewed (correctness + trust-boundary passes); both medium findings fixed in the last commit (Origin-header link injection, notification spam without dedup).
- Not yet verified at runtime: end-to-end click-through behind SAML, and the Java PATCH endpoint being live (gated on the Dynamodb-Model 3.0.7 → ReCiter #711 chain; until then the route fails loud with 502 by design).

## Depends on

Java endpoint `PATCH /reciter/external-article/feedback` — live on reciter-dev via ReCiter #708; prod arrives with #711.