### PR TITLE
restore(auth): individual-level proxy assignment (PM#849)

### DIFF
--- a/controllers/db/proxy.controller.ts
+++ b/controllers/db/proxy.controller.ts
@@ -1,0 +1,269 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Op, Sequelize, QueryTypes } from 'sequelize';
+import models from '../../src/db/sequelize';
+import sequelize from '../../src/db/db';
+
+/**
+ * Helper: parse a JSON column value that may come back as a string or array
+ * depending on MySQL/MariaDB driver behavior.
+ */
+function parseJsonColumn(value: unknown): string[] {
+    if (!value) return [];
+    if (Array.isArray(value)) return value;
+    if (typeof value === 'string') {
+        try {
+            const parsed = JSON.parse(value);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch {
+            return [];
+        }
+    }
+    return [];
+}
+
+/**
+ * GET /api/db/admin/proxy?userID=N
+ * Returns enriched proxy person list for a given admin user.
+ */
+export const getProxiesForUser = async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+        const userID = Number(req.query.userID);
+        if (!userID || isNaN(userID)) {
+            return res.status(400).json({ error: 'Valid userID query param required' });
+        }
+
+        const user = await models.AdminUser.findOne({
+            where: { userID },
+            attributes: ['proxy_person_ids'],
+            raw: true
+        });
+
+        if (!user) {
+            return res.status(404).json({ error: 'User not found' });
+        }
+
+        const personIds = parseJsonColumn(user.proxy_person_ids);
+        if (personIds.length === 0) {
+            return res.status(200).json([]);
+        }
+
+        // Batch-query person table for enriched data
+        const persons = await models.Person.findAll({
+            where: {
+                personIdentifier: { [Op.in]: personIds }
+            },
+            attributes: ['personIdentifier', 'firstName', 'middleName', 'lastName', 'primaryOrganizationalUnit'],
+            raw: true
+        });
+
+        return res.status(200).json(persons);
+    } catch (error) {
+        console.log('[PROXY] Error in getProxiesForUser:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+};
+
+/**
+ * GET /api/db/admin/proxy?personIdentifier=X
+ * Reverse lookup: find all admin users who have this person in their proxy list.
+ */
+export const getProxiesForPerson = async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+        const personIdentifier = req.query.personIdentifier as string;
+        if (!personIdentifier) {
+            return res.status(400).json({ error: 'personIdentifier query param required' });
+        }
+
+        const users = await sequelize.query(
+            'SELECT userID, personIdentifier, nameFirst, nameMiddle, nameLast FROM admin_users WHERE JSON_CONTAINS(proxy_person_ids, ?)',
+            {
+                replacements: [JSON.stringify(personIdentifier)],
+                type: QueryTypes.SELECT
+            }
+        );
+
+        return res.status(200).json(users);
+    } catch (error) {
+        console.log('[PROXY] Error in getProxiesForPerson:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+};
+
+/**
+ * POST /api/db/admin/proxy
+ * Save/replace the entire proxy_person_ids array for a given user.
+ * Body: { userID: number, personIdentifiers: string[] }
+ */
+export const saveProxiesForUser = async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+        const { userID, personIdentifiers } = req.body;
+
+        if (!userID) {
+            return res.status(400).json({ error: 'userID is required' });
+        }
+
+        // Validate user exists
+        const user = await models.AdminUser.findOne({ where: { userID } });
+        if (!user) {
+            return res.status(404).json({ error: 'User not found' });
+        }
+
+        // proxy_person_ids is a JSON column (DataTypes.JSON) -- Sequelize serializes it itself.
+        // Passing a JSON.stringify'd value here double-encodes it (matches the scope_person_types/
+        // scope_org_units save pattern in user.controller.ts, see PM#849).
+        await models.AdminUser.update(
+            { proxy_person_ids: Array.isArray(personIdentifiers) && personIdentifiers.length > 0 ? personIdentifiers : null },
+            { where: { userID } }
+        );
+
+        return res.status(200).json({ success: true });
+    } catch (error) {
+        console.log('[PROXY] Error in saveProxiesForUser:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+};
+
+/**
+ * POST /api/db/admin/proxy/grant
+ * Grant or revoke proxy for a specific person across multiple users.
+ * Body: { personIdentifier: string, userIds: number[] }
+ *
+ * This is the inverse of saveProxiesForUser: instead of setting all proxies for one user,
+ * it sets which users can proxy for one person.
+ */
+export const grantProxyForPerson = async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+        const { personIdentifier, userIds } = req.body;
+
+        if (!personIdentifier) {
+            return res.status(400).json({ error: 'personIdentifier is required' });
+        }
+        if (!Array.isArray(userIds)) {
+            return res.status(400).json({ error: 'userIds must be an array' });
+        }
+
+        // Step 1: Find all users who currently have this personIdentifier in proxy_person_ids
+        const currentProxiers: any[] = await sequelize.query(
+            'SELECT userID, proxy_person_ids FROM admin_users WHERE JSON_CONTAINS(proxy_person_ids, ?)',
+            {
+                replacements: [JSON.stringify(personIdentifier)],
+                type: QueryTypes.SELECT
+            }
+        );
+
+        const currentUserIds = currentProxiers.map((u: any) => u.userID);
+        const newUserIds = userIds.map(Number);
+
+        // Step 2: Remove personIdentifier from users no longer in the list
+        const toRemove = currentUserIds.filter((id: number) => !newUserIds.includes(id));
+        for (const uid of toRemove) {
+            const row = currentProxiers.find((u: any) => u.userID === uid);
+            const currentArr = parseJsonColumn(row.proxy_person_ids);
+            const newArr = currentArr.filter((pid: string) => pid !== personIdentifier);
+            await models.AdminUser.update(
+                { proxy_person_ids: newArr.length > 0 ? newArr : null },
+                { where: { userID: uid } }
+            );
+        }
+
+        // Step 3: Add personIdentifier to users newly in the list
+        const toAdd = newUserIds.filter((id: number) => !currentUserIds.includes(id));
+        for (const uid of toAdd) {
+            const user = await models.AdminUser.findOne({
+                where: { userID: uid },
+                attributes: ['proxy_person_ids'],
+                raw: true
+            });
+            if (user) {
+                const currentArr = parseJsonColumn(user.proxy_person_ids);
+                if (!currentArr.includes(personIdentifier)) {
+                    currentArr.push(personIdentifier);
+                }
+                await models.AdminUser.update(
+                    { proxy_person_ids: currentArr },
+                    { where: { userID: uid } }
+                );
+            }
+        }
+
+        return res.status(200).json({ success: true });
+    } catch (error) {
+        console.log('[PROXY] Error in grantProxyForPerson:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+};
+
+/**
+ * GET /api/db/admin/proxy/search-persons?q=
+ * Search person table for proxy assignment autocomplete.
+ */
+export const searchPersons = async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+        const q = (req.query.q as string || '').trim();
+        if (q.length < 2) {
+            return res.status(200).json([]);
+        }
+
+        const persons = await models.Person.findAll({
+            where: {
+                [Op.or]: [
+                    { firstName: { [Op.like]: `%${q}%` } },
+                    { lastName: { [Op.like]: `%${q}%` } },
+                    { personIdentifier: { [Op.like]: `%${q}%` } }
+                ]
+            },
+            attributes: ['personIdentifier', 'firstName', 'middleName', 'lastName', 'primaryOrganizationalUnit'],
+            limit: 20,
+            raw: true
+        });
+
+        return res.status(200).json(persons);
+    } catch (error) {
+        console.log('[PROXY] Error in searchPersons:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+};
+
+/**
+ * GET /api/db/admin/proxy/search-users?q=
+ * Search admin users who have curation roles (for GrantProxyModal).
+ */
+// Define association with unique alias to avoid conflicts
+models.AdminUser.hasMany(models.AdminUsersRole, {
+    as: 'proxySearchRoles',
+    constraints: false,
+    foreignKey: 'userID'
+});
+models.AdminUsersRole.belongsTo(models.AdminRole, {
+    as: 'proxySearchRole',
+    constraints: false,
+    foreignKey: 'roleID'
+});
+
+export const searchUsersWithCurationRoles = async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+        const q = (req.query.q as string || '').trim();
+        if (q.length < 2) {
+            return res.status(200).json([]);
+        }
+
+        const users = await models.AdminUser.findAll({
+            attributes: ['userID', 'personIdentifier', 'nameFirst', 'nameMiddle', 'nameLast'],
+            where: {
+                status: 1,
+                [Op.or]: [
+                    { nameFirst: { [Op.like]: `%${q}%` } },
+                    { nameLast: { [Op.like]: `%${q}%` } },
+                    { personIdentifier: { [Op.like]: `%${q}%` } }
+                ]
+            },
+            limit: 20,
+            raw: true
+        });
+
+        return res.status(200).json(users);
+    } catch (error) {
+        console.log('[PROXY] Error in searchUsersWithCurationRoles:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+};

--- a/src/components/elements/AddUser/AddUser.tsx
+++ b/src/components/elements/AddUser/AddUser.tsx
@@ -7,10 +7,11 @@ import { RootStateOrAny } from "../../../types/redux";
 import styles from './AddUser.module.css';
 import Loader from '../Common/Loader';
 import TextField from '@mui/material/TextField';
-import { createAdminUser, createORupdateUserIDAction, fetchUserInfoByID, getAdminDepartments, getAdminRoles, getPersonTypes} from "../../../redux/actions/actions";
+import { createAdminUser, createORupdateUserIDAction, fetchUserInfoByID, getAdminDepartments, getAdminRoles, getPersonTypes, fetchProxiesForUser, saveProxiesForUser} from "../../../redux/actions/actions";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import ToastContainerWrapper from '../ToastContainerWrapper/ToastContainerWrapper';
+import ProxyAssignmentsSection, { PersonOption } from './ProxyAssignmentsSection';
 
 /* ── Role label formatting ── */
 const ROLE_LABELS: Record<string, string> = {
@@ -67,6 +68,9 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
     // scope_org_units (see PM#849).
     const [selectedPersonTypes, setSelectedPersonTypes] = useState([]);
     const [selectedScopeOrgUnits, setSelectedScopeOrgUnits] = useState([]);
+    // Individual-level proxy: specific people this user can curate regardless of role/scope
+    // (admin_users.proxy_person_ids, see PM#849). Independent of selectedScopeOrgUnits above.
+    const [selectedProxies, setSelectedProxies] = useState<PersonOption[]>([]);
     const [loading, setLoading] = useState(false);
     const isCuratorScoped = selectedRoles.includes('Curator_Scoped');
 
@@ -129,6 +133,7 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
             if (isEditUserId) {
                 let resp = await createAdminUser(createOrUpdatePayload)
                 if (resp && resp.length > 0 && resp[0] === 1) {
+                    await saveProxiesForUser(isEditUserId, selectedProxies.map(p => p.personIdentifier))
                     dispatch(createORupdateUserIDAction("UserID " + isEditUserId + " has been Updated"))
                     router.push("/admin/manage/users")
                 }
@@ -136,6 +141,7 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
             else {
                 let resp = await createAdminUser(createOrUpdatePayload)
                 if (resp && resp.length > 0 && resp[0].userID) {
+                    await saveProxiesForUser(resp[0].userID, selectedProxies.map(p => p.personIdentifier))
                     dispatch(createORupdateUserIDAction("UserID " + resp[0].userID + " has been Created"))
                     router.push("/admin/manage/users")
                 }
@@ -182,6 +188,8 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
                 setState(state => ({ ...state, cwid: personIdentifier, lastName: nameLast, firstName: nameFirst, email, middleName: nameMiddle }))
                 setLoading(false)
             })
+
+            fetchProxiesForUser(isEditUserId).then(persons => setSelectedProxies(persons || []))
         }
     }, [router.query.userId])
 
@@ -577,6 +585,17 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
                                 </div>
                             )}
                             {formErrorsInst.selectedScope && <span className={styles.errorText}>{formErrorsInst.selectedScope}</span>}
+                            <div className={styles.fieldGrid} style={{ marginTop: 16 }}>
+                                <div className={styles.field}>
+                                    <label className={styles.fieldLabel}>Proxy — additional people this user can curate</label>
+                                    <ProxyAssignmentsSection
+                                        selectedProxies={selectedProxies}
+                                        onProxiesChange={setSelectedProxies}
+                                        sx={orgUnitSx}
+                                    />
+                                    <span className={styles.fieldHint}>Grants curation access to specific people regardless of role or scope above. Leave empty for none.</span>
+                                </div>
+                            </div>
                         </div>
 
                         {/* ── Footer ── */}

--- a/src/components/elements/AddUser/ProxyAssignmentsSection.tsx
+++ b/src/components/elements/AddUser/ProxyAssignmentsSection.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useRef } from 'react';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import CircularProgress from '@mui/material/CircularProgress';
+import { reciterConfig } from '../../../../config/local';
+
+export interface PersonOption {
+  personIdentifier: string;
+  firstName: string;
+  middleName?: string;
+  lastName: string;
+  primaryOrganizationalUnit?: string;
+}
+
+interface ProxyAssignmentsSectionProps {
+  selectedProxies: PersonOption[];
+  onProxiesChange: (values: PersonOption[]) => void;
+  sx?: any;
+  renderTags?: (value: PersonOption[], getTagProps: any) => React.ReactNode;
+}
+
+// Presentational only -- the field wrapper (label/hint/layout) lives in AddUser.tsx so this
+// matches the org-unit/role/scope fields around it instead of introducing its own look.
+const ProxyAssignmentsSection: React.FC<ProxyAssignmentsSectionProps> = ({
+  selectedProxies,
+  onProxiesChange,
+  sx,
+  renderTags,
+}) => {
+  const [searchResults, setSearchResults] = useState<PersonOption[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const searchTimer = useRef<NodeJS.Timeout | null>(null);
+
+  const handleSearch = (query: string) => {
+    // Clear any pending search
+    if (searchTimer.current) {
+      clearTimeout(searchTimer.current);
+    }
+
+    if (!query || query.trim().length < 2) {
+      setSearchResults([]);
+      return;
+    }
+
+    // Debounce 300ms
+    searchTimer.current = setTimeout(async () => {
+      setSearchLoading(true);
+      try {
+        const res = await fetch(
+          `/api/db/admin/proxy/search-persons?q=${encodeURIComponent(query.trim())}`,
+          {
+            headers: { Authorization: reciterConfig?.backendApiKey || '' },
+          }
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setSearchResults(data);
+        }
+      } catch (err) {
+        console.log('Error searching persons for proxy:', err);
+      } finally {
+        setSearchLoading(false);
+      }
+    }, 300);
+  };
+
+  return (
+    <Autocomplete
+      multiple
+      options={searchResults}
+      getOptionLabel={(option: PersonOption) =>
+        `${option.lastName}, ${option.firstName} (${option.personIdentifier}) - ${option.primaryOrganizationalUnit || 'N/A'}`
+      }
+      value={selectedProxies}
+      onChange={(e, value) => onProxiesChange(value as PersonOption[])}
+      onInputChange={(e, value, reason) => {
+        if (reason === 'input') handleSearch(value);
+      }}
+      loading={searchLoading}
+      noOptionsText="No people found matching your search."
+      isOptionEqualToValue={(option, value) =>
+        option.personIdentifier === value.personIdentifier
+      }
+      sx={sx}
+      renderTags={renderTags}
+      renderInput={(params) => (
+        <TextField
+          variant="outlined"
+          {...params}
+          placeholder={selectedProxies.length === 0 ? "Search people..." : ""}
+          aria-label="Proxy People"
+          InputProps={{
+            ...params.InputProps,
+            type: 'search',
+            endAdornment: (
+              <>
+                {searchLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+        />
+      )}
+    />
+  );
+};
+
+export default ProxyAssignmentsSection;

--- a/src/components/elements/CurateIndividual/GrantProxyModal.module.css
+++ b/src/components/elements/CurateIndividual/GrantProxyModal.module.css
@@ -1,0 +1,57 @@
+.subtitle {
+    font-size: 13px;
+    color: #5a6478;
+    margin-bottom: 16px;
+}
+.emptyState {
+    text-align: center;
+    padding: 24px;
+    font-size: 13px;
+    color: #8a94a6;
+}
+.errorState {
+    color: #c0392b;
+    font-size: 13px;
+}
+.footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 16px;
+    border-top: 1px solid #e8e2d9;
+}
+.btnSave {
+    background: #1a2133;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 7px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+}
+.btnSave:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+.loginNote {
+    font-size: 12px;
+    color: #8a94a6;
+    margin-top: 12px;
+    padding: 8px 12px;
+    background: #f8f6f3;
+    border-radius: 5px;
+    border-left: 3px solid #ddd7ce;
+}
+.btnDiscard {
+    background: transparent;
+    color: #8a94a6;
+    border: 1px solid #ddd7ce;
+    border-radius: 6px;
+    padding: 7px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+}

--- a/src/components/elements/CurateIndividual/GrantProxyModal.tsx
+++ b/src/components/elements/CurateIndividual/GrantProxyModal.tsx
@@ -1,0 +1,326 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Modal } from 'react-bootstrap';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import { Spinner } from 'react-bootstrap';
+import { toast } from 'react-toastify';
+import Loader from '../Common/Loader';
+import { reciterConfig } from '../../../../config/local';
+import styles from './GrantProxyModal.module.css';
+
+interface ProxyUser {
+    userID: number;
+    personIdentifier: string;
+    nameFirst: string;
+    nameMiddle: string;
+    nameLast: string;
+}
+
+interface GrantProxyModalProps {
+    show: boolean;
+    onHide: () => void;
+    personIdentifier: string;
+    personName: string;
+    onSave: () => void;
+}
+
+const GrantProxyModal: React.FC<GrantProxyModalProps> = ({
+    show,
+    onHide,
+    personIdentifier,
+    personName,
+    onSave,
+}) => {
+    const [searchResults, setSearchResults] = useState<ProxyUser[]>([]);
+    const [searchLoading, setSearchLoading] = useState(false);
+    const [selectedUsers, setSelectedUsers] = useState<ProxyUser[]>([]);
+    const [existingUsers, setExistingUsers] = useState<ProxyUser[]>([]);
+    const [loadingExisting, setLoadingExisting] = useState(false);
+    const [loadError, setLoadError] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        if (show && personIdentifier) {
+            loadExisting();
+        }
+        if (!show) {
+            // Reset state when modal closes
+            setSearchResults([]);
+            setSearchLoading(false);
+            setSelectedUsers([]);
+            setExistingUsers([]);
+            setLoadingExisting(false);
+            setLoadError(false);
+            setSaving(false);
+            if (searchTimer.current) {
+                clearTimeout(searchTimer.current);
+                searchTimer.current = null;
+            }
+        }
+    }, [show, personIdentifier]);
+
+    const loadExisting = async () => {
+        setLoadingExisting(true);
+        setLoadError(false);
+        try {
+            const res = await fetch(
+                `/api/db/admin/proxy?personIdentifier=${encodeURIComponent(personIdentifier)}`,
+                {
+                    headers: {
+                        'Authorization': reciterConfig.backendApiKey,
+                    },
+                }
+            );
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const data: ProxyUser[] = await res.json();
+            setExistingUsers(data);
+            setSelectedUsers(data);
+        } catch (err) {
+            console.error('[GrantProxyModal] loadExisting error:', err);
+            setLoadError(true);
+        } finally {
+            setLoadingExisting(false);
+        }
+    };
+
+    const handleSearch = (query: string) => {
+        if (searchTimer.current) {
+            clearTimeout(searchTimer.current);
+        }
+        if (!query || query.length < 2) {
+            setSearchResults([]);
+            setSearchLoading(false);
+            return;
+        }
+        setSearchLoading(true);
+        searchTimer.current = setTimeout(async () => {
+            try {
+                const res = await fetch(
+                    `/api/db/admin/proxy/search-users?q=${encodeURIComponent(query)}`,
+                    {
+                        headers: {
+                            'Authorization': reciterConfig.backendApiKey,
+                        },
+                    }
+                );
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const data = await res.json();
+                // Handle both flat and nested Sequelize response formats
+                const users: ProxyUser[] = data.map((item: any) => ({
+                    userID: item.userID,
+                    personIdentifier: item.personIdentifier || '',
+                    nameFirst: item.nameFirst || '',
+                    nameMiddle: item.nameMiddle || '',
+                    nameLast: item.nameLast || '',
+                }));
+                setSearchResults(users);
+            } catch (err) {
+                console.error('[GrantProxyModal] search error:', err);
+                setSearchResults([]);
+            } finally {
+                setSearchLoading(false);
+            }
+        }, 300);
+    };
+
+    const formatUserLabel = (user: ProxyUser): string => {
+        const name = [user.nameLast, user.nameFirst].filter(Boolean).join(', ');
+        return user.personIdentifier ? `${name} (${user.personIdentifier})` : name;
+    };
+
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            const res = await fetch('/api/db/admin/proxy/grant', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': reciterConfig.backendApiKey,
+                },
+                body: JSON.stringify({
+                    personIdentifier,
+                    userIds: selectedUsers.map((u) => u.userID),
+                }),
+            });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            toast.success(
+                'Proxy access updated. Changes take effect on the user\'s next login.',
+                { position: 'top-right', autoClose: 5000, theme: 'colored' }
+            );
+            onSave();
+            onHide();
+        } catch (err) {
+            console.error('[GrantProxyModal] save error:', err);
+            toast.error(
+                'Failed to update proxy access. Please try again.',
+                { position: 'top-right', autoClose: 5000, theme: 'colored' }
+            );
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDiscard = () => {
+        onHide();
+    };
+
+    // Filter out already-selected users from search results
+    const filteredResults = searchResults.filter(
+        (sr) => !selectedUsers.some((su) => su.userID === sr.userID)
+    );
+
+    return (
+        <Modal show={show} onHide={onHide} centered size="lg">
+            <Modal.Header closeButton>
+                <Modal.Title style={{ fontSize: 13, fontWeight: 600, color: '#1a2133' }}>
+                    Manage Proxy Access
+                </Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <div className={styles.subtitle}>for {personName}</div>
+
+                {loadingExisting ? (
+                    <div style={{ display: 'flex', justifyContent: 'center', padding: '40px 0' }}>
+                        <Loader />
+                    </div>
+                ) : loadError ? (
+                    <div className={styles.errorState}>
+                        Unable to load proxy data. Please close and try again.
+                    </div>
+                ) : (
+                    <>
+                        <Autocomplete
+                            multiple
+                            disablePortal
+                            options={filteredResults}
+                            getOptionLabel={formatUserLabel}
+                            filterOptions={(x) => x}
+                            value={selectedUsers}
+                            loading={searchLoading}
+                            noOptionsText="No users found matching your search."
+                            isOptionEqualToValue={(option, value) => option.userID === value.userID}
+                            onChange={(_event, newValue) => {
+                                setSelectedUsers(newValue as ProxyUser[]);
+                            }}
+                            onInputChange={(_event, value, reason) => {
+                                if (reason === 'input') {
+                                    handleSearch(value);
+                                }
+                            }}
+                            renderTags={(value, getTagProps) =>
+                                value.map((user, index) => {
+                                    const { key, ...tagProps } = getTagProps({ index });
+                                    return (
+                                        <span
+                                            key={key}
+                                            {...tagProps}
+                                            style={{
+                                                display: 'inline-flex',
+                                                alignItems: 'center',
+                                                gap: 4,
+                                                background: '#1a2133',
+                                                color: '#fff',
+                                                borderRadius: 20,
+                                                padding: '3px 10px',
+                                                fontSize: 12,
+                                                fontWeight: 500,
+                                                margin: '2px 4px 2px 0',
+                                            }}
+                                        >
+                                            {formatUserLabel(user)}
+                                            <button
+                                                type="button"
+                                                onClick={tagProps.onDelete}
+                                                aria-label="Remove"
+                                                style={{
+                                                    cursor: 'pointer',
+                                                    fontSize: 16,
+                                                    lineHeight: 1,
+                                                    marginLeft: 4,
+                                                    opacity: 0.7,
+                                                    background: 'none',
+                                                    border: 'none',
+                                                    padding: 0,
+                                                    color: 'inherit',
+                                                    minWidth: 24,
+                                                    minHeight: 24,
+                                                }}
+                                            >
+                                                &times;
+                                            </button>
+                                        </span>
+                                    );
+                                })
+                            }
+                            renderInput={(params) => (
+                                <TextField
+                                    {...params}
+                                    variant="outlined"
+                                    placeholder="Search users by name or CWID..."
+                                    size="small"
+                                    sx={{
+                                        '& .MuiOutlinedInput-root': {
+                                            background: '#fff',
+                                            '& fieldset': {
+                                                borderColor: '#ddd7ce',
+                                            },
+                                            '&:hover fieldset': {
+                                                borderColor: '#ddd7ce',
+                                            },
+                                            '&.Mui-focused fieldset': {
+                                                borderColor: '#2563a8',
+                                                borderWidth: 2,
+                                            },
+                                        },
+                                    }}
+                                />
+                            )}
+                        />
+                        {existingUsers.length === 0 && selectedUsers.length === 0 && (
+                            <div className={styles.emptyState}>
+                                No users currently have proxy access for this person.
+                            </div>
+                        )}
+                        <div className={styles.loginNote}>
+                            Any user who has logged in can be assigned as a proxy. Access takes effect on their next login.
+                        </div>
+                    </>
+                )}
+            </Modal.Body>
+            <div className={styles.footer}>
+                <button
+                    type="button"
+                    className={styles.btnDiscard}
+                    onClick={handleDiscard}
+                >
+                    Discard Changes
+                </button>
+                <button
+                    type="button"
+                    className={styles.btnSave}
+                    onClick={handleSave}
+                    disabled={saving || loadingExisting || loadError}
+                >
+                    {saving ? (
+                        <>
+                            <Spinner
+                                as="span"
+                                animation="border"
+                                size="sm"
+                                role="status"
+                                aria-hidden="true"
+                                style={{ marginRight: 6 }}
+                            />
+                            Saving...
+                        </>
+                    ) : (
+                        'Save Changes'
+                    )}
+                </button>
+            </div>
+        </Modal>
+    );
+};
+
+export default GrantProxyModal;

--- a/src/components/elements/Navbar/ScopeLabel.module.css
+++ b/src/components/elements/Navbar/ScopeLabel.module.css
@@ -1,0 +1,18 @@
+.scopeLabel {
+    margin: 2px 16px 8px;
+    padding: 6px 10px;
+    white-space: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 10px;
+    font-weight: 500;
+    color: rgba(168,180,204,0.7);
+    line-height: 1.4;
+    cursor: default;
+    background: rgba(168,180,204,0.08);
+    border-radius: 4px;
+    letter-spacing: 0.02em;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}

--- a/src/components/elements/Navbar/ScopeLabel.tsx
+++ b/src/components/elements/Navbar/ScopeLabel.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import Tooltip from '@mui/material/Tooltip';
+
+interface ScopeLabelProps {
+  scopeData: { personTypes: string[] | null; orgUnits: string[] | null } | null;
+  proxyCount?: number;
+}
+
+const ScopeLabel: React.FC<ScopeLabelProps> = ({ scopeData, proxyCount }) => {
+  const items: string[] = [];
+  if (scopeData) {
+    if (scopeData.personTypes) items.push(...scopeData.personTypes);
+    if (scopeData.orgUnits) items.push(...scopeData.orgUnits);
+  }
+
+  const proxyText = proxyCount
+    ? proxyCount === 1
+      ? '1 proxied person'
+      : `${proxyCount} proxied people`
+    : '';
+
+  // Nothing to display if no scope items and no proxy count
+  if (items.length === 0 && !proxyText) return null;
+
+  const maxDisplay = 3;
+  const displayItems = items.slice(0, maxDisplay);
+  const remaining = items.length - maxDisplay;
+  const scopeDisplayText = displayItems.join(', ') + (remaining > 0 ? `, +${remaining} more` : '');
+  const fullScopeText = items.join(', ');
+
+  // Build label text
+  let labelText = '';
+  if (items.length > 0 && proxyText) {
+    labelText = `Curating: ${scopeDisplayText} + ${proxyText}`;
+  } else if (items.length > 0) {
+    labelText = `Curating: ${scopeDisplayText}`;
+  } else if (proxyText) {
+    labelText = `Curating: ${proxyText}`;
+  }
+
+  // Build aria-label
+  const ariaLabel = items.length > 0
+    ? `Curation scope: ${fullScopeText}${proxyText ? ' plus ' + proxyText : ''}`
+    : `Curation scope: ${proxyText}`;
+
+  return (
+    <Tooltip title={items.length > maxDisplay ? fullScopeText : ''} placement="right">
+      <div
+        aria-label={ariaLabel}
+        style={{
+          fontSize: '12px',
+          fontWeight: 600,
+          lineHeight: 1.4,
+          color: '#777777',
+          padding: '4px 16px 8px 16px',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {labelText}
+      </div>
+    </Tooltip>
+  );
+};
+
+export default ScopeLabel;

--- a/src/pages/api/db/admin/proxy/grant.ts
+++ b/src/pages/api/db/admin/proxy/grant.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { reciterConfig } from '../../../../../../config/local';
+import { grantProxyForPerson } from '../../../../../../controllers/db/proxy.controller';
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+        if (!(await isAuthorizedAdmin(req))) {
+            return res.status(403).send('Forbidden');
+        }
+        if (req.method === 'POST') {
+            return grantProxyForPerson(req, res);
+        }
+        return res.status(405).send('HTTP Supported method is POST');
+    } else if (req.headers.authorization === undefined) {
+        res.status(400).send('Authorization header is needed');
+    } else {
+        res.status(401).send('Authorization header is incorrect');
+    }
+}

--- a/src/pages/api/db/admin/proxy/index.ts
+++ b/src/pages/api/db/admin/proxy/index.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { reciterConfig } from '../../../../../../config/local';
+import { getProxiesForUser, getProxiesForPerson, saveProxiesForUser } from '../../../../../../controllers/db/proxy.controller';
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+        if (!(await isAuthorizedAdmin(req))) {
+            return res.status(403).send('Forbidden');
+        }
+        if (req.method === 'GET') {
+            if (req.query.personIdentifier) {
+                return getProxiesForPerson(req, res);
+            }
+            if (req.query.userID) {
+                return getProxiesForUser(req, res);
+            }
+            return res.status(400).json({ error: 'userID or personIdentifier query param required' });
+        }
+        if (req.method === 'POST') {
+            return saveProxiesForUser(req, res);
+        }
+        return res.status(405).json({ error: 'Method not allowed' });
+    } else if (req.headers.authorization === undefined) {
+        res.status(400).send('Authorization header is needed');
+    } else {
+        res.status(401).send('Authorization header is incorrect');
+    }
+}

--- a/src/pages/api/db/admin/proxy/search-persons.ts
+++ b/src/pages/api/db/admin/proxy/search-persons.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { reciterConfig } from '../../../../../../config/local';
+import { searchPersons } from '../../../../../../controllers/db/proxy.controller';
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+        if (!(await isAuthorizedAdmin(req))) {
+            return res.status(403).send('Forbidden');
+        }
+        if (req.method === 'GET') {
+            return searchPersons(req, res);
+        }
+        return res.status(405).send('HTTP Supported method is GET');
+    } else if (req.headers.authorization === undefined) {
+        res.status(400).send('Authorization header is needed');
+    } else {
+        res.status(401).send('Authorization header is incorrect');
+    }
+}

--- a/src/pages/api/db/admin/proxy/search-users.ts
+++ b/src/pages/api/db/admin/proxy/search-users.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { reciterConfig } from '../../../../../../config/local';
+import { searchUsersWithCurationRoles } from '../../../../../../controllers/db/proxy.controller';
+import { isAuthorizedAdmin } from '../../../../../../controllers/db/adminAuth.controller';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.headers.authorization !== undefined && req.headers.authorization === reciterConfig.backendApiKey) {
+        if (!(await isAuthorizedAdmin(req))) {
+            return res.status(403).send('Forbidden');
+        }
+        if (req.method === 'GET') {
+            return searchUsersWithCurationRoles(req, res);
+        }
+        return res.status(405).send('HTTP Supported method is GET');
+    } else if (req.headers.authorization === undefined) {
+        res.status(400).send('Authorization header is needed');
+    } else {
+        res.status(401).send('Authorization header is incorrect');
+    }
+}

--- a/src/redux/actions/actions.js
+++ b/src/redux/actions/actions.js
@@ -2332,6 +2332,71 @@ export const fetchUserInfoByID = (userID) =>{
         })
 }
 
+// Get the enriched proxy-person list currently saved for an admin user (PM#849 proxy grant flow)
+export const fetchProxiesForUser = (userID) => {
+    return fetch(`/api/db/admin/proxy?userID=${userID}`, {
+        credentials: "same-origin",
+        method: 'GET',
+        headers: {
+            Accept: 'application/json',
+            'Authorization': reciterConfig.backendApiKey
+        }
+    })
+        .then(response => {
+            if (response.status === 200) {
+                return response.json()
+            }
+            throw {
+                type: response.type,
+                title: response.statusText,
+                status: response.status,
+                detail: "Error occurred with api " + response.url + ". Please, try again later "
+            }
+        })
+        .catch(error => {
+            console.log(error)
+            toast.error("fetch proxies " + error.title, {
+                position: "top-right",
+                autoClose: 2000,
+                theme: 'colored'
+            });
+            return []
+        })
+}
+
+// Replace the full proxy_person_ids list for an admin user (PM#849 proxy grant flow)
+export const saveProxiesForUser = (userID, personIdentifiers) => {
+    return fetch(`/api/db/admin/proxy`, {
+        credentials: "same-origin",
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            "Content-Type": "application/json",
+            'Authorization': reciterConfig.backendApiKey
+        },
+        body: JSON.stringify({ userID, personIdentifiers })
+    })
+        .then(response => {
+            if (response.status === 200) {
+                return response.json()
+            }
+            throw {
+                type: response.type,
+                title: response.statusText,
+                status: response.status,
+                detail: "Error occurred with api " + response.url + ". Please, try again later "
+            }
+        })
+        .catch(error => {
+            console.log(error)
+            toast.error("save proxies " + error.title, {
+                position: "top-right",
+                autoClose: 2000,
+                theme: 'colored'
+            });
+        })
+}
+
 // Get personIdentifiers and pmids of results of Create Reports
 export const fetchReportsResultsIds = (requestBody) => dispatch => {
     dispatch({


### PR DESCRIPTION
## What
Restores individual-level proxy assignment — a user can be granted curation rights for specific people beyond their role/scope (`admin_users.proxy_person_ids`).

This was originally built (phases 09/04/11) alongside the person-type/org-unit scope work, deleted by an unrelated commit, and restored only on a branch line that never reached `dev`/`master_Next14`. The scope side was since independently rebuilt and shipped in #854 (PM#849) — this PR fills the one remaining gap: the proxy **write** path. The proxy **read** path (JWT population in `[...nextauth].jsx`, `isProxyFor` checks in `Search.js`/`authorization.controller.ts`) was already live and unused until now.

## Changes
- `controllers/db/proxy.controller.ts` — get/save/grant/search functions for `proxy_person_ids`
- 4 routes under `pages/api/db/admin/proxy/` — gated with `isAuthorizedAdmin` (added here; the restored routes predated that fix and only had the non-secret `backendApiKey` header check)
- `AddUser.tsx` — new "Proxy" field: loads existing proxies on edit, saves the full list on submit
- `ProxyAssignmentsSection.tsx` — restyled to a plain Autocomplete so it inherits `AddUser`'s existing field/label/hint markup instead of shipping its own mismatched styling
- Fixed a double-JSON-encoding bug in the restored controller: `proxy_person_ids` is `DataTypes.JSON` (Sequelize serializes it itself), the original code was also `JSON.stringify`-ing before the write

## Deliberately left out
- `CurationScopeSection.tsx` / `checkCurationScope.ts` — superseded by `authorization.controller.ts::canCurate` from #854, would be dead duplicates
- `GrantProxyModal.tsx` (curator self-service grant, for `CurateIndividual`) and `ScopeLabel.tsx` (nav scope badge) — restored but not wired in; new UI surfaces without a mockup, holding for a placement/design call

## Verification
- `npx tsc --noEmit` — clean
- `npx next build` — exit 0, no new warnings beyond pre-existing repo-wide `exhaustive-deps` noise
- Not yet runtime-tested on reciter-dev — opening this to test there next