### PR TITLE
feat(auth): wire Grant Proxy button into the curate page (PM#849)

### DIFF
--- a/src/components/elements/CurateIndividual/CurateIndividual.module.css
+++ b/src/components/elements/CurateIndividual/CurateIndividual.module.css
@@ -294,6 +294,8 @@
 
 .personActions {
   flex-shrink: 0;
+  display: flex;
+  gap: 8px;
 }
 
 .viewProfileBtn {

--- a/src/components/elements/CurateIndividual/CurateIndividual.tsx
+++ b/src/components/elements/CurateIndividual/CurateIndividual.tsx
@@ -14,11 +14,12 @@ import ReciterTabs from "./ReciterTabs";
 import Image from "next/image";
 import Profile from "../Profile/Profile";
 import { useSession } from "next-auth/react";
-import { allowedPermissions, toastMessage } from "../../../utils/constants";
+import { allowedPermissions, toastMessage, getCapabilities } from "../../../utils/constants";
 import ToastContainerWrapper from "../ToastContainerWrapper/ToastContainerWrapper";
 import { reciterConfig } from "../../../../config/local";
 import { toast } from "react-toastify";
 import { reportError } from "../../../utils/reportError";
+import GrantProxyModal from "./GrantProxyModal";
 
 
 
@@ -50,6 +51,11 @@ const CurateIndividual = () => {
   const [headShot, setHeadShot] = useState<any>([]);
   const [showNoPermitError, setShowNoPermitError] = useState(false)
   const [headShotLoaded, setHeadShotLoaded] = useState(false)
+  const [grantProxyShow, setGrantProxyShow] = useState(false);
+  // Grant Proxy hits Superuser-only API routes (see PM#849 / proxy.controller.ts) -- match
+  // that gate here so the button isn't shown to someone who'd just get a 403.
+  const userRoles = session?.data?.userRoles ? JSON.parse(session.data.userRoles) : [];
+  const canManageUsers = getCapabilities(userRoles).canManageUsers;
 
   useEffect(() => {
 
@@ -205,6 +211,9 @@ const CurateIndividual = () => {
                 }
               </div>
               <div className={styles.personActions}>
+                {canManageUsers && (
+                  <button className={styles.viewProfileBtn} onClick={() => setGrantProxyShow(true)}>Grant Proxy</button>
+                )}
                 <button className={styles.viewProfileBtn} onClick={handleShow}>View Profile</button>
               </div>
             </div>
@@ -224,6 +233,15 @@ const CurateIndividual = () => {
             headShotLabelData={headShot}
             reciterData={reciterData}
           />
+          {canManageUsers && (
+            <GrantProxyModal
+              show={grantProxyShow}
+              onHide={() => setGrantProxyShow(false)}
+              personIdentifier={String(id)}
+              personName={personFullName}
+              onSave={() => {}}
+            />
+          )}
         </>
       }
     </div>


### PR DESCRIPTION
## What
Second entry point for individual-level proxy assignment, following up on #880.

#880 added the "Proxy" field to Add/Edit User (pick specific people this admin user can curate for). This PR adds the reverse direction: a **Grant Proxy** button on `/curate/[id]` that opens `GrantProxyModal` (restored in #880 but not wired in yet) — pick which other users can curate for *this* specific person.

## Changes
- `CurateIndividual.tsx`: new "Grant Proxy" button next to "View Profile" in the person header, opens `GrantProxyModal`
- Gated on `canManageUsers` (Superuser) — matches the `/api/db/admin/proxy*` routes it calls, which are `isAuthorizedAdmin`-gated to the same capability. Showing the button to anyone else would just 403 on click.
- `personIdentifier` passed as the `id` route param directly (confirmed this is the canonical identifier — same value shown in the URL, e.g. `/curate/paa2013`)

## Verification
- `npx tsc --noEmit` — clean
- `npx next build` — exit 0, no new errors
- Not yet runtime-tested on reciter-dev