### PR TITLE
fix(auth,search): unconditional scope fields + real Actions dropdown fix (PM#849)

### DIFF
--- a/src/components/elements/AddUser/AddUser.tsx
+++ b/src/components/elements/AddUser/AddUser.tsx
@@ -126,8 +126,12 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
             let isEditUserId = router.query.userId;
             let createOrUpdatePayload = {
                 cwid, email, firstName, lastName, middleName, division, title, selectedRoleIds, departmentIds, isEditUserId,
-                scopePersonTypes: isCuratorScoped ? selectedPersonTypes : [],
-                scopeOrgUnits: isCuratorScoped ? selectedScopeOrgUnits : [],
+                // Always save whatever's entered, regardless of role -- the fields are now
+                // unconditionally visible (not just for Curator_Scoped), so gating the save on
+                // isCuratorScoped would silently drop a value the admin can see on screen.
+                // Harmless when unused: only canCurate's Curator_Scoped branch reads these.
+                scopePersonTypes: selectedPersonTypes,
+                scopeOrgUnits: selectedScopeOrgUnits,
             }
 
             if (isEditUserId) {
@@ -528,62 +532,60 @@ const AddUser: FunctionComponent<FuncProps> = (props) => {
                                     {formErrorsInst.selectedRole && <span className={styles.errorText}>{formErrorsInst.selectedRole}</span>}
                                 </div>
                             </div>
-                            {isCuratorScoped && (
-                                <div className={styles.fieldGrid} style={{ marginTop: 16 }}>
-                                    <div className={styles.field}>
-                                        <label className={styles.fieldLabel}>Person type(s) user can manage</label>
-                                        <Autocomplete
-                                            freeSolo
-                                            multiple
-                                            id="scopePersonTypes"
-                                            disableClearable
-                                            value={selectedPersonTypes}
-                                            options={personTypesData.map((option) => option.personType)}
-                                            onChange={(event, value) => setSelectedPersonTypes(value as string[])}
-                                            sx={orgUnitSx}
-                                            renderTags={renderOrgTags}
-                                            renderInput={(params) => (
-                                                <TextField
-                                                    variant="outlined"
-                                                    {...params}
-                                                    placeholder={selectedPersonTypes.length === 0 ? "Search and select person types..." : ""}
-                                                    InputProps={{
-                                                        ...params.InputProps,
-                                                        type: 'search',
-                                                    }}
-                                                />
-                                            )}
-                                        />
-                                        <span className={styles.fieldHint}>A person matches if they have any of the selected types. Leave empty for no person-type restriction.</span>
-                                    </div>
-                                    <div className={styles.field}>
-                                        <label className={styles.fieldLabel}>Org unit(s) for scoped access</label>
-                                        <Autocomplete
-                                            freeSolo
-                                            multiple
-                                            id="scopeOrgUnits"
-                                            disableClearable
-                                            value={selectedScopeOrgUnits}
-                                            options={adminDepartments.map((option) => option.departmentLabel)}
-                                            onChange={(event, value) => setSelectedScopeOrgUnits(value as string[])}
-                                            sx={orgUnitSx}
-                                            renderTags={renderOrgTags}
-                                            renderInput={(params) => (
-                                                <TextField
-                                                    variant="outlined"
-                                                    {...params}
-                                                    placeholder={selectedScopeOrgUnits.length === 0 ? "Search and select departments..." : ""}
-                                                    InputProps={{
-                                                        ...params.InputProps,
-                                                        type: 'search',
-                                                    }}
-                                                />
-                                            )}
-                                        />
-                                        <span className={styles.fieldHint}>Separate from &ldquo;Organizational unit(s) user can manage&rdquo; above (that field is for Curator — Department). Leave empty for no org-unit restriction.</span>
-                                    </div>
+                            <div className={styles.fieldGrid} style={{ marginTop: 16 }}>
+                                <div className={styles.field}>
+                                    <label className={styles.fieldLabel}>Person type(s) user can manage</label>
+                                    <Autocomplete
+                                        freeSolo
+                                        multiple
+                                        id="scopePersonTypes"
+                                        disableClearable
+                                        value={selectedPersonTypes}
+                                        options={personTypesData.map((option) => option.personType)}
+                                        onChange={(event, value) => setSelectedPersonTypes(value as string[])}
+                                        sx={orgUnitSx}
+                                        renderTags={renderOrgTags}
+                                        renderInput={(params) => (
+                                            <TextField
+                                                variant="outlined"
+                                                {...params}
+                                                placeholder={selectedPersonTypes.length === 0 ? "Search and select person types..." : ""}
+                                                InputProps={{
+                                                    ...params.InputProps,
+                                                    type: 'search',
+                                                }}
+                                            />
+                                        )}
+                                    />
+                                    <span className={styles.fieldHint}>Only takes effect for Curator — Scoped (see Role(s) above). A person matches if they have any of the selected types. Leave empty for no person-type restriction.</span>
                                 </div>
-                            )}
+                                <div className={styles.field}>
+                                    <label className={styles.fieldLabel}>Org unit(s) for scoped access</label>
+                                    <Autocomplete
+                                        freeSolo
+                                        multiple
+                                        id="scopeOrgUnits"
+                                        disableClearable
+                                        value={selectedScopeOrgUnits}
+                                        options={adminDepartments.map((option) => option.departmentLabel)}
+                                        onChange={(event, value) => setSelectedScopeOrgUnits(value as string[])}
+                                        sx={orgUnitSx}
+                                        renderTags={renderOrgTags}
+                                        renderInput={(params) => (
+                                            <TextField
+                                                variant="outlined"
+                                                {...params}
+                                                placeholder={selectedScopeOrgUnits.length === 0 ? "Search and select departments..." : ""}
+                                                InputProps={{
+                                                    ...params.InputProps,
+                                                    type: 'search',
+                                                }}
+                                            />
+                                        )}
+                                    />
+                                    <span className={styles.fieldHint}>Only takes effect for Curator — Scoped (see Role(s) above). Separate from &ldquo;Organizational unit(s) user can manage&rdquo; above (that field is for Curator — Department). Leave empty for no org-unit restriction.</span>
+                                </div>
+                            </div>
                             {formErrorsInst.selectedScope && <span className={styles.errorText}>{formErrorsInst.selectedScope}</span>}
                             <div className={styles.fieldGrid} style={{ marginTop: 16 }}>
                                 <div className={styles.field}>

--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -13,7 +13,7 @@ import { updatePubFiltersFromSearch } from "../../../redux/actions/actions";
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { styled } from '@mui/material/styles';
-import { Table,Button,Dropdown} from "react-bootstrap";
+import { Table,Button} from "react-bootstrap";
 import SplitDropdown from "../Dropdown/SplitDropdown";
 import Loader from "../Common/Loader";
 import { reciterConfig } from "../../../../config/local";
@@ -604,52 +604,11 @@ const Search = () => {
     if (isCuratorSelf) return pid === loggedInPersonIdentifier;
     return false;
   };			 
-  const RoleSplitDropdown = (identity) => {
-    
-    if(dropdownTitle && dropdownTitle =='Curate Publications' && isCuratorSelf && !isReporterAll && !isCuratorAll && !isSuperUser && (loggedInPersonIdentifier === identity.identity.personIdentifier || isProxyFor(proxyPersonIds, identity.identity.personIdentifier))) 
-    {
-        return <Button className="secondary" variant="secondary" onClick={() => redirectToCurate("individual", identity.identity.personIdentifier)}>{"Curate Publications"}</Button>
-    }
-    else if(dropdownTitle && dropdownTitle =='Create Report' && isReporterAll && !isCuratorAll && !isSuperUser && !isCuratorSelf)
-    {
-		 if (isProxyFor(proxyPersonIds, identity.identity.personIdentifier)) {
-          return <Button className="secondary" variant="secondary" onClick={() => redirectToCurate("individual", identity.identity.personIdentifier)}>{"Curate Publications"}</Button>
-        }
-        return <Button className="secondary" variant="secondary" onClick={() => redirectToCurate("report", identity.identity)}>{"Create Reports"}</Button>
-    }
-    else if(dropdownTitle && dropdownTitle =='Curate Publications' && isCuratorAll && !isReporterAll && !isSuperUser && !isCuratorSelf) 
-    {
-        return <Button className="secondary" variant="secondary" onClick={() => redirectToCurate("individual", identity.identity.personIdentifier)}>{"Curate Publications"}</Button>
-    }
-    else if(isCuratorSelf && isReporterAll && !isCuratorAll && !isSuperUser)
-    {
-		const canCurateRow = identity && (identity.identity.personIdentifier === loggedInPersonIdentifier || isProxyFor(proxyPersonIds, identity.identity.personIdentifier));			 
-      return  <SplitDropdown
-        title={canCurateRow ? "Curate Publications" : "Create Reports"}
-        onDropDownClick={canCurateRow ? (e) => redirectToCurate("individual",identity.identity.personIdentifier,e) : (e) => redirectToCurate("report", identity.identity.personIdentifier,e)}
-        id={`curate-publications_${identity.identity.personIdentifier}`}
-        listItems={canCurateRow ? dropdownMenuItems : []}
-        secondary={true}
-        onClick={canCurateRow ? (e) => redirectToCurate("report", identity.identity,e): "undefined"}/>
-    }
-    else if((isCuratorAll && isReporterAll && isCuratorSelf) ||isSuperUser || (isCuratorAll && isReporterAll))
-    {
-      return  <SplitDropdown
-        title={"Curate Publications"}
-        //{isUserRole && isUserRole === allowedPermissions.Reporter_All ? "Create Reports" : "Curate Publications"}
-        // to={`/curate/${identity.personIdentifier}`}
-        //onDropDownClick={isUserRole && isUserRole === allowedPermissions.Reporter_All ? () => redirectToCurate("report",identity.personIdentifier) : () => redirectToCurate("individual", identity.personIdentifier)}
-        onDropDownClick={(e) => redirectToCurate("individual",identity.identity.personIdentifier,e)}
-        id={`curate-publications_${identity.identity.personIdentifier}`}
-        listItems={dropdownMenuItems} 
-        secondary={true}
-        onClick={(e) => redirectToCurate("report", identity.identity,e)}/>
-    }
-    else
-       return null;
-  
-  
-  }
+  // Note: an earlier RoleSplitDropdown() helper duplicated this same role-branching logic to
+  // render the Actions dropdown, but was never actually called -- the real Actions cell (in
+  // tableBody below) used a separate raw react-bootstrap Dropdown instead, which is why it
+  // didn't match Manage Users' styling. Removed the dead helper rather than leave two
+  // implementations of the same decision to drift out of sync again.
 
 
 
@@ -684,16 +643,24 @@ const Search = () => {
         </td>
          : ""}
         <td key={`${identityIndex}__actions`} width="24%" className={styles.actionsCell}>
-          <Dropdown className="d-inline-block">
-            <Dropdown.Toggle variant="primary" id={`actions_${identity.personIdentifier}`}>
-              {rowCanCurate ? "Curate Publications" : "Create Reports"}
-            </Dropdown.Toggle>
-            <Dropdown.Menu className={styles.actionMenu} popperConfig={{ strategy: 'fixed' }} renderOnMount>
-              {rowCanCurate && <Dropdown.Item className={styles.actionMenuItem} onClick={() => onClickProfile(identity.personIdentifier)}>Curate Publications</Dropdown.Item>}
-              <Dropdown.Item className={styles.actionMenuItem} onClick={() => redirectToCurate("report", identity)}>Create Reports</Dropdown.Item>
-              <Dropdown.Item className={styles.actionMenuItem} onClick={() => { setShowprofileID(identity.personIdentifier); handleShow(); }}>View Profile</Dropdown.Item>
-            </Dropdown.Menu>
-          </Dropdown>
+          {/* Was a raw react-bootstrap Dropdown (bootstrap variant="primary" styling) -- switched
+              to the shared SplitDropdown component so this matches the Manage Users row action
+              button (dark-navy split button, icons, "Actions for this person" header). */}
+          <SplitDropdown
+            title={rowCanCurate ? "Curate Publications" : "Create Reports"}
+            onDropDownClick={rowCanCurate ? () => onClickProfile(identity.personIdentifier) : () => redirectToCurate("report", identity)}
+            id={`actions_${identity.personIdentifier}`}
+            listItems={rowCanCurate
+              ? [
+                  { title: 'Create Reports', onClick: () => redirectToCurate("report", identity) },
+                  { title: 'View Profile', onClick: () => { setShowprofileID(identity.personIdentifier); handleShow(); } },
+                ]
+              : [
+                  { title: 'View Profile', onClick: () => { setShowprofileID(identity.personIdentifier); handleShow(); } },
+                ]
+            }
+            secondary={true}
+          />
         </td>
       </tr>;;
     })


### PR DESCRIPTION
## What
Two fixes found while testing #880/#881 on reciter-dev.

### 1. Person type(s)/Org unit(s) fields were hidden until "Curator — Scoped" was already selected
`AddUser.tsx` only rendered the scope Autocompletes inside `isCuratorScoped && (...)`, so on a fresh Add/Edit User they were invisible until you picked that role first — easy to miss entirely. Made them unconditionally visible, matching "Organizational unit(s) user can manage" above. Also stopped gating the *save* on `isCuratorScoped`: a value visibly sitting in the field getting silently dropped on submit (because the role wasn't picked) would have been worse than doing nothing. Hints now call out that these only take effect for Curator — Scoped.

### 2. Find People's Actions dropdown didn't match Manage Users' style
Reported as "it's gray" vs. Manage Users' dark-navy button. Root cause: there were two implementations of the same row-action decision — a `RoleSplitDropdown()` helper that correctly used the shared `SplitDropdown` component (same as `UsersTable.tsx`), and the *actual* Actions cell in `tableBody`, which used a separate raw `react-bootstrap` `Dropdown` with `variant="primary"`. The helper was dead code — never called. Swapped the real cell to `SplitDropdown` (`secondary={true}`) and deleted the dead helper so there's one implementation instead of two silently drifting apart.

## Verification
- `npx tsc --noEmit` — clean
- `npx next build` — exit 0, no new warnings beyond pre-existing repo-wide `exhaustive-deps` noise
- Not yet runtime-tested on reciter-dev