### PR TITLE
fix(auth): make proxy grants independent of curate roles (PM#849)

### DIFF
--- a/controllers/db/authorization.controller.ts
+++ b/controllers/db/authorization.controller.ts
@@ -48,14 +48,13 @@ export const canCurate = async (token: any, targetUid: any): Promise<boolean> =>
     if (caps.canCurate.all) return true
     if (caps.canCurate.self && caps.canCurate.personIdentifier === targetUid) return true
 
-    // Proxy delegation only extends a role that already has some curate capability (matches
-    // the existing client-side intent in Search.js, which only ever surfaces proxy access
-    // nested under a curator role) -- it is not an independent grant. Without this gate, a
-    // Reporter_All user (canCurate: false) with a stray proxy_person_ids entry could curate.
-    if (caps.canCurate.self || caps.canCurate.scoped) {
-        const proxyPersonIds = safeJsonParse(token?.proxyPersonIds, [])
-        if (isProxyFor(proxyPersonIds, targetUid)) return true
-    }
+    // A proxy grant is an independent, person-scoped delegation -- it does not require the
+    // grantee to hold any curate-capable role. This matches the shipped admin UI ("Grants
+    // curation access to specific people regardless of role or scope above") and is safe
+    // because proxy_person_ids is only writable through isAuthorizedAdmin-gated routes: every
+    // entry is a deliberate Superuser grant, never user-controlled.
+    const proxyPersonIds = safeJsonParse(token?.proxyPersonIds, [])
+    if (isProxyFor(proxyPersonIds, targetUid)) return true
 
     if (caps.canCurate.scoped) {
         const scopeData = safeJsonParse(token?.scopeData, null)

--- a/repositories/db/userroles.repository.ts
+++ b/repositories/db/userroles.repository.ts
@@ -3,9 +3,12 @@ import sequelize from "../../src/db/db";
 // Data access for a user's roles. The WHERE is fixed; only the replacements (personIdentifier, email)
 // vary, and they are always bound parameters — never interpolated — so this stays injection-safe.
 // A user is matched by (personIdentifier AND email), or by an email that is unique across admin_users.
+// A row with no stored email matches on personIdentifier alone -- requiring email equality there
+// stranded email-less accounts with zero roles forever (their proxy grants vanished at login too).
 export function queryUserPermissions(replacements: Record<string, any>) {
     const whereClause = `
-        (au.personIdentifier = :personIdentifier AND au.email = :email)
+        (au.personIdentifier = :personIdentifier
+         AND (au.email = :email OR au.email IS NULL OR au.email = ''))
         OR
         (
         au.email = :email

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,7 +41,18 @@ export async function middleware(request: NextRequest) {
             let isSuperUser = userRoles.some((role) => role.roleLabel === allowedPermissions.Superuser)
             let isCuratorAll = userRoles.some((role) => role.roleLabel === allowedPermissions.Curator_All)
             let isReporterAll = userRoles.some((role) => role.roleLabel === allowedPermissions.Reporter_All)
-            if (pathName && pathName.startsWith('/curate')  &&  !isCuratorAll  && !isSuperUser)
+            // A proxy grant (admin_users.proxy_person_ids, PM#849) allows curating the named
+            // people regardless of role, so /curate/<granted-uid> must not be bounced by the
+            // role-based rules below. canCurate on the write API stays the real enforcement;
+            // this only stops the middleware from redirecting a page the API would allow.
+            let proxyPersonIds = [];
+            try {
+              const parsed = JSON.parse((decodedTokenJson as any)?.proxyPersonIds || '[]');
+              if (Array.isArray(parsed)) proxyPersonIds = parsed;
+            } catch (e) { /* malformed token field -> no proxy allowance */ }
+            const curateTarget = pathName.startsWith('/curate/') ? decodeURIComponent(pathName.split('/')[2] || '') : '';
+            const isProxiedTarget = curateTarget.length > 0 && proxyPersonIds.includes(curateTarget);
+            if (pathName && pathName.startsWith('/curate')  &&  !isCuratorAll  && !isSuperUser && !isProxiedTarget)
             {
                 if (userRoles.length == 1 && isReporterAll  && !isCuratorSelf) {
                   return redirectToLandingPage(request,'/search');

--- a/src/pages/api/auth/[...nextauth].jsx
+++ b/src/pages/api/auth/[...nextauth].jsx
@@ -198,18 +198,18 @@ export const authOptions = {
           if (typeof value !== 'string') return value;
           try { return JSON.parse(value); } catch { return null; }
         };
-        let firstRole = {};
-        try {
-          const rolesArr = JSON.parse(token.userRoles || '[]');
-          firstRole = rolesArr[0] || {};
-        } catch (e) {
-          console.warn('JWT callback: could not parse userRoles for scope data', e);
-        }
+        // Read the three columns from the user's own admin_users row (already fetched by
+        // findOrcreateAdminUser above), NOT from a role row: they are per-user values, and a
+        // user with zero resolved roles (or a proxy grant and nothing else) would otherwise
+        // lose their scope/proxy data at login even though the DB has it.
+        const dbUser = (user.databaseUser && typeof user.databaseUser.get === 'function')
+          ? user.databaseUser.get({ plain: true })
+          : (user.databaseUser || {});
         token.scopeData = JSON.stringify({
-          personTypes: parseJsonColumn(firstRole.scope_person_types),
-          orgUnits: parseJsonColumn(firstRole.scope_org_units),
+          personTypes: parseJsonColumn(dbUser.scope_person_types),
+          orgUnits: parseJsonColumn(dbUser.scope_org_units),
         });
-        token.proxyPersonIds = JSON.stringify(parseJsonColumn(firstRole.proxy_person_ids) || []);
+        token.proxyPersonIds = JSON.stringify(parseJsonColumn(dbUser.proxy_person_ids) || []);
 
         token.name = `${user.firstName || ''} ${user.lastName || ''}`.trim() || token.username;;
         token.picture = user.image || user.databaseUser?.profilePicture;


### PR DESCRIPTION
The 2026-08-21 round-trip test (documented in #849) showed individual-level proxy grants only worked end-to-end for Curator_Scoped grantees. This makes the shipped UI's promise ("Grants curation access to specific people regardless of role or scope above") true.

Four changes:

1. **`canCurate`**: honor `proxy_person_ids` unconditionally instead of only when the grantee already holds Curator_Self/Scoped. Safe because proxy entries are only writable through `isAuthorizedAdmin`-gated routes — every entry is a deliberate Superuser grant, never user-controlled. The negative path is unchanged: persons not in the list still 403.
2. **`src/middleware.ts`**: stop bouncing `/curate/<granted-uid>` when the token's `proxyPersonIds` names that uid. The write API's `canCurate` remains the real enforcement; the middleware was redirecting pages the API would allow.
3. **jwt callback**: read the three scope/proxy columns from the user's own `admin_users` row (already fetched at login) instead of the first resolved role row — a user with zero resolved roles no longer loses their proxy data.
4. **`queryUserPermissions`**: rows with no stored email now match on `personIdentifier` alone. Requiring email equality stranded email-less accounts with zero roles forever (email is not editable after creation and users can't be deleted).

Verified by re-running the live round-trip on this branch against the dev DB:
- `Reporter_All`-only grantee: reaches `/curate/<granted>` in the browser, goldstandard authz passes for the granted person, 403 for anyone else.
- Email-less grantee (the previously stranded case): resolves roles at login, lands on /search instead of /noaccess, proxy works identically.
- Superuser/Curator_All behavior unchanged; `tsc --noEmit` clean.