### PR TITLE
fix(search): match 2-3 pasted CWIDs in Find People (#886)

### DIFF
--- a/controllers/db/person.controller.ts
+++ b/controllers/db/person.controller.ts
@@ -23,12 +23,16 @@ export const findAll  = async (req: NextApiRequest, res: NextApiResponse) => {
                 
                 }
                 else if(where[Op.and] && apiBody.filters.nameOrUids && apiBody.filters.nameOrUids.length <= reciterConstants.nameCWIDSpaceCountThreshold) {
-                    apiBody.filters.nameOrUids.forEach((name: string) => {
-                            where[Op.and].push({[Op.or]:[{'$Person.firstName$': { [Op.like]: `%${name}%`}},
-                          {'$Person.middleName$': { [Op.like]: `%${name}%`}},
+                    // ponytail: OR an exact-CWID IN against the existing AND-of-names, so 2-3 pasted CWIDs match (#886).
+                    // Strictly additive: name search keeps the same AND semantics, exact-CWID rows are only added.
+                    where[Op.and].push({[Op.or]:[
+                        {'$Person.personIdentifier$': { [Op.in]: apiBody.filters.nameOrUids }},
+                        {[Op.and]: apiBody.filters.nameOrUids.map((name: string) => ({[Op.or]:[
+                            {'$Person.firstName$': { [Op.like]: `%${name}%`}},
+                            {'$Person.middleName$': { [Op.like]: `%${name}%`}},
                             {'$Person.lastName$': { [Op.like]: `%${name}%`}},
-                            {'$Person.personIdentifier$': { [Op.like]: `%${name}%`}}]})
-                        })
+                            {'$Person.personIdentifier$': { [Op.like]: `%${name}%`}}]}))},
+                    ]})
                      }
                // }
                 if(apiBody.filters.institutions) {


### PR DESCRIPTION
Closes #886.

## Problem

`controllers/db/person.controller.ts` `findAll` splits on `reciterConstants.nameCWIDSpaceCountThreshold` (3). Above the threshold it does an exact `personIdentifier IN (...)`; at or below it AND-s a per-token block of `LIKE`s across firstName/middleName/lastName/personIdentifier. That AND is correct for `john smith` (first AND last of one person) and impossible for two CWIDs — no row is both `%ccole%` and `%tew2004%`, so 2-3 pasted CWIDs always returned zero. Never worked; not a regression from #880-#885.

## Fix

In the `<=` threshold branch, OR an exact `personIdentifier IN (tokens)` clause against the existing AND-of-names block. Strictly additive: rows the old query returned still match through the AND branch, exact-CWID rows are only added.

## Verification

Ran locally against the dev DB (`npm run dev`, POST `/api/db/users`), generated SQL confirmed in the server log:

| Search | Rows |
|---|---|
| `ccole tew2004` | 2 (ccole, tew2004) |
| `ccole tew2004 paa2013` | 3 |
| `ccole` | 1 |
| `curtis cole` (name search) | 1 — Curtis Cole |
| `cole` (partial name) | 50 (Coleman, Cole, Nicole, ...) — unchanged |

`npx tsc --noEmit` clean.