### PR TITLE
port: Find People multi-CWID search to prod (#886 + #851 tokenizer)

### DIFF
--- a/controllers/db/person.controller.ts
+++ b/controllers/db/person.controller.ts
@@ -23,12 +23,16 @@ export const findAll  = async (req: NextApiRequest, res: NextApiResponse) => {
                 
                 }
                 else if(where[Op.and] && apiBody.filters.nameOrUids && apiBody.filters.nameOrUids.length <= reciterConstants.nameCWIDSpaceCountThreshold) {
-                    apiBody.filters.nameOrUids.forEach((name: string) => {
-                            where[Op.and].push({[Op.or]:[{'$Person.firstName$': { [Op.like]: `%${name}%`}},
-                          {'$Person.middleName$': { [Op.like]: `%${name}%`}},
+                    // ponytail: OR an exact-CWID IN against the existing AND-of-names, so 2-3 pasted CWIDs match (#886).
+                    // Strictly additive: name search keeps the same AND semantics, exact-CWID rows are only added.
+                    where[Op.and].push({[Op.or]:[
+                        {'$Person.personIdentifier$': { [Op.in]: apiBody.filters.nameOrUids }},
+                        {[Op.and]: apiBody.filters.nameOrUids.map((name: string) => ({[Op.or]:[
+                            {'$Person.firstName$': { [Op.like]: `%${name}%`}},
+                            {'$Person.middleName$': { [Op.like]: `%${name}%`}},
                             {'$Person.lastName$': { [Op.like]: `%${name}%`}},
-                            {'$Person.personIdentifier$': { [Op.like]: `%${name}%`}}]})
-                        })
+                            {'$Person.personIdentifier$': { [Op.like]: `%${name}%`}}]}))},
+                    ]})
                      }
                // }
                 if(apiBody.filters.institutions) {

--- a/src/components/elements/Search/Search.js
+++ b/src/components/elements/Search/Search.js
@@ -412,7 +412,11 @@ const Search = () => {
       setTotalCount(countAllData);
     }
     if (searchText) {
-      let searchWords = searchText.trim().split(' ');
+      // Split on any run of whitespace or commas, not just a single space, so a CWID
+      // list pasted from a spreadsheet column (newline-separated) or a comma-separated
+      // list parses into one token per person instead of collapsing into one mangled
+      // string that then misses the bulk-CWID threshold below.
+      let searchWords = searchText.trim().split(/[\s,]+/).filter(Boolean);
       dispatch(updateAuthorFilter(searchWords.join(),10));
 
       updatedFilters = { ...updatedFilters, nameOrUids: searchWords };


### PR DESCRIPTION
Prod port of #887 (merged to `dev` as `c229f6cc`), plus the one tokenizer line prod was missing.

## Commits

1. `578f62c9` — clean cherry-pick of the #886 fix. `controllers/db/person.controller.ts` and `src/utils/constants.js` were byte-identical between `dev` and `master_Next14`, so this applied without conflict.
2. `3839c43e` — ports the #851 tokenizer line. `master_Next14` still had `searchText.trim().split(' ')`, so without this the #886 fix would only help space-separated input; a list pasted from a spreadsheet column (newlines) or a comma-separated list still collapses into one mangled token.

After both, `Search.js` and `person.controller.ts` are identical to `origin/dev`.

## Verification

`master_Next14` has no CI workflow, so these were run locally on this branch:

```
npm install --legacy-peer-deps   OK
npx tsc --noEmit                 OK (no output)
npx next build                   OK (compiled, all routes emitted)
```

The behaviour itself was verified on the dev branch against the dev DB before the pick (see #887): `ccole tew2004` → 2 rows, `ccole tew2004 paa2013` → 3, `curtis cole` → 1, `cole` → 50 partial matches unchanged.

## Deploy note

Merging deploys nothing — `ReCiter-Publication-Manager-Dev-V2` has `DetectChanges: false`. It needs `aws codepipeline start-pipeline-execution --name ReCiter-Publication-Manager-Dev-V2`, then approval of the `ManualAproval` action (misspelled). Expect a duplicate execution to appear from the merge anyway; reject it. Confirm the `idp-cert` volume is still on the deployment afterwards.